### PR TITLE
Drop unused `silent` option from `lib/fork.js`.

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -167,15 +167,11 @@ module.exports = function (file, opts) {
 	});
 
 	ps.stdout.on('data', function (data) {
-		if (!opts.silent) {
-			ps.emit('stdout', data);
-		}
+		ps.emit('stdout', data);
 	});
 
 	ps.stderr.on('data', function (data) {
-		if (!opts.silent) {
-			ps.emit('stderr', data);
-		}
+		ps.emit('stderr', data);
 	});
 
 	promise.on = function () {


### PR DESCRIPTION
It's not used anywhere. I think we've refactored out all the tests that used to use it.