### PR TITLE
Update JSPM+SystemJS recipe per @jamestalmage.

### DIFF
--- a/docs/recipes/jspm-systemjs.md
+++ b/docs/recipes/jspm-systemjs.md
@@ -1,6 +1,8 @@
 # JSPM and SystemJS for ES2015
 
 It requires a special loader helper to correctly resolve `import`s of JSPM packages when using AVA.
+The purpose of the loader is to allow you to run your tests without having to
+pre-build your JSPM project.
 
 ## Setup
 


### PR DESCRIPTION
See istanbuljs/nyc#305 - specifically [this comment and the one after it](https://github.com/istanbuljs/nyc/issues/305#issuecomment-231517122).

Essentially, @jamestalmage brought up that it would be good to explicitly mention in the recipe that you should not pre-build your project with JSPM/SystemJS to run your tests. The purpose of ava-jspm-loader is that you do not have to build before testing.