### PR TITLE
fix typo in test/api.js

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -703,7 +703,7 @@ function generateTests(prefix, apiCreator) {
 		}
 
 		function endsWithMap(filename) {
-			return /\.js$/.test(filename);
+			return /\.map$/.test(filename);
 		}
 	});
 


### PR DESCRIPTION
the `endWithMap` function had the wrong regex