### PR TITLE
Translate React recipe to Spanish (es_ES)

### DIFF
--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -1,6 +1,6 @@
 # Testing React components
 
-Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/recipes/react.md)
+Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/docs/recipes/react.md), [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/recipes/react.md)
 
 ## Setting up Babel
 


### PR DESCRIPTION
Adds recipe to test **React components** in Spanish! :es:

Should be merged when https://github.com/avajs/ava-docs/pull/31 is merged first. :wink:

