### PR TITLE
Invoke `resolveCwd` from package.json directory within `require`

### DIFF
--- a/api.js
+++ b/api.js
@@ -24,16 +24,21 @@ function Api(options) {
 	EventEmitter.call(this);
 
 	this.options = objectAssign({
-		cwd: process.cwd(),
 		resolveTestsFrom: process.cwd(),
 		match: []
 	}, options);
 
 	this.options.require = (this.options.require || []).map(function (moduleId) {
+		var originalCwd = process.cwd();
+		if (options.pkgDir) {
+			process.chdir(options.pkgDir);
+		}
+
 		var ret = resolveCwd(moduleId);
 		if (ret === null) {
 			throw new Error('Could not resolve required module \'' + moduleId + '\'');
 		}
+		process.chdir(originalCwd);
 
 		return ret;
 	});

--- a/cli.js
+++ b/cli.js
@@ -130,6 +130,7 @@ var api = new Api({
 	explicitTitles: cli.flags.watch,
 	match: arrify(cli.flags.match),
 	babelConfig: conf.babel,
+	pkgDir: pkgDir,
 	resolveTestsFrom: cli.input.length === 0 ? pkgDir : process.cwd(),
 	timeout: cli.flags.timeout,
 	concurrency: cli.flags.concurrency ? parseInt(cli.flags.concurrency, 10) : 0


### PR DESCRIPTION
Resolves #936

A variable `process.cwd()` was problematic for the invocation of `resolveCwd` on https://github.com/avajs/ava/compare/master...ltk:ltk/fix-936?expand=1#diff-2d5bbda346ebb54b9745d10f2fb5b1b6R37 when using the CLI from outside of the package.json directory.

This PR normalizes the cwd to the pkgDir for every invocation.
