### PR TITLE
Swap arr-diff for lodash.difference

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,7 +1,7 @@
 'use strict';
 var nodePath = require('path');
 var debug = require('debug')('ava:watcher');
-var diff = require('arr-diff');
+var diff = require('lodash.difference');
 var flatten = require('arr-flatten');
 var union = require('array-union');
 var uniq = require('array-uniq');

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "tap"
   ],
   "dependencies": {
-    "arr-diff": "^2.0.0",
     "arr-flatten": "^1.0.1",
     "array-union": "^1.0.1",
     "array-uniq": "^1.0.2",
@@ -119,6 +118,7 @@
     "is-promise": "^2.1.0",
     "last-line-stream": "^1.0.0",
     "lodash.debounce": "^4.0.3",
+    "lodash.difference": "^4.3.0",
     "loud-rejection": "^1.2.0",
     "matcher": "^0.1.1",
     "max-timeout": "^1.0.0",


### PR DESCRIPTION
Follow-up to <https://github.com/avajs/ava/pull/869#issuecomment-221456875>. `arr-diff@3` mutates the input array. `lodash.difference` is a drop-in replacement.