### PR TITLE
Add after.always afterEach.always runners to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,11 +15,17 @@ export interface Runner {
 	skip: Runner;
 	cb: CallbackRunner;
 }
+export interface AfterRunner extends Runner {
+	always: Runner;
+}
 export interface ContextualRunner {
 	(name: string, run: ContextualTest): void;
 	(run: ContextualTest): void;
 	skip: ContextualRunner;
 	cb: ContextualCallbackRunner;
+}
+export interface ContextualAfterRunner extends ContextualRunner {
+	always: ContextualRunner;
 }
 export interface SerialRunner {
 	(name: string, run: SerialTest): void;
@@ -46,9 +52,9 @@ export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
 export namespace test {
 	export const before: Runner;
-	export const after: Runner;
+	export const after: AfterRunner;
 	export const beforeEach: ContextualRunner;
-	export const afterEach: ContextualRunner;
+	export const afterEach: ContextualAfterRunner;
 
 	export const skip: typeof test;
 	export const only: typeof test;


### PR DESCRIPTION
`after.always` and `afterEach.always` runners were added to ava in 0.15.  I added them to `index.d.ts`.  I already confirmed that below code can be compiled with new `index.d.ts`.

```typescript
import test from 'ava';

test.afterEach(t => {
    console.log('BEFORE');
});

test.afterEach.always(t => {
    console.log('BEFORE ALWAYS');
});

test.after(t => {
    console.log('AFTER');
});

test.after.always(t => {
    console.log('AFTER ALWAYS');
});
```
