### PR TITLE
move power assert error message formatting to child processes

### DIFF
--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -6,7 +6,6 @@ var chalk = require('chalk');
 var isObj = require('is-obj');
 var flatten = require('arr-flatten');
 var figures = require('figures');
-var formatter = require('./enhance-assert').formatter();
 
 function RunStatus(opts) {
 	if (!(this instanceof RunStatus)) {
@@ -108,16 +107,6 @@ RunStatus.prototype.handleTest = function (test) {
 	test.title = this.prefixTitle(test.file) + test.title;
 
 	if (test.error) {
-		if (test.error.powerAssertContext) {
-			var message = formatter(test.error.powerAssertContext);
-
-			if (test.error.originalMessage) {
-				message = test.error.originalMessage + ' ' + message;
-			}
-
-			test.error.message = message;
-		}
-
 		if (test.error.name !== 'AssertionError') {
 			test.error.message = 'failed with "' + test.error.message + '"';
 		}

--- a/lib/test.js
+++ b/lib/test.js
@@ -13,6 +13,7 @@ var assert = require('./assert');
 var enhanceAssert = require('./enhance-assert');
 var globals = require('./globals');
 var throwsHelper = require('./throws-helper');
+var formatter = enhanceAssert.formatter();
 
 function Test(title, fn, contextRef, report) {
 	if (!(this instanceof Test)) {
@@ -294,8 +295,12 @@ function PublicApi(test) {
 
 function onAssertionEvent(event) {
 	if (event.assertionThrew) {
-		event.error.powerAssertContext = event.powerAssertContext;
-		event.error.originalMessage = event.originalMessage;
+		if (event.powerAssertContext) {
+			event.error.message = formatter(event.powerAssertContext);
+			if (event.originalMessage) {
+				event.error.message = event.originalMessage + ' ' + event.error.message;
+			}
+		}
 		this._test._setAssertError(event.error);
 		this._test._assert(null);
 		return null;

--- a/test/api.js
+++ b/test/api.js
@@ -650,7 +650,7 @@ function generateTests(prefix, apiCreator) {
 	});
 
 	test(prefix + 'power-assert support', function (t) {
-		t.plan(5);
+		t.plan(4);
 
 		var api = apiCreator({
 			babelConfig: {
@@ -660,8 +660,6 @@ function generateTests(prefix, apiCreator) {
 
 		api.run([path.join(__dirname, 'fixture/power-assert.js')])
 			.then(function (result) {
-				t.ok(result.errors[0].error.powerAssertContext);
-
 				t.match(
 					result.errors[0].error.message,
 					/t\.true\(a === 'bar'\)\s*\n\s+\|\s*\n\s+"foo"/m


### PR DESCRIPTION
- removed power assert formatter usage from `run-status.js`
- onError function passed to `enhanceAssert` in `test.js` now replaces message on `Error` object if there is `powerAssertContext` and does not attach `powerAssertContext` to the error anymore.
- removed assertion from test in `test/api.js` that assumed errors had `powerAssertContext`.
