### PR TITLE
Add parameter types to notRegex in Typescript definition

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -92,7 +92,7 @@ export interface AssertContext {
 	/**
 	 * Assert that contents does not match regex.
 	 */
-	notRegex(contents, regex, message?: string): void;
+	notRegex(contents: string, regex: RegExp, message?: string): void;
 	/**
 	 * Assert that error is falsy.
 	 */


### PR DESCRIPTION
Allows using AVA with Typescript's `noImplicitAny` restriction enabled.

// @ivogabe @SamVerschueren