### PR TITLE
Chokidar shouldn't be an optional dependency

### DIFF
--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -59,11 +59,7 @@ Please note that the TAP reporter is unavailable when using watch mode.
 
 ## Requirements
 
-AVA uses [`chokidar`] as the file watcher. It's configured as an optional dependency since `chokidar` sometimes can't be installed. Watch mode is not available if `chokidar` fails to install, instead you'll see a message like:
-
-> The optional dependency chokidar failed to install and is required for --watch. Chokidar is likely not supported on your platform.
-
-Please refer to the [`chokidar` documentation][`chokidar`] for how to resolve this problem.
+AVA uses [`chokidar`] as the file watcher. Note that even if you see warnings about optional dependencies failing during install, it will still work fine. Please refer to the *[Install Troubleshooting]* section of `chokidar` documentation for how to resolve the installation problems with chokidar.
 
 ## Source files and test files
 
@@ -111,6 +107,7 @@ $ npm test -- --watch --verbose
 Watch mode is relatively new and there might be some rough edges. Please [report](https://github.com/avajs/ava/issues) any issues you encounter. Thanks!
 
 [`chokidar`]: https://github.com/paulmillr/chokidar
+[Install Troubleshooting]: https://github.com/paulmillr/chokidar#install-troubleshooting
 [`ignore-by-default`]: https://github.com/novemberborn/ignore-by-default
 [`--require` CLI flag]: https://github.com/avajs/ava#cli
 [`--source` CLI flag]: https://github.com/avajs/ava#cli

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -2,19 +2,11 @@
 var nodePath = require('path');
 var debug = require('debug')('ava:watcher');
 var diff = require('lodash.difference');
+var chokidar = require('chokidar');
 var flatten = require('arr-flatten');
 var union = require('array-union');
 var uniq = require('array-uniq');
-var AvaError = require('./ava-error');
 var AvaFiles = require('./ava-files');
-
-function requireChokidar() {
-	try {
-		return require('chokidar');
-	} catch (err) {
-		throw new AvaError('The optional dependency chokidar failed to install and is required for --watch. Chokidar is likely not supported on your platform.');
-	}
-}
 
 function rethrowAsync(err) {
 	// Don't swallow exceptions. Note that any expected error should already have
@@ -96,7 +88,7 @@ Watcher.prototype.watchFiles = function () {
 	var self = this;
 	var patterns = this.avaFiles.getChokidarPatterns();
 
-	requireChokidar().watch(patterns.paths, {
+	chokidar.watch(patterns.paths, {
 		ignored: patterns.ignored,
 		ignoreInitial: true
 	}).on('all', function (event, path) {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "bluebird": "^3.0.0",
     "caching-transform": "^1.0.0",
     "chalk": "^1.0.0",
+    "chokidar": "^1.4.2",
     "clean-yaml-object": "^0.1.0",
     "cli-cursor": "^1.0.2",
     "cli-spinners": "^0.1.2",
@@ -173,9 +174,6 @@
     "touch": "^1.0.0",
     "xo": "*",
     "zen-observable": "^0.2.1"
-  },
-  "optionalDependencies": {
-    "chokidar": "^1.4.2"
   },
   "xo": {
     "rules": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -15,12 +15,6 @@ var cliPath = path.join(__dirname, '../cli.js');
 chalk.enabled = true;
 var colors = require('../lib/colors');
 
-var hasChokidar = false;
-try {
-	require('chokidar');
-	hasChokidar = true;
-} catch (err) {}
-
 function execCli(args, opts, cb) {
 	var dirname;
 	var env;
@@ -180,16 +174,10 @@ test('pkg-conf: cli takes precedence', function (t) {
 test('watcher reruns test files when they changed', function (t) {
 	var killed = false;
 
-	var child = execCli(['--verbose', '--watch', 'test.js'], {dirname: 'fixture/watcher'}, function (err, stdout, stderr) {
-		if (err && err.code === 1 && !hasChokidar) {
-			t.comment('chokidar dependency is missing, cannot test watcher');
-			t.match(stderr, 'The optional dependency chokidar failed to install and is required for --watch. Chokidar is likely not supported on your platform.');
-			t.end();
-		} else {
-			t.ok(killed);
-			t.ifError(err);
-			t.end();
-		}
+	var child = execCli(['--verbose', '--watch', 'test.js'], {dirname: 'fixture/watcher'}, function (err) {
+		t.ok(killed);
+		t.ifError(err);
+		t.end();
 	});
 
 	var buffer = '';
@@ -209,72 +197,70 @@ test('watcher reruns test files when they changed', function (t) {
 	});
 });
 
-if (hasChokidar) {
-	test('watcher reruns test files when source dependencies change', function (t) {
-		var killed = false;
+test('watcher reruns test files when source dependencies change', function (t) {
+	var killed = false;
 
-		var child = execCli(['--verbose', '--watch', '--source=source.js', 'test-*.js'], {dirname: 'fixture/watcher/with-dependencies'}, function (err) {
-			t.ok(killed);
-			t.ifError(err);
-			t.end();
-		});
-
-		var buffer = '';
-		var passedFirst = false;
-		child.stderr.on('data', function (str) {
-			buffer += str;
-			if (/2 tests passed/.test(buffer) && !passedFirst) {
-				touch.sync(path.join(__dirname, 'fixture/watcher/with-dependencies/source.js'));
-				buffer = '';
-				passedFirst = true;
-			} else if (/1 test passed/.test(buffer) && !killed) {
-				child.kill();
-				killed = true;
-			}
-		});
+	var child = execCli(['--verbose', '--watch', '--source=source.js', 'test-*.js'], {dirname: 'fixture/watcher/with-dependencies'}, function (err) {
+		t.ok(killed);
+		t.ifError(err);
+		t.end();
 	});
 
-	test('`"tap": true` config is ignored when --watch is given', function (t) {
-		var killed = false;
+	var buffer = '';
+	var passedFirst = false;
+	child.stderr.on('data', function (str) {
+		buffer += str;
+		if (/2 tests passed/.test(buffer) && !passedFirst) {
+			touch.sync(path.join(__dirname, 'fixture/watcher/with-dependencies/source.js'));
+			buffer = '';
+			passedFirst = true;
+		} else if (/1 test passed/.test(buffer) && !killed) {
+			child.kill();
+			killed = true;
+		}
+	});
+});
 
-		var child = execCli(['--watch', 'test.js'], {dirname: 'fixture/watcher/tap-in-conf'}, function () {
-			t.ok(killed);
-			t.end();
-		});
+test('`"tap": true` config is ignored when --watch is given', function (t) {
+	var killed = false;
 
-		var combined = '';
-		var testOutput = function (output) {
-			combined += output;
-			t.notMatch(combined, /TAP/);
-			if (/works/.test(combined)) {
-				child.kill();
-				killed = true;
-			}
-		};
-		child.stdout.on('data', testOutput);
-		child.stderr.on('data', testOutput);
+	var child = execCli(['--watch', 'test.js'], {dirname: 'fixture/watcher/tap-in-conf'}, function () {
+		t.ok(killed);
+		t.end();
 	});
 
-	test('bails when config contains `"tap": true` and `"watch": true`', function (t) {
-		execCli(['test.js'], {dirname: 'fixture/watcher/tap-and-watch-in-conf'}, function (err, stdout, stderr) {
-			t.is(err.code, 1);
-			t.match(stderr, 'The TAP reporter is not available when using watch mode.');
-			t.end();
-		});
-	});
+	var combined = '';
+	var testOutput = function (output) {
+		combined += output;
+		t.notMatch(combined, /TAP/);
+		if (/works/.test(combined)) {
+			child.kill();
+			killed = true;
+		}
+	};
+	child.stdout.on('data', testOutput);
+	child.stderr.on('data', testOutput);
+});
 
-	['--watch', '-w'].forEach(function (watchFlag) {
-		['--tap', '-t'].forEach(function (tapFlag) {
-			test('bails when ' + tapFlag + ' reporter is used while ' + watchFlag + ' is given', function (t) {
-				execCli([tapFlag, watchFlag, 'test.js'], {dirname: 'fixture/watcher'}, function (err, stdout, stderr) {
-					t.is(err.code, 1);
-					t.match(stderr, 'The TAP reporter is not available when using watch mode.');
-					t.end();
-				});
+test('bails when config contains `"tap": true` and `"watch": true`', function (t) {
+	execCli(['test.js'], {dirname: 'fixture/watcher/tap-and-watch-in-conf'}, function (err, stdout, stderr) {
+		t.is(err.code, 1);
+		t.match(stderr, 'The TAP reporter is not available when using watch mode.');
+		t.end();
+	});
+});
+
+['--watch', '-w'].forEach(function (watchFlag) {
+	['--tap', '-t'].forEach(function (tapFlag) {
+		test('bails when ' + tapFlag + ' reporter is used while ' + watchFlag + ' is given', function (t) {
+			execCli([tapFlag, watchFlag, 'test.js'], {dirname: 'fixture/watcher'}, function (err, stdout, stderr) {
+				t.is(err.code, 1);
+				t.match(stderr, 'The TAP reporter is not available when using watch mode.');
+				t.end();
 			});
 		});
 	});
-}
+});
 
 test('--match works', function (t) {
 	execCli(['-m=foo', '-m=bar', '-m=!baz', '-m=t* a* f*', '-m=!t* a* n* f*', 'fixture/matcher-skip.js'], function (err) {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -36,25 +36,7 @@ function makeGroup(test) {
 }
 var group = makeGroup(test);
 
-test('chokidar is not installed', function (t) {
-	t.plan(2);
-
-	var Subject = proxyquire.noCallThru().load('../lib/watcher', {
-		chokidar: null
-	});
-
-	try {
-		new Subject({}, { // eslint-disable-line no-new
-			excludePatterns: [],
-			on: function () {}
-		}, [], []);
-	} catch (err) {
-		t.is(err.name, 'AvaError');
-		t.is(err.message, 'The optional dependency chokidar failed to install and is required for --watch. Chokidar is likely not supported on your platform.');
-	}
-});
-
-group('chokidar is installed', function (beforeEach, test, group) {
+group('chokidar', function (beforeEach, test, group) {
 	var chokidar;
 	var debug;
 	var logger;


### PR DESCRIPTION
Fixes #913 

Changes made according to the instructions in #913

Todo (or not):
- [X] Remove or change section [Requirements](https://github.com/avajs/ava/blob/master/docs/recipes/watch-mode.md#requirements) in the watch-mode recipe 
- [x] ~~Bump chokidar to 1.5.x~~

