### PR TITLE
[typescript] added missing todo definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ export namespace test {
 	export function serial(run: ContextualSerialTest): void;
 	export function cb(name: string, run: ContextualCallbackTest): void;
 	export function cb(run: ContextualCallbackTest): void;
+	export function todo(name: string): void;
 }
 export namespace test.serial {
 	export const before: SerialRunner;


### PR DESCRIPTION
Hey guys,
first of all thanks for this awesome testrunner.

I've added the missing todo definition to the index.d.ts.