### PR TITLE
add test.failing and add cb to test.serial

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,8 @@ export namespace test {
 
 	export function serial(name: string, run: ContextualSerialTest): void;
 	export function serial(run: ContextualSerialTest): void;
+	export function failing(name: string, run: ContextualCallbackTest): void;
+	export function failing(run: ContextualCallbackTest): void;
 	export function cb(name: string, run: ContextualCallbackTest): void;
 	export function cb(run: ContextualCallbackTest): void;
 	export function todo(name: string): void;
@@ -67,6 +69,21 @@ export namespace test.serial {
 
 	export const skip: typeof test.serial;
 	export const only: typeof test.serial;
+
+	export function cb(name: string, run: ContextualCallbackTest): void;
+	export function cb(run: ContextualCallbackTest): void;
+}
+export namespace test.failing {
+	export const before: CallbackRunner;
+	export const after: CallbackRunner;
+	export const beforeEach: ContextualCallbackRunner;
+	export const afterEach: ContextualCallbackRunner;
+
+	export const skip: typeof test.cb;
+	export const only: typeof test.cb;
+
+	export function cb(name: string, run: ContextualCallbackTest): void;
+	export function cb(run: ContextualCallbackTest): void;
 }
 export namespace test.cb {
 	export const before: CallbackRunner;


### PR DESCRIPTION
Added the declaration for [test.failing](https://github.com/avajs/ava#failing-tests) and fixed `test.serial`. It now allows you to write `test.serial.cb`.

I'm not sure if this is possible?
- `test.cb.serial`
- `test.cb.failing`

But I don't think it is and it is not allowed at the moment.
