### PR TITLE
RunStatus#prefixTitle should remove this.base only if it occurs at the beginning of the path

### DIFF
--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -143,6 +143,9 @@ RunStatus.prototype.prefixTitle = function (file) {
 		.replace(/test\-/g, '')
 		.replace(/\.js$/, '')
 		.split(path.sep)
+		.filter(function (p) {
+			return p !== '__tests__';
+		})
 		.join(separator);
 
 	if (prefix.length > 0) {

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -134,7 +134,10 @@ RunStatus.prototype.prefixTitle = function (file) {
 	var separator = ' ' + chalk.gray.dim(figures.pointerSmall) + ' ';
 
 	var prefix = path.relative('.', file)
-		.replace(this.base, '')
+		.replace(this.base, function (match, offset) {
+			// only replace this.base if it is found at the start of the path
+			return offset === 0 ? '' : match;
+		})
 		.replace(/\.spec/, '')
 		.replace(/\.test/, '')
 		.replace(/test\-/g, '')

--- a/test/run-status.js
+++ b/test/run-status.js
@@ -1,0 +1,70 @@
+'use strict';
+var path = require('path');
+var test = require('tap').test;
+var chalk = require('chalk');
+var figures = require('figures');
+var RunStatus = require('../lib/run-status');
+
+var sep = ' ' + chalk.gray.dim(figures.pointerSmall) + ' ';
+
+test('requires new', function (t) {
+	var runStatus = RunStatus;
+	t.throws(function () {
+		runStatus({});
+	}, 'Class constructor RunStatus cannot be invoked without \'new\'');
+	t.end();
+});
+
+test('prefixTitle returns empty if prefixTitles == false', function (t) {
+	var runStatus = new RunStatus({prefixTitles: false});
+	t.is(runStatus.prefixTitle('test/run-status.js'), '');
+	t.end();
+});
+
+test('prefixTitle removes base if found at start of path', function (t) {
+	var runStatus = new RunStatus({base: 'test' + path.sep});
+	t.is(runStatus.prefixTitle('test/run-status.js'), 'run-status' + sep);
+	t.end();
+});
+
+test('prefixTitle does not remove base if found but not at start of path', function (t) {
+	var runStatus = new RunStatus({base: path.sep});
+	t.is(runStatus.prefixTitle('test/run-status.js'), 'test' + sep + 'run-status' + sep);
+	t.end();
+});
+
+test('prefixTitle removes .js extension', function (t) {
+	var runStatus = new RunStatus({base: path.sep});
+	t.is(runStatus.prefixTitle('run-status.js'), 'run-status' + sep);
+	t.end();
+});
+
+test('prefixTitle does not remove .js from middle of path', function (t) {
+	var runStatus = new RunStatus({base: path.sep});
+	t.is(runStatus.prefixTitle('run-.js-status.js'), 'run-.js-status' + sep);
+	t.end();
+});
+
+test('prefixTitle removes __tests__ from path', function (t) {
+	var runStatus = new RunStatus({base: path.sep});
+	t.is(runStatus.prefixTitle('backend/__tests__/run-status.js'), 'backend' + sep + 'run-status' + sep);
+	t.end();
+});
+
+test('prefixTitle removes .spec from path', function (t) {
+	var runStatus = new RunStatus({base: path.sep});
+	t.is(runStatus.prefixTitle('backend/run-status.spec.js'), 'backend' + sep + 'run-status' + sep);
+	t.end();
+});
+
+test('prefixTitle removes .test from path', function (t) {
+	var runStatus = new RunStatus({base: path.sep});
+	t.is(runStatus.prefixTitle('backend/run-status.test.js'), 'backend' + sep + 'run-status' + sep);
+	t.end();
+});
+
+test('prefixTitle removes test- from path', function (t) {
+	var runStatus = new RunStatus({base: path.sep});
+	t.is(runStatus.prefixTitle('backend/test-run-status.js'), 'backend' + sep + 'run-status' + sep);
+	t.end();
+});


### PR DESCRIPTION
When `this.base` is `/` it ends up replacing the first `/`, joining the first two directories.
Before this change it  #looked like this:
<img width="702" alt="screen shot 2016-05-18 at 16 36 40" src="https://cloud.githubusercontent.com/assets/56902/15365111/efac942c-1d16-11e6-865b-5447a1588afb.png">
(notice no separator between `backend` and `models`)
But it should look like this:
<img width="703" alt="screen shot 2016-05-18 at 16 35 31" src="https://cloud.githubusercontent.com/assets/56902/15365173/2ae65424-1d17-11e6-8f7d-d3d1b1eb3e30.png">
Unless I misunderstood `this.base` it should only be replaced if that's what the path begins with.
I didn't add any test because there's no test file for `run-status.js`