### PR TITLE
Update docs for always verbose behavior

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -750,7 +750,6 @@ $ ava --tap | tap-nyan
 
 Please note that the TAP reporter is unavailable when using [watch mode](#watch-it).
 
-
 ### Clean stack traces
 
 AVA automatically removes unrelated lines in stack traces, allowing you to find the source of an error much faster.

--- a/readme.md
+++ b/readme.md
@@ -975,7 +975,7 @@ In contrast AVA is highly opinionated and runs tests concurrently, with a separa
 
 ### How can I use custom reporters?
 
-AVA supports the TAP format and thus is compatible with any [TAP reporter](https://github.com/sindresorhus/awesome-tap#reporters). Use the [`--tap` flag](#optional-tap-output) to enable TAP output. Please note, the verbose reporter is always used in CI environments unless [`--tap`](#optional-tap-output) is specified
+AVA supports the TAP format and thus is compatible with any [TAP reporter](https://github.com/sindresorhus/awesome-tap#reporters). Use the [`--tap` flag](#optional-tap-output) to enable TAP output. The verbose reporter is always used in CI environments unless [`--tap`](#optional-tap-output) is specified.
 
 ### How is the name written and pronounced?
 

--- a/readme.md
+++ b/readme.md
@@ -750,6 +750,7 @@ $ ava --tap | tap-nyan
 
 Please note that the TAP reporter is unavailable when using [watch mode](#watch-it).
 
+
 ### Clean stack traces
 
 AVA automatically removes unrelated lines in stack traces, allowing you to find the source of an error much faster.
@@ -975,7 +976,7 @@ In contrast AVA is highly opinionated and runs tests concurrently, with a separa
 
 ### How can I use custom reporters?
 
-AVA supports the TAP format and thus is compatible with any [TAP reporter](https://github.com/sindresorhus/awesome-tap#reporters). Use the [`--tap` flag](#optional-tap-output) to enable TAP output.
+AVA supports the TAP format and thus is compatible with any [TAP reporter](https://github.com/sindresorhus/awesome-tap#reporters). Use the [`--tap` flag](#optional-tap-output) to enable TAP output. Please note, the verbose reporter is always used in CI environments unless [`--tap`](#optional-tap-output) is specified
 
 ### How is the name written and pronounced?
 


### PR DESCRIPTION
The docs now show that in CI environments the verbose reporter is used unless --tap is specified for #890 