### PR TITLE
fix #342 set child process debug port to available

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -21,7 +21,7 @@ if (env.NODE_PATH) {
 		.join(path.delimiter);
 }
 
-module.exports = function (file, opts) {
+module.exports = function (file, opts, execArgv) {
 	opts = objectAssign({
 		file: file,
 		tty: process.stdout.isTTY ? {
@@ -33,7 +33,8 @@ module.exports = function (file, opts) {
 	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
 		cwd: path.dirname(file),
 		silent: true,
-		env: env
+		env: env,
+		execArgv: execArgv
 	});
 
 	var relFile = path.relative('.', file);
@@ -115,18 +116,6 @@ module.exports = function (file, opts) {
 		}
 	});
 
-	promise.on = function () {
-		ps.on.apply(ps, arguments);
-
-		return promise;
-	};
-
-	promise.send = function (name, data) {
-		send(ps, name, data);
-
-		return promise;
-	};
-
 	// send 'run' event only when fork is listening for it
 	var isReady = false;
 
@@ -134,18 +123,31 @@ module.exports = function (file, opts) {
 		isReady = true;
 	});
 
-	promise.run = function (options) {
-		if (isReady) {
-			send(ps, 'run', options);
-			return promise;
+	return {
+		promise: promise,
+		on: function () {
+			ps.on.apply(ps, arguments);
+			return this;
+		},
+		send: function (name, data) {
+			send(ps, name, data);
+			return this;
+		},
+		run: function (options) {
+			if (isReady) {
+				send(ps, 'run', options);
+				return this;
+			}
+
+			ps.on('stats', function () {
+				send(ps, 'run', options);
+			});
+
+			return this;
+		},
+		then: function () {
+			// only to simplify test code, in production use .promise
+			return promise.then.apply(promise, arguments);
 		}
-
-		ps.on('stats', function () {
-			send(ps, 'run', options);
-		});
-
-		return promise;
 	};
-
-	return promise;
 };

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "figures": "^1.4.0",
     "find-cache-dir": "^0.1.1",
     "fn-name": "^2.0.0",
+    "get-port": "^2.1.0",
     "globby": "^4.0.0",
     "ignore-by-default": "^1.0.0",
     "is-ci": "^1.0.7",


### PR DESCRIPTION
We decided to support AVA debug (#342) without any efforts [on your side](https://github.com/nodejs/node/pull/5025#issuecomment-177985896).

But:
* [debugger: bind to random port with --debug-port=0 #5025](https://github.com/nodejs/node/pull/5025) is not yet merged into NodeJS.
* IntelliJ JS Debugger doesn't support yet `=0`, and when will be supported, it will take time to be available for users in the generally available release.

Unfortunately, although idea of fix is very simple (`getPort().then`), change is complex because existing code adds custom context-dependent methods to Promise. And Github diff view is very unclear compared to IntelliJ IDEA.

What's done:
* if `debug-brk=` or `debug=` in the main process args, find available port and change debug arg.
* `fork` now returns object with custom methods (`on`, `run`) and `promise` field. We don't add custom methods to `promise` anymore.
  * to simplify test code (and reduce changes), method `then` added to returned object. Test-only — in production we use `promise` field.
  * `send` is not used, as far I see, but I didn't delete it. Should I do it?

Please note — as it stated [in my comment](https://github.com/sindresorhus/ava/issues/342#issuecomment-177239663), debugging will be still not possible due to another issues. Solving `sourcemap` issue is out of this PR scope.

PS: AVA is so awesome, that multi-process debug was reimplemented in the IntelliJ JS Debugger to avoid multiple debug tabs (IntelliJ Platform 146+).