### PR TITLE
Extract babel config generation into it's own submodule

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -38,11 +38,7 @@ var Api = require('./api');
 // Bluebird specific
 Promise.longStackTraces();
 
-var conf = pkgConf.sync('ava', {
-	defaults: {
-		babel: 'default'
-	}
-});
+var conf = pkgConf.sync('ava');
 
 var pkgDir = path.dirname(pkgConf.filepath(conf));
 

--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,6 @@ var arrify = require('arrify');
 var meow = require('meow');
 var Promise = require('bluebird');
 var pkgConf = require('pkg-conf');
-var chalk = require('chalk');
 var isCi = require('is-ci');
 var hasFlag = require('has-flag');
 var colors = require('./lib/colors');
@@ -33,6 +32,7 @@ var miniReporter = require('./lib/reporters/mini');
 var tapReporter = require('./lib/reporters/tap');
 var Logger = require('./lib/logger');
 var Watcher = require('./lib/watcher');
+var babelConfig = require('./lib/babel-config');
 var Api = require('./api');
 
 // Bluebird specific
@@ -46,15 +46,10 @@ var conf = pkgConf.sync('ava', {
 
 var pkgDir = path.dirname(pkgConf.filepath(conf));
 
-// check for valid babel config shortcuts (can be either "default" or "inherit")
-var isValidShortcut = ['default', 'inherit'].indexOf(conf.babel) !== -1;
-
-if (!conf.babel || (typeof conf.babel === 'string' && !isValidShortcut)) {
-	var message = '';
-	message += 'Unexpected Babel configuration for AVA. ';
-	message += 'See ' + chalk.underline('https://github.com/avajs/ava#es2015-support') + ' for allowed values.';
-
-	console.log('\n  ' + colors.error(figures.cross) + ' ' + message);
+try {
+	conf.babel = babelConfig.validate(conf.babel);
+} catch (err) {
+	console.log('\n  ' + err.message);
 	process.exit(1);
 }
 

--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -85,7 +85,7 @@ var defaultPlugins = lazy(function () {
 });
 
 function build(babelConfig, filePath, code) {
-	validate(babelConfig);
+	babelConfig = validate(babelConfig);
 
 	var options;
 

--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -12,7 +12,7 @@ function validate(conf) {
 	}
 
 	// check for valid babel config shortcuts (can be either "default" or "inherit")
-	var isValidShortcut = ['default', 'inherit'].indexOf(conf) !== -1;
+	var isValidShortcut = conf === 'default' || conf === 'inherit';
 
 	if (!conf || (typeof conf === 'string' && !isValidShortcut)) {
 		var message = colors.error(figures.cross);

--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -1,0 +1,146 @@
+'use strict';
+var path = require('path');
+var chalk = require('chalk');
+var figures = require('figures');
+var convertSourceMap = require('convert-source-map');
+var objectAssign = require('object-assign');
+var colors = require('./colors');
+
+function validate(conf) {
+	if (conf === undefined || conf === null) {
+		conf = 'default';
+	}
+
+	// check for valid babel config shortcuts (can be either "default" or "inherit")
+	var isValidShortcut = ['default', 'inherit'].indexOf(conf) !== -1;
+
+	if (!conf || (typeof conf === 'string' && !isValidShortcut)) {
+		var message = colors.error(figures.cross);
+		message += ' Unexpected Babel configuration for AVA. ';
+		message += 'See ' + chalk.underline('https://github.com/avajs/ava#es2015-support') + ' for allowed values.';
+
+		throw new Error(message);
+	}
+
+	return conf;
+}
+
+function lazy(initFn) {
+	var initialized = false;
+	var value;
+
+	return function () {
+		if (!initialized) {
+			initialized = true;
+			value = initFn();
+		}
+
+		return value;
+	};
+}
+
+var defaultPresets = lazy(function () {
+	return [
+		require('babel-preset-stage-2'),
+		require('babel-preset-es2015')
+	];
+});
+
+var rewritePlugin = lazy(function () {
+	var wrapListener = require('babel-plugin-detective/wrap-listener');
+
+	return wrapListener(rewriteBabelRuntimePaths, 'rewrite-runtime', {
+		generated: true,
+		require: true,
+		import: true
+	});
+});
+
+function rewriteBabelRuntimePaths(path) {
+	var isBabelPath = /^babel-runtime[\\\/]?/.test(path.node.value);
+
+	if (path.isLiteral() && isBabelPath) {
+		path.node.value = require.resolve(path.node.value);
+	}
+}
+
+var espowerPlugin = lazy(function () {
+	var babel = require('babel-core');
+	var createEspowerPlugin = require('babel-plugin-espower/create');
+
+	// initialize power-assert
+	return createEspowerPlugin(babel, {
+		embedAst: true,
+		patterns: require('./enhance-assert').PATTERNS
+	});
+});
+
+var defaultPlugins = lazy(function () {
+	return [
+		espowerPlugin(),
+		require('babel-plugin-ava-throws-helper'),
+		rewritePlugin(),
+		require('babel-plugin-transform-runtime')
+	];
+});
+
+function build(babelConfig, filePath, code) {
+	validate(babelConfig);
+
+	var options;
+
+	if (babelConfig === 'default') {
+		options = {
+			babelrc: false,
+			presets: defaultPresets()
+		};
+	} else if (babelConfig === 'inherit') {
+		options = {
+			babelrc: true
+		};
+	} else {
+		options = {
+			babelrc: false
+		};
+
+		objectAssign(options, babelConfig);
+	}
+
+	var sourceMap = getSourceMap(filePath, code);
+
+	objectAssign(options, {
+		inputSourceMap: sourceMap,
+		filename: filePath,
+		sourceMaps: true,
+		ast: false
+	});
+
+	options.plugins = (options.plugins || []).concat(defaultPlugins());
+
+	return options;
+}
+
+function getSourceMap(filePath, code) {
+	var sourceMap = convertSourceMap.fromSource(code);
+
+	if (!sourceMap) {
+		var dirPath = path.dirname(filePath);
+
+		sourceMap = convertSourceMap.fromMapFileSource(code, dirPath);
+	}
+
+	if (sourceMap) {
+		sourceMap = sourceMap.toObject();
+	}
+
+	return sourceMap;
+}
+
+module.exports = {
+	validate: validate,
+	build: build,
+	pluginPackages: [
+		require.resolve('babel-core/package.json'),
+		require.resolve('babel-plugin-espower/package.json')
+	]
+};

--- a/lib/caching-precompiler.js
+++ b/lib/caching-precompiler.js
@@ -3,18 +3,17 @@ var path = require('path');
 var fs = require('fs');
 var convertSourceMap = require('convert-source-map');
 var cachingTransform = require('caching-transform');
-var objectAssign = require('object-assign');
 var stripBom = require('strip-bom');
 var md5Hex = require('md5-hex');
 var packageHash = require('package-hash');
-var enhanceAssert = require('./enhance-assert');
+var babelConfigHelper = require('./babel-config');
 
 function CachingPrecompiler(cacheDirPath, babelConfig) {
 	if (!(this instanceof CachingPrecompiler)) {
 		throw new TypeError('Class constructor CachingPrecompiler cannot be invoked without \'new\'');
 	}
 
-	this.babelConfig = babelConfig || 'default';
+	this.babelConfig = babelConfigHelper.validate(babelConfig);
 	this.cacheDirPath = cacheDirPath;
 	this.fileHashes = {};
 
@@ -46,30 +45,12 @@ CachingPrecompiler.prototype._factory = function () {
 
 CachingPrecompiler.prototype._init = function () {
 	this.babel = require('babel-core');
-
-	this.defaultPresets = [
-		require('babel-preset-stage-2'),
-		require('babel-preset-es2015')
-	];
-
-	var transformRuntime = require('babel-plugin-transform-runtime');
-	var throwsHelper = require('babel-plugin-ava-throws-helper');
-
-	var rewriteBabelPaths = this._createRewritePlugin();
-	var powerAssert = this._createEspowerPlugin();
-
-	this.defaultPlugins = [
-		powerAssert,
-		throwsHelper,
-		rewriteBabelPaths,
-		transformRuntime
-	];
 };
 
 CachingPrecompiler.prototype._transform = function (code, filePath, hash) {
 	code = code.toString();
 
-	var options = this._buildOptions(filePath, code);
+	var options = babelConfigHelper.build(this.babelConfig, filePath, code);
 	var result = this.babel.transform(code, options);
 
 	// save source map
@@ -92,81 +73,11 @@ CachingPrecompiler.prototype._transform = function (code, filePath, hash) {
 	return result.code + '\n' + comment;
 };
 
-CachingPrecompiler.prototype._buildOptions = function (filePath, code) {
-	var options = {babelrc: false};
-
-	if (this.babelConfig === 'default') {
-		objectAssign(options, {presets: this.defaultPresets});
-	} else if (this.babelConfig === 'inherit') {
-		objectAssign(options, {babelrc: true});
-	} else {
-		objectAssign(options, this.babelConfig);
-	}
-
-	var sourceMap = this._getSourceMap(filePath, code);
-
-	objectAssign(options, {
-		inputSourceMap: sourceMap,
-		filename: filePath,
-		sourceMaps: true,
-		ast: false
-	});
-
-	options.plugins = (options.plugins || []).concat(this.defaultPlugins);
-
-	return options;
-};
-
-CachingPrecompiler.prototype._getSourceMap = function (filePath, code) {
-	var sourceMap = convertSourceMap.fromSource(code);
-
-	if (!sourceMap) {
-		var dirPath = path.dirname(filePath);
-
-		sourceMap = convertSourceMap.fromMapFileSource(code, dirPath);
-	}
-
-	if (sourceMap) {
-		sourceMap = sourceMap.toObject();
-	}
-
-	return sourceMap;
-};
-
-CachingPrecompiler.prototype._createRewritePlugin = function () {
-	var wrapListener = require('babel-plugin-detective/wrap-listener');
-
-	return wrapListener(this._rewriteBabelRuntimePaths, 'rewrite-runtime', {
-		generated: true,
-		require: true,
-		import: true
-	});
-};
-
-CachingPrecompiler.prototype._rewriteBabelRuntimePaths = function (path) {
-	var isBabelPath = /^babel-runtime[\\\/]?/.test(path.node.value);
-
-	if (path.isLiteral() && isBabelPath) {
-		path.node.value = require.resolve(path.node.value);
-	}
-};
-
-CachingPrecompiler.prototype._createEspowerPlugin = function () {
-	var createEspowerPlugin = require('babel-plugin-espower/create');
-
-	// initialize power-assert
-	return createEspowerPlugin(this.babel, {
-		embedAst: true,
-		patterns: enhanceAssert.PATTERNS
-	});
-};
-
 CachingPrecompiler.prototype._createTransform = function () {
-	var salt = packageHash.sync([
-		require.resolve('../package.json'),
-		require.resolve('babel-core/package.json'),
-		require.resolve('babel-plugin-espower/package.json')
-	], JSON.stringify(this.babelConfig));
+	var salt = packageHash.sync(
+		[require.resolve('../package.json')].concat(babelConfigHelper.pluginPackages),
+		JSON.stringify(this.babelConfig)
+	);
 
 	return cachingTransform({
 		factory: this._factory,

--- a/test/bable-config.js
+++ b/test/bable-config.js
@@ -1,0 +1,50 @@
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var test = require('tap').test;
+var sinon = require('sinon');
+var proxyquire = require('proxyquire').noCallThru();
+var throwsHelper = require('babel-plugin-ava-throws-helper');
+var transformRuntime = require('babel-plugin-transform-runtime');
+
+function fixture(name) {
+	return path.join(__dirname, 'fixture', name);
+}
+
+test('uses babelConfig for babel options when babelConfig is an object', function (t) {
+	var customPlugin = sinon.stub().returns({visitor: {}});
+	var powerAssert = sinon.stub().returns({visitor: {}});
+	var rewrite = sinon.stub().returns({visitor: {}});
+
+	function createEspowerPlugin() {
+		return powerAssert;
+	}
+
+	function babelDetectiveWrap() {
+		return rewrite;
+	}
+
+	var babelConfigHelper = proxyquire('../lib/babel-config', {
+		'babel-plugin-espower/create': createEspowerPlugin,
+		'babel-plugin-detective/wrap-listener': babelDetectiveWrap
+	});
+
+	var babelConfig = {
+		presets: ['stage-2', 'es2015'],
+		plugins: [customPlugin]
+	};
+
+	var fixturePath = fixture('es2015.js');
+	var fixtureSource = fs.readFileSync(fixturePath, 'utf8');
+
+	var options = babelConfigHelper.build(babelConfig, fixturePath, fixtureSource);
+
+	t.true('filename' in options);
+	t.true(options.sourceMaps);
+	t.false(options.ast);
+	t.true('inputSourceMap' in options);
+	t.false(options.babelrc);
+	t.strictDeepEqual(options.presets, ['stage-2', 'es2015']);
+	t.strictDeepEqual(options.plugins, [customPlugin, powerAssert, throwsHelper, rewrite, transformRuntime]);
+	t.end();
+});

--- a/test/caching-precompiler.js
+++ b/test/caching-precompiler.js
@@ -5,8 +5,6 @@ var test = require('tap').test;
 var uniqueTempDir = require('unique-temp-dir');
 var sinon = require('sinon');
 var babel = require('babel-core');
-var transformRuntime = require('babel-plugin-transform-runtime');
-var throwsHelper = require('babel-plugin-ava-throws-helper');
 var fromMapFileSource = require('convert-source-map').fromMapFileSource;
 
 var CachingPrecompiler = require('../lib/caching-precompiler');
@@ -119,34 +117,6 @@ test('allows babel config from package.json/babel when babelConfig === "inherit"
 	t.false(options.ast);
 	t.true('inputSourceMap' in options);
 	t.true(options.babelrc);
-	t.end();
-});
-
-test('uses babelConfig for babel options when babelConfig is an object', function (t) {
-	var tempDir = uniqueTempDir();
-	var customPlugin = sinon.stub().returns({visitor: {}});
-	var powerAssert = sinon.stub().returns({visitor: {}});
-	var rewrite = sinon.stub().returns({visitor: {}});
-	var precompiler = new CachingPrecompiler(tempDir, {
-		presets: ['stage-2', 'es2015'],
-		plugins: [customPlugin]
-	});
-	sinon.stub(precompiler, '_createEspowerPlugin').returns(powerAssert);
-	sinon.stub(precompiler, '_createRewritePlugin').returns(rewrite);
-	babel.transform.reset();
-
-	precompiler.precompileFile(fixture('es2015.js'));
-
-	t.true(babel.transform.calledOnce);
-	var options = babel.transform.firstCall.args[1];
-
-	t.true('filename' in options);
-	t.true(options.sourceMaps);
-	t.false(options.ast);
-	t.true('inputSourceMap' in options);
-	t.false(options.babelrc);
-	t.strictDeepEqual(options.presets, ['stage-2', 'es2015']);
-	t.strictDeepEqual(options.plugins, [customPlugin, powerAssert, throwsHelper, rewrite, transformRuntime]);
 	t.end();
 });
 


### PR DESCRIPTION
This adds `lib/babel-config.js`, it is used to:

1. Validate the `babel` option in `package.json` (i.e. make sure it's either `"default"`, `"inherit"`, or an `Object`). We were doing this in `cli.js`, which was definitely not the right place to do it.

2. Build a babel config which is passed to `babel.transform`. This was previously done in `caching-precompiler`. That didn't make much sense either, `caching-precompiler` should be dedicated to handling the caching, not options manipulation.