### PR TITLE
Add support for test macros in Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,9 +47,15 @@ export interface ContextualCallbackRunner {
 	(run: ContextualCallbackTest): void;
 	skip: ContextualCallbackRunner;
 }
+export interface Macro {
+	(t: ContextualTestContext, input: any, expected: any): void;
+	title? (providedTitle: string, input: any, expected: any): string;
+}
 
 export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
+export function test(run: Macro, input: any, expected: any): void;
+export function test(name: string, run: Macro, input: any, expected: any): void;
 export namespace test {
 	export const before: Runner;
 	export const after: AfterRunner;

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,15 +47,15 @@ export interface ContextualCallbackRunner {
 	(run: ContextualCallbackTest): void;
 	skip: ContextualCallbackRunner;
 }
-export interface Macro {
-	(t: ContextualTestContext, input: any, expected: any): void;
-	title? (providedTitle: string, input: any, expected: any): string;
+export interface Macro<I,E> {
+	(t: ContextualTestContext, input: I, expected: E): void;
+	title? (providedTitle: string, input: I, expected: E): string;
 }
 
 export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
-export function test(run: Macro, input: any, expected: any): void;
-export function test(name: string, run: Macro, input: any, expected: any): void;
+export function test<I, E> (run: Macro<I, E> | Macro<I, E>[], input: I, expected: E): void;
+export function test<I, E> (name: string, run: Macro<I, E> | Macro<I, E>[], input: I, expected: E): void;
 export namespace test {
 	export const before: Runner;
 	export const after: AfterRunner;


### PR DESCRIPTION
This brings support for test macros in the typescript definition.
It adds a macro interface and overloads the test function definition.

Based off https://github.com/avajs/ava#test-macros