### PR TITLE
Improve the issue template.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,28 +1,60 @@
-<!--
+<!-- CLICK "Preview" FOR MORE READABLE FORMAT -->
 
 ## Prerequisites
 
 - Read the [contributing guidelines](https://github.com/sindresorhus/ava/blob/master/contributing.md).
-- Support questions are better asked in our [chat](https://gitter.im/sindresorhus/ava) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/ava).
+- Support questions are better asked in one of the following locations
+  - [our chat](https://gitter.im/sindresorhus/ava)
+  - [Stack Overflow](https://stackoverflow.com/questions/tagged/ava)
 - Ensure the issue isn't already reported.
-- Should be reproducible with the latest AVA version. (Ensure `ava --version` matches ![](https://img.shields.io/npm/v/ava.svg))
-
--->
+- Should be reproducible with the latest AVA version.
+  - (Ensure `ava --version` matches ![](https://img.shields.io/npm/v/ava.svg))
 
 ## Description
 
-<!--
+If this is a feature request, explain why it should be added. Specific use cases are best.
 
-Description of the issue.
+For bug reports, please provide as much *relevant* info as possible.
 
-If it's a feature request, include why it should be added.
+### Test Source
 
--->
+```js
+// Avoid posting hundreds of lines of source code.
+// Edit to just the relevant portions.
+```
 
+### Stack Trace
+
+```
+COPY THE FAILURE STACK TRACE HERE
+```
+
+### Configuration
+
+Copy the relevant section from `package.json`:
+
+```json
+{
+  "ava": {
+  ...
+  }
+}
+```
+
+### Command Line Arguments
+
+Copy your npm build scripts or the `ava` command used:
+
+```
+ava [OPTIONS HERE]
+```
+
+## Relevant Links
+
+- If your project is public, link to the repo so we can investigate directly.
+- **BONUS POINTS:** Create a [minimal reproduction](http://stackoverflow.com/help/mcve) and upload it to GitHub. This will get you the fastest support.
 
 ## Environment
-
-<!--
 
 Include the Node.js version and operating system. Run the following to get it quickly:
 
@@ -30,4 +62,9 @@ Include the Node.js version and operating system. Run the following to get it qu
 node -e "var os=require('os');console.log('Node.js ' + process.version + '\n' + os.platform() + ' ' + os.release())"
 ```
 
--->
+The versions of AVA and `npm` in use:
+
+```
+ava --version
+npm --version
+```

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,14 +1,16 @@
-<!-- CLICK "Preview" FOR MORE READABLE FORMAT -->
+<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->
 
 ## Prerequisites
 
 - Read the [contributing guidelines](https://github.com/sindresorhus/ava/blob/master/contributing.md).
-- Support questions are better asked in one of the following locations
-  - [our chat](https://gitter.im/sindresorhus/ava)
+- Support questions are better asked in one of the following locations:
+  - [Our chat](https://gitter.im/sindresorhus/ava)
   - [Stack Overflow](https://stackoverflow.com/questions/tagged/ava)
 - Ensure the issue isn't already reported.
 - Should be reproducible with the latest AVA version.
   - (Ensure `ava --version` matches ![](https://img.shields.io/npm/v/ava.svg))
+
+*Delete the above section and the instructions in the sections below before submitting*
 
 ## Description
 
@@ -56,15 +58,10 @@ ava [OPTIONS HERE]
 
 ## Environment
 
-Include the Node.js version and operating system. Run the following to get it quickly:
+Tell us which operating system you are using, as well as which versions of  Node.js, npm, and AVA. Run the following to get it quickly:
 
 ```
 node -e "var os=require('os');console.log('Node.js ' + process.version + '\n' + os.platform() + ' ' + os.release())"
-```
-
-The versions of AVA and `npm` in use:
-
-```
 ava --version
 npm --version
 ```

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,6 +2,7 @@
 
 ## Prerequisites
 
+- We realize there is a lot of data requested here. We ask only that you do your best to provide as much information as possible so we can better help you.
 - Read the [contributing guidelines](https://github.com/sindresorhus/ava/blob/master/contributing.md).
 - Support questions are better asked in one of the following locations:
   - [Our chat](https://gitter.im/sindresorhus/ava)

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -25,13 +25,13 @@ For bug reports, please provide as much *relevant* info as possible.
 // Edit to just the relevant portions.
 ```
 
-### Stack Trace
+### Error Message & Stack Trace
 
 ```
-COPY THE FAILURE STACK TRACE HERE
+COPY THE ERROR MESSAGE, INCLUDING STACK TRACE HERE
 ```
 
-### Configuration
+### Config
 
 Copy the relevant section from `package.json`:
 


### PR DESCRIPTION
The current issue template uses HTML comment tags to remove template text from the rendered output. I have gone through the last dozen issues filed, and it appears everyone deletes that anyways. By removing the comment tags, people can click "Preview" and get a pretty print of the template markdown.

Reformat lists and links. Tries to get links as close to the left edge as possible, so they are easy to see, and copy-paste from the raw markdown editor. Puts multiple links on their own line for the same reason.

Adds a request that they explicitly tell us what their AVA and `npm` versions are.

Adds a section for their AVA config and CLI args.

Adds a section for linking to thier project if public.

Requests they create a minimal reproduction and post it to GitHub.