### PR TITLE
api#run should return runStatus even when no files are found

### DIFF
--- a/api.js
+++ b/api.js
@@ -105,7 +105,7 @@ Api.prototype._run = function (files, _options) {
 			file: undefined
 		});
 
-		return Promise.resolve([]);
+		return Promise.resolve(runStatus);
 	}
 
 	var cacheEnabled = self.options.cacheEnabled !== false;

--- a/test/cli.js
+++ b/test/cli.js
@@ -290,3 +290,11 @@ test('handles NODE_PATH', function (t) {
 		t.end();
 	});
 });
+
+test('works when no files are found', function (t) {
+	execCli('!*', function (err, stdout, stderr) {
+		t.is(err.code, 1);
+		t.match(stderr, 'Couldn\'t find any files to test');
+		t.end();
+	});
+});


### PR DESCRIPTION
on master running `ava blah` assuming `blah` matches no files will fail like this 
<img width="608" alt="screen shot 2016-05-17 at 11 02 14" src="https://cloud.githubusercontent.com/assets/56902/15318635/dc19c568-1c1e-11e6-8d2a-d13d4cc265de.png">

instead of like this, as it should
<img width="610" alt="screen shot 2016-05-17 at 11 03 00" src="https://cloud.githubusercontent.com/assets/56902/15318655/f548fc98-1c1e-11e6-834d-f6ead4550643.png">

This happens because when no files are found `Api.prototype.run` is returning an empty array instead of `runStatus`. So it then fails in the reporter, which in its `finish` method expects its argument to be an instance of `runStatus` instead of an empty array

