### PR TITLE
Fix "Test files must be run with the AVA CLI warning".

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,6 @@ var globals = require('./lib/globals');
 var Runner = require('./lib/runner');
 var send = require('./lib/send');
 
-// note that test files have require('ava')
-require('./lib/test-worker').avaRequired = true;
-
 var opts = globals.options;
 var runner = new Runner({
 	serial: opts.serial,
@@ -27,6 +24,9 @@ if (!isForked) {
 
 	process.exit(1); // eslint-disable-line
 }
+
+// note that test files have require('ava')
+require('./lib/test-worker').avaRequired = true;
 
 // if fail-fast is enabled, use this variable to detect
 // that no more tests should be logged

--- a/test/cli.js
+++ b/test/cli.js
@@ -298,3 +298,11 @@ test('works when no files are found', function (t) {
 		t.end();
 	});
 });
+
+test('should warn ava is required without the cli', function (t) {
+	childProcess.execFile(process.execPath, [path.resolve(__dirname, '../index.js')], function (error) {
+		t.ok(error);
+		t.match(error.message, /Test files must be run with the AVA CLI/);
+		t.end();
+	});
+});


### PR DESCRIPTION
We used to have a nice warning, telling people to use the CLI if they ran `node path/to/testfile.js`. It was broken by requiring `test-worker` to early. `test-worker` tries `JSON.parse(process.argv[2])`, which will likely throw. Preventing the helpful message.

This adds a fix, and a regression test.