### PR TITLE
Proof Of Concept: Alternate debug

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -87,6 +87,7 @@ var cli = meow([
 		'concurrency'
 	],
 	boolean: [
+		'debug',
 		'fail-fast',
 		'verbose',
 		'serial',
@@ -109,6 +110,22 @@ var cli = meow([
 
 updateNotifier({pkg: cli.pkg}).notify();
 
+if (cli.flags.debug) {
+	cli.flags.concurrency = '1';
+	cli.flags.debug = 5858;
+	process.argv.some(function (arg) {
+		if (/^--debug=/.test(arg)) {
+			cli.flags.debug = parseInt(arg.substring(8), 10);
+			return true;
+		}
+		return false;
+	});
+
+	if (isNaN(cli.flags.debug)) {
+		cli.flags.debug = 5858;
+	}
+}
+
 if (cli.flags.init) {
 	require('ava-init')();
 	return;
@@ -125,6 +142,7 @@ if (
 var api = new Api({
 	failFast: cli.flags.failFast,
 	serial: cli.flags.serial,
+	debug: cli.flags.debug,
 	require: arrify(cli.flags.require),
 	cacheEnabled: cli.flags.cache !== false,
 	explicitTitles: cli.flags.watch,

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -44,7 +44,7 @@ module.exports = function (file, opts) {
 	var execArgv = process.execArgv.slice();
 
 	if (opts.debug) {
-		execArgv.push('--debug=' + opts.debug);
+		execArgv.push(opts.debug);
 	}
 
 	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -41,10 +41,17 @@ module.exports = function (file, opts) {
 		} : false
 	}, opts);
 
+	var execArgv = process.execArgv.slice();
+
+	if (opts.debug) {
+		execArgv.push('--debug=' + opts.debug);
+	}
+
 	var ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), [JSON.stringify(opts)], {
 		cwd: path.dirname(file),
 		silent: true,
-		env: env
+		env: env,
+		execArgv: execArgv
 	});
 
 	var relFile = path.relative('.', file);


### PR DESCRIPTION
Alternate to #874
Possibly Fixes #342

I have tested this locally, and it seems to just work.

Run with:

``` js
ava --debug=<PORT> testfile1.js testfile2.js
```

In a separate terminal:

```
node debug localhost:<PORT>
```

You can see the list of available commands by typing `help`.

Once the first test terminates, you _do_ need to type `run` to reconnect the debugger between tests. I think we could request `node debug` add a flag to automatically reconnect (still, I don't know why you would want to debug multiple test files, and typing `run` a few times isn't that bad). It seems like auto-reconnect would be much easier for existing tools to implement instead of parsing stderr`.
