### PR TITLE
Improve tests for deepEqual

### DIFF
--- a/test/assert.js
+++ b/test/assert.js
@@ -230,6 +230,14 @@ test('.deepEqual()', function (t) {
 		});
 	});
 
+	t.throws(function () {
+		assert.deepEqual({}, []);
+	});
+
+	t.throws(function () {
+		assert.deepEqual({0: 'a', 1: 'b'}, ['a', 'b']);
+	});
+
 	// Regression test end here
 
 	t.doesNotThrow(function () {


### PR DESCRIPTION
Additional tests for deepEqual:
* Empty array and empty object do not match
* Array and object do not match

Related #992 