### PR TITLE
Fix babel settings for jsx in test files

### DIFF
--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -9,7 +9,8 @@ The first step is setting up Babel to transpile JSX code from the tests by addin
 ```json
 {
   "ava": {
-    "require": ["babel-register"]
+    "require": ["babel-register"],
+    "babel": "inherit"
   },
   "babel": {
     "presets": ["react"]


### PR DESCRIPTION
# Challenge
When using JSX in test code, you need to enable the react preset, even if you already do so as part of your general babel config.

The current docs use JSX in the test, but have no babel presets in the `ava` config.

# Solution
Setting the `babel` option to `"inherit"` (to pick up the babel config set in the same file) does the trick.