### PR TITLE
support test macros in typescript definitions

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -124,8 +124,9 @@ export interface Macro<I, E, T> {
 	(t: T, input: I, expected: E): void;
 	title? (providedTitle: string, input: I, expected: E): string;
 }
+export type Macros<I, E, T> = Macro<I, E, T> | Macro<I, E, T>[];
 
 export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
-export function test<I, E> (run: Macro<I, E, ContextualTestContext> | Macro<I, E, ContextualTestContext>[], input: I, expected: E): void;
-export function test<I, E> (name: string, run: Macro<I, E, ContextualTestContext> | Macro<I, E, ContextualTestContext>[], input: I, expected: E): void;
+export function test<I, E> (name: string, run: Macros<I, E, ContextualTestContext>, input: I, expected: E): void;
+export function test<I, E> (run: Macros<I, E, ContextualTestContext>, input: I, expected: E): void;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -121,12 +121,12 @@ export interface ContextualCallbackTestContext extends CallbackTestContext {
 }
 
 export interface Macro<T, I, E> {
-	(t: T, input: I, expected: E): void;
-	title? (providedTitle: string, input: I, expected: E): string;
+	(t: T, input?: I, expected?: E): void;
+	title? (providedTitle: string, input?: I, expected?: E): string;
 }
 export type Macros<T, I, E> = Macro<T, I, E> | Macro<T, I, E>[];
 
 export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
-export function test<I, E> (name: string, run: Macros<ContextualTestContext, I, E>, input: I, expected: E): void;
-export function test<I, E> (run: Macros<ContextualTestContext, I, E>, input: I, expected: E): void;
+export function test<I, E> (name: string, run: Macros<ContextualTestContext, I, E>, input?: I, expected?: E): void;
+export function test<I, E> (run: Macros<ContextualTestContext, I, E>, input?: I, expected?: E): void;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -120,13 +120,13 @@ export interface ContextualCallbackTestContext extends CallbackTestContext {
 	context: any;
 }
 
-export interface Macro<T, I, E> {
-	(t: T, input: I, expected: E): void;
-	title? (providedTitle: string, input: I, expected: E): string;
+export interface Macro<T> {
+	(t: T, ...args: any[]): void;
+	title? (providedTitle: string, ...args: any[]): string;
 }
-export type Macros<T, I, E> = Macro<T, I, E> | Macro<T, I, E>[];
+export type Macros<T> = Macro<T> | Macro<T>[];
 
 export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
-export function test<I, E> (name: string, run: Macros<ContextualTestContext, I, E>, input?: I, expected?: E): void;
-export function test<I, E> (run: Macros<ContextualTestContext, I, E>, input?: I, expected?: E): void;
+export function test(name: string, run: Macros<ContextualTestContext>, ...args: any[]): void;
+export function test(run: Macros<ContextualTestContext>, ...args: any[]): void;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -120,13 +120,13 @@ export interface ContextualCallbackTestContext extends CallbackTestContext {
 	context: any;
 }
 
-export interface Macro<I, E, T> {
+export interface Macro<T, I, E> {
 	(t: T, input: I, expected: E): void;
 	title? (providedTitle: string, input: I, expected: E): string;
 }
-export type Macros<I, E, T> = Macro<I, E, T> | Macro<I, E, T>[];
+export type Macros<T, I, E> = Macro<T, I, E> | Macro<T, I, E>[];
 
 export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
-export function test<I, E> (name: string, run: Macros<I, E, ContextualTestContext>, input: I, expected: E): void;
-export function test<I, E> (run: Macros<I, E, ContextualTestContext>, input: I, expected: E): void;
+export function test<I, E> (name: string, run: Macros<ContextualTestContext, I, E>, input: I, expected: E): void;
+export function test<I, E> (run: Macros<ContextualTestContext, I, E>, input: I, expected: E): void;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -121,8 +121,8 @@ export interface ContextualCallbackTestContext extends CallbackTestContext {
 }
 
 export interface Macro<T, I, E> {
-	(t: T, input?: I, expected?: E): void;
-	title? (providedTitle: string, input?: I, expected?: E): string;
+	(t: T, input: I, expected: E): void;
+	title? (providedTitle: string, input: I, expected: E): string;
 }
 export type Macros<T, I, E> = Macro<T, I, E> | Macro<T, I, E>[];
 

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -120,5 +120,12 @@ export interface ContextualCallbackTestContext extends CallbackTestContext {
 	context: any;
 }
 
+export interface Macro<I, E, T> {
+	(t: T, input: I, expected: E): void;
+	title? (providedTitle: string, input: I, expected: E): string;
+}
+
 export function test(name: string, run: ContextualTest): void;
 export function test(run: ContextualTest): void;
+export function test<I, E> (run: Macro<I, E, ContextualTestContext> | Macro<I, E, ContextualTestContext>[], input: I, expected: E): void;
+export function test<I, E> (name: string, run: Macro<I, E, ContextualTestContext> | Macro<I, E, ContextualTestContext>[], input: I, expected: E): void;

--- a/types/make.js
+++ b/types/make.js
@@ -51,6 +51,8 @@ function generatePrefixed(prefix) {
 				output += '\t' + writeFunction(part, 'name: string', 'void');
 			} else {
 				const type = testType(parts);
+				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macro<I, E, ' + type + 'Context>, input: I, expected: E');
+				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macro<I, E, ' + type + 'Context>, input: I, expected: E');
 				output += '\t' + writeFunction(part, 'name: string, implementation: ' + type);
 				output += '\t' + writeFunction(part, 'implementation: ' + type);
 			}

--- a/types/make.js
+++ b/types/make.js
@@ -51,10 +51,10 @@ function generatePrefixed(prefix) {
 				output += '\t' + writeFunction(part, 'name: string', 'void');
 			} else {
 				const type = testType(parts);
-				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macro<I, E, ' + type + 'Context>, input: I, expected: E');
-				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macro<I, E, ' + type + 'Context>, input: I, expected: E');
 				output += '\t' + writeFunction(part, 'name: string, implementation: ' + type);
 				output += '\t' + writeFunction(part, 'implementation: ' + type);
+				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macros<I, E, ' + type + 'Context>, input: I, expected: E');
+				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macros<I, E, ' + type + 'Context>, input: I, expected: E');
 			}
 		}
 

--- a/types/make.js
+++ b/types/make.js
@@ -53,8 +53,8 @@ function generatePrefixed(prefix) {
 				const type = testType(parts);
 				output += '\t' + writeFunction(part, 'name: string, implementation: ' + type);
 				output += '\t' + writeFunction(part, 'implementation: ' + type);
-				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macros<' + type + 'Context, I, E>, input: I, expected: E');
-				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macros<' + type + 'Context, I, E>, input: I, expected: E');
+				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macros<' + type + 'Context, I, E>, input?: I, expected?: E');
+				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macros<' + type + 'Context, I, E>, input?: I, expected?: E');
 			}
 		}
 

--- a/types/make.js
+++ b/types/make.js
@@ -53,8 +53,8 @@ function generatePrefixed(prefix) {
 				const type = testType(parts);
 				output += '\t' + writeFunction(part, 'name: string, implementation: ' + type);
 				output += '\t' + writeFunction(part, 'implementation: ' + type);
-				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macros<I, E, ' + type + 'Context>, input: I, expected: E');
-				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macros<I, E, ' + type + 'Context>, input: I, expected: E');
+				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macros<' + type + 'Context, I, E>, input: I, expected: E');
+				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macros<' + type + 'Context, I, E>, input: I, expected: E');
 			}
 		}
 

--- a/types/make.js
+++ b/types/make.js
@@ -53,8 +53,8 @@ function generatePrefixed(prefix) {
 				const type = testType(parts);
 				output += '\t' + writeFunction(part, 'name: string, implementation: ' + type);
 				output += '\t' + writeFunction(part, 'implementation: ' + type);
-				output += '\t' + writeFunction(part + '<I, E>', 'name: string, implementation: Macros<' + type + 'Context, I, E>, input?: I, expected?: E');
-				output += '\t' + writeFunction(part + '<I, E>', 'implementation: Macros<' + type + 'Context, I, E>, input?: I, expected?: E');
+				output += '\t' + writeFunction(part, 'name: string, implementation: Macros<' + type + 'Context>, ...args: any[]');
+				output += '\t' + writeFunction(part, 'implementation: Macros<' + type + 'Context>, ...args: any[]');
 			}
 		}
 


### PR DESCRIPTION
This brings support for [test macros](https://github.com/avajs/ava#test-macros) in the typescript.
It adds a macro interface, overloads the test function definition, and overloads all combinations of test modifiers.

Similar to #895 but built on top of #884