### PR TITLE
[WIP] Add recipe for hot observables

### DIFF
--- a/docs/recipes/hot-observables.md
+++ b/docs/recipes/hot-observables.md
@@ -1,0 +1,52 @@
+# How to test hot observables
+
+Ava supports autosubscribing to cold observables, which will not work for hot observables.
+For hot observables, we will need to first subscribe, and then trigger the values to be sent in the stream.
+We can automatically unsubscribe by using `#take()`.
+
+## Installing rxjs v5
+`npm install --save rxjs`
+
+## Create a source file named interactions.js
+
+```
+function create({Rx}) {
+  const writeSubject = new Rx.Subject()
+  
+  function write(data) {
+    writeSubject.next(data)
+  }
+  
+  return {
+    actions: {write},
+    events: {write: writeSubject.toObservable()}
+  }
+}
+
+export default {
+  create
+}
+```
+
+## Now test it
+
+```
+import tests from 'Ava'
+import Rx from 'rxjs'
+import interactionsFactory from './interactions'
+
+tests(
+  `Given that we subscribe to the write event,
+  when  the user calls the action write with 'hello'
+  then our subscriber recieves the message 'hello'`,
+  function onTest(test) {
+    const expected = 'hello'
+    const interactions = interactionsFactory.create({Rx})
+    interactions.events.write.take(1).subscribe(function(actual) {
+      test.is(actual, expected)
+      test.done()
+    })
+    interactions.actions.write(expected)
+  }
+)
+```


### PR DESCRIPTION

I think it would be nice to add some recipies for observables. Right now, I'm not able to use the observable snippet in the readme since it is based on cold observables. I made a draft of how I currently do testing with hot observables using Subjects. But since I'm new at observables, someone more senior should go in and say if this style is valid. There might be some even better way that I haven't learned about yet.

Also, it would be nice to just note that the readme docs example is only for hot observables. It might confuse newbies (like it did for me) and be a letdown when you discover that Ava doesn't support most of the observables created in web development.

I just wrote this code from my head. If you want to accept this recipe, I will go through the code and test run it before a possible merge.
