### PR TITLE
Pass shared caches to `globby`.

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -41,7 +41,12 @@ function AvaFiles(files, sources) {
 }
 
 AvaFiles.prototype.findTestFiles = function () {
-	return handlePaths(this.files, this.excludePatterns);
+	return handlePaths(this.files, this.excludePatterns, {
+		cache: Object.create(null),
+		statCache: Object.create(null),
+		realpathCache: Object.create(null),
+		symlinks: Object.create(null)
+	});
 };
 
 function getDefaultIgnorePatterns() {
@@ -193,9 +198,9 @@ AvaFiles.prototype.getChokidarPatterns = function () {
 	};
 };
 
-function handlePaths(files, excludePatterns) {
+function handlePaths(files, excludePatterns, globOptions) {
 	// convert pinkie-promise to Bluebird promise
-	files = Promise.resolve(globby(files.concat(excludePatterns)));
+	files = Promise.resolve(globby(files.concat(excludePatterns), globOptions));
 
 	var searchedParents = Object.create(null);
 	var foundFiles = Object.create(null);
@@ -231,7 +236,7 @@ function handlePaths(files, excludePatterns) {
 					pattern = slash(pattern);
 				}
 
-				return handlePaths([pattern], excludePatterns);
+				return handlePaths([pattern], excludePatterns, globOptions);
 			}
 
 			// globby returns slashes even on Windows. Normalize here so the file


### PR DESCRIPTION
Improves globbing performance.

From the [`node-glob` docs](https://github.com/isaacs/node-glob#options):

> At the very least, you may pass in shared symlinks, statCache, realpathCache, and cache options, so that parallel glob operations will be sped up by sharing information about the filesystem.