### PR TITLE
set child process debug port to an available port - fixes #342

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -30,7 +30,7 @@ if (env.NODE_PATH) {
 		.join(path.delimiter);
 }
 
-module.exports = function (file, opts) {
+module.exports = function (file, opts, execArgv) {
 	opts = objectAssign({
 		file: file,
 		baseDir: process.cwd(),
@@ -43,7 +43,8 @@ module.exports = function (file, opts) {
 	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
 		cwd: path.dirname(file),
 		silent: true,
-		env: env
+		env: env,
+		execArgv: execArgv || process.execArgv
 	});
 
 	var relFile = path.relative('.', file);

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "figures": "^1.4.0",
     "find-cache-dir": "^0.1.1",
     "fn-name": "^2.0.0",
+    "get-port": "^2.1.0",
+    "globby": "^5.0.0",
     "has-flag": "^2.0.0",
     "ignore-by-default": "^1.0.0",
     "is-ci": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "find-cache-dir": "^0.1.1",
     "fn-name": "^2.0.0",
     "get-port": "^2.1.0",
-    "globby": "^5.0.0",
     "has-flag": "^2.0.0",
     "ignore-by-default": "^1.0.0",
     "is-ci": "^1.0.7",

--- a/test/api.js
+++ b/test/api.js
@@ -1022,3 +1022,20 @@ function generateTests(prefix, apiCreator) {
 		]);
 	});
 }
+
+function generatePassDebugTests(execArgv) {
+	test('pass ' + execArgv.join(' ') + ' to fork', function (t) {
+		t.plan(3);
+
+		var api = new Api({testOnlyExecArgv: execArgv});
+		return api.computeForkExecArgs(['foo.js'])
+			.then(function (result) {
+				t.true(result.length === 1);
+				t.true(result[0].length === 1);
+				t.true(/--debug=\d+/.test(result[0][0]));
+			});
+	});
+}
+
+generatePassDebugTests(['--debug=0']);
+generatePassDebugTests(['--debug']);

--- a/test/api.js
+++ b/test/api.js
@@ -1037,5 +1037,20 @@ function generatePassDebugTests(execArgv) {
 	});
 }
 
+function generatePassDebugIntegrationTests(execArgv) {
+	test('pass ' + execArgv.join(' ') + ' to fork', function (t) {
+		t.plan(1);
+
+		var api = new Api({testOnlyExecArgv: execArgv});
+		return api.run([path.join(__dirname, 'fixture/debug-arg.js')])
+			.then(function (result) {
+				t.is(result.passCount, 1);
+			});
+	});
+}
+
 generatePassDebugTests(['--debug=0']);
 generatePassDebugTests(['--debug']);
+
+generatePassDebugIntegrationTests(['--debug=0']);
+

--- a/test/fixture/debug-arg.js
+++ b/test/fixture/debug-arg.js
@@ -1,0 +1,5 @@
+import test from '../../';
+
+test(t => {
+	t.true(process.execArgv[0].indexOf('--debug') === 0);
+});


### PR DESCRIPTION
Continue #613

More robust and maintainable approach was found. Just compute required data before main promise for all files. So, it is simple to add new function in to the existing promise chain. Yeah, I spend a lot of time trying to fix last failed test and decided to rework solution.

> This also doesn't handle the case where the user would do --debug-brk 213 instead of --debug-brk=213.
> https://github.com/avajs/ava/pull/613#discussion_r55246479

This syntax is not supported because node supports only `--debug=`, but not `--debug <port number>`.

```
develar-work:~ develar$ node --debug 12334 foo.js
Debugger listening on port 5858
module.js:442
    throw err;
    ^

Error: Cannot find module '/Users/develar/12334'
```


> Can you add some tests?
> https://github.com/avajs/ava/pull/613#issuecomment-193336125

Tests added. Initially as heavy-weight tests, but I got weird error `Test files must be run with the AVA CLI` if I run with `nyc` (passed without `nyc`). So, I decided to write unit tests.
