### PR TITLE
Deprecate `t.error()` - fixes #995

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -147,7 +147,7 @@ x.notRegex = function (contents, regex, msg) {
 	test(!regex.test(contents), create(regex, contents, '!==', msg, x.notRegex));
 };
 
-x.ifError = x.error = function (err, msg) {
+x.ifError = function (err, msg) {
 	test(!err, create(err, 'Error', '!==', msg, x.ifError));
 };
 
@@ -159,6 +159,7 @@ x.ok = util.deprecate(x.truthy, getDeprecationNotice('ok()', 'truthy()'));
 x.notOk = util.deprecate(x.falsy, getDeprecationNotice('notOk()', 'falsy()'));
 x.same = util.deprecate(x.deepEqual, getDeprecationNotice('same()', 'deepEqual()'));
 x.notSame = util.deprecate(x.notDeepEqual, getDeprecationNotice('notSame()', 'notDeepEqual()'));
+x.error = util.deprecate(x.ifError, getDeprecationNotice('error()', 'ifError()'));
 
 function getDeprecationNotice(oldApi, newApi) {
 	return 'DEPRECATION NOTICE: ' + oldApi + ' has been renamed to ' + newApi + ' and will eventually be removed. See https://github.com/avajs/ava-codemods to help upgrade your codebase automatically.';


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

This fixes issue #995. This is my first AVA contribution, any feedback would be appreciated.

