### PR TITLE
revert npm link fix.

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -8,14 +8,13 @@ var debug = require('debug')('ava');
 var AvaError = require('./ava-error');
 var doSend = require('./send');
 
-var fixNpmLink = fs.realpathSync(__filename) !== __filename;
-
-if (fixNpmLink) {
-	// Workaround for breakage caused by https://github.com/nodejs/node/pull/5950
-	// Those changes will be reverted in https://github.com/nodejs/node/pull/6537
-
-	// Revert #815 and #827 when the above changes land in Node.js
-	console.warn('WARNING: `npm link ava` detected: This breaks NYC coverage on early versions of Node 6.\nSee https://github.com/avajs/ava/pull/815');
+if (fs.realpathSync(__filename) !== __filename) {
+	console.warn(
+		'WARNING: `npm link ava` and the `--preserve-symlink` flag are incompatible. ' +
+		'We have detected that AVA is linked via `npm link`, and that your are using either using ether ' +
+		'an early version of Node 6, or the `--preserve-symlink` flag. This breaks AVA. ' +
+		'You should upgrade to Node 6.2.0+, avoid the `--preserve-symlink` flag, or avoid using `npm link ava`.'
+	);
 }
 
 var env = process.env;
@@ -42,47 +41,11 @@ module.exports = function (file, opts) {
 		} : false
 	}, opts);
 
-	var ps;
-
-	if (fixNpmLink) {
-		// Workaround for breakage caused by https://github.com/nodejs/node/pull/5950
-		// Those changes will be reverted in https://github.com/nodejs/node/pull/6537
-
-		// Revert #815 and #827 when the above changes land in Node.js
-		var execArgv = process.execArgv;
-		var cwd = path.dirname(file);
-
-		// This whole if statement is copied straight out of Nodes `child_process`
-		if (process._eval != null) { // eslint-disable-line
-			var index = execArgv.lastIndexOf(process._eval);
-			if (index > 0) {
-				// Remove the -e switch to avoid fork bombing ourselves.
-				execArgv = execArgv.slice();
-				execArgv.splice(index - 1, 2);
-			}
-		}
-
-		var testWorkerPath = path.join(__dirname, 'test-worker.js');
-
-		var args = execArgv.concat([
-			'-e',
-			'require(' + JSON.stringify(testWorkerPath) + ')',
-			testWorkerPath,
-			JSON.stringify(opts)
-		]);
-
-		ps = childProcess.spawn(process.execPath, args, {
-			cwd: cwd,
-			stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
-			env: env
-		});
-	} else {
-		ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
-			cwd: path.dirname(file),
-			silent: true,
-			env: env
-		});
-	}
+	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
+		cwd: path.dirname(file),
+		silent: true,
+		env: env
+	});
 
 	var relFile = path.relative('.', file);
 


### PR DESCRIPTION
This mostly reverts #815, and #827. The Node regressions they fixed were resolved in Node 6.2.0. The new behavior is just to print a warning message so people know how to fix it.