### PR TITLE
Add Flow type definition

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -5,79 +5,79 @@
  */
 
 type PromiseLike<R> = {
-  then<U>(
-    onFulfill?: (value: R) => Promise<U> | U,
-    onReject?: (error: any) => Promise<U> | U
-  ): Promise<U>;
+	then<U>(
+		onFulfill?: (value: R) => Promise<U> | U,
+		onReject?: (error: any) => Promise<U> | U
+	): Promise<U>;
 }
 
 type ObservableLike = {
-  subscribe(observer: (value: {}) => void): void;
+	subscribe(observer: (value: {}) => void): void;
 };
 
 type SpecialReturnTypes =
-  | PromiseLike<any>
-  | Iterator<any>
-  | ObservableLike;
+	| PromiseLike<any>
+	| Iterator<any>
+	| ObservableLike;
 
 type Constructor = Class<{
-  constructor(...args: Array<any>): any
+	constructor(...args: Array<any>): any
 }>;
 
 type ErrorValidator =
-  | Constructor
-  | RegExp
-  | string
-  | ((error: any) => boolean);
+	| Constructor
+	| RegExp
+	| string
+	| ((error: any) => boolean);
 
 /**
  * Asertion Types
  */
 
 type AssertContext = {
-  // Passing assertion.
-  pass(message?: string): void;
-  // Failing assertion.
-  fail(message?: string): void;
-  // Assert that value is truthy.
-  truthy(value: mixed, message?: string): void;
-  // Assert that value is falsy.
-  falsy(value: mixed, message?: string): void;
-  // DEPRECATED, use `truthy`. Assert that value is truthy.
-  ok(value: mixed, message?: string): void;
-  // DEPRECATED, use `falsy`. Assert that value is falsy.
-  notOk(value: mixed, message?: string): void;
-  // Assert that value is true.
-  true(value: boolean, message?: string): void;
-  // Assert that value is false.
-  false(value: boolean, message?: string): void;
-  // Assert that value is equal to expected.
-  is<U>(value: U, expected: U, message?: string): void;
-  // Assert that value is not equal to expected.
-  not<U>(value: U, expected: U, message?: string): void;
-  // Assert that value is deep equal to expected.
-  deepEqual<U>(value: U, expected: U, message?: string): void;
-  // Assert that value is not deep equal to expected.
-  notDeepEqual<U>(value: U, expected: U, message?: string): void;
-  // Assert that function throws an error or promise rejects.
-  // DEPRECATED, use `deepEqual`. Assert that value is deep equal to expected.
-  // @param error Can be a constructor, regex, error message or validation function.
-  same<U>(value: U, expected: U, message?: string): void;
-  // DEPRECATED use `notDeepEqual`. Assert that value is not deep equal to expected.
-  notSame<U>(value: U, expected: U, message?: string): void;
-  // Assert that function throws an error or promise rejects.
-  // @param error Can be a constructor, regex, error message or validation function.
-  throws(value: PromiseLike<mixed>, error?: ErrorValidator, message?: string): Promise<mixed>;
-  throws(value: () => void, error?: ErrorValidator, message?: string): mixed;
-  // Assert that function doesn't throw an error or promise resolves.
-  notThrows<U>(value: PromiseLike<U>, message?: string): Promise<U>;
-  notThrows(value: () => void, message?: string): void;
-  // Assert that contents matches regex.
-  regex(contents: string, regex: RegExp, message?: string): void;
-  // Assert that contents does not match regex.
-  notRegex(contents: string, regex: RegExp, message?: string): void;
-  // Assert that error is falsy.
-  ifError(error: any, message?: string): void;
+	// Passing assertion.
+	pass(message?: string): void;
+	// Failing assertion.
+	fail(message?: string): void;
+	// Assert that value is truthy.
+	truthy(value: mixed, message?: string): void;
+	// Assert that value is falsy.
+	falsy(value: mixed, message?: string): void;
+	// DEPRECATED, use `truthy`. Assert that value is truthy.
+	ok(value: mixed, message?: string): void;
+	// DEPRECATED, use `falsy`. Assert that value is falsy.
+	notOk(value: mixed, message?: string): void;
+	// Assert that value is true.
+	true(value: boolean, message?: string): void;
+	// Assert that value is false.
+	false(value: boolean, message?: string): void;
+	// Assert that value is equal to expected.
+	is<U>(value: U, expected: U, message?: string): void;
+	// Assert that value is not equal to expected.
+	not<U>(value: U, expected: U, message?: string): void;
+	// Assert that value is deep equal to expected.
+	deepEqual<U>(value: U, expected: U, message?: string): void;
+	// Assert that value is not deep equal to expected.
+	notDeepEqual<U>(value: U, expected: U, message?: string): void;
+	// Assert that function throws an error or promise rejects.
+	// DEPRECATED, use `deepEqual`. Assert that value is deep equal to expected.
+	// @param error Can be a constructor, regex, error message or validation function.
+	same<U>(value: U, expected: U, message?: string): void;
+	// DEPRECATED use `notDeepEqual`. Assert that value is not deep equal to expected.
+	notSame<U>(value: U, expected: U, message?: string): void;
+	// Assert that function throws an error or promise rejects.
+	// @param error Can be a constructor, regex, error message or validation function.
+	throws(value: PromiseLike<mixed>, error?: ErrorValidator, message?: string): Promise<mixed>;
+	throws(value: () => void, error?: ErrorValidator, message?: string): mixed;
+	// Assert that function doesn't throw an error or promise resolves.
+	notThrows<U>(value: PromiseLike<U>, message?: string): Promise<U>;
+	notThrows(value: () => void, message?: string): void;
+	// Assert that contents matches regex.
+	regex(contents: string, regex: RegExp, message?: string): void;
+	// Assert that contents does not match regex.
+	notRegex(contents: string, regex: RegExp, message?: string): void;
+	// Assert that error is falsy.
+	ifError(error: any, message?: string): void;
 };
 
 /**
@@ -85,8 +85,8 @@ type AssertContext = {
  */
 
 type TestContext = AssertContext & {
-  plan(count: number): void;
-  skip: AssertContext;
+	plan(count: number): void;
+	skip: AssertContext;
 };
 type CallbackTestContext           = TestContext         & { end(): void; };
 type ContextualTestContext         = TestContext         & { context: any; };
@@ -106,23 +106,23 @@ type ContextualCallbackTest = (t: ContextualCallbackTestContext) => void;
  */
 
 type Macro<T> = {
-  (t: T, ...args: Array<any>): void;
-  title?: (providedTitle: string, ...args: Array<any>) => string;
+	(t: T, ...args: Array<any>): void;
+	title?: (providedTitle: string, ...args: Array<any>) => string;
 };
 
 type Macros<T> =
-  | Macro<T>
-  | Array<Macro<T>>;
+	| Macro<T>
+	| Array<Macro<T>>;
 
 /**
  * Method Types
  */
 
 type Method<TestType, TestContextType> =
-  & ((              implementation: TestType) => void)
-  & ((name: string, implementation: TestType) => void)
-  & ((              implementation: Macros<TestContextType>, ...args: Array<any>) => void)
-  & ((name: string, implementation: Macros<TestContextType>, ...args: Array<any>) => void);
+	& ((              implementation: TestType) => void)
+	& ((name: string, implementation: TestType) => void)
+	& ((              implementation: Macros<TestContextType>, ...args: Array<any>) => void)
+	& ((name: string, implementation: Macros<TestContextType>, ...args: Array<any>) => void);
 
 type TestMethod                   = Method<Test, TestContext>;
 type CallbackTestMethod           = Method<CallbackTest, CallbackTestContext>;
@@ -134,17 +134,17 @@ type ContextualCallbackTestMethod = Method<ContextualCallbackTest, ContextualCal
  */
 
 type Chain<T, TCallback> = T & {
-  serial     : Chain<T, TCallback>;
-  before     : Chain<T, TCallback>;
-  after      : Chain<T, TCallback>;
-  skip       : Chain<T, TCallback>;
-  todo       : Chain<T, TCallback>;
-  failing    : Chain<T, TCallback>;
-  only       : Chain<T, TCallback>;
-  beforeEach : Chain<T, TCallback>;
-  afterEach  : Chain<T, TCallback>;
-  cb         : Chain<TCallback, TCallback>;
-  always     : Chain<T, TCallback>;
+	serial     : Chain<T, TCallback>;
+	before     : Chain<T, TCallback>;
+	after      : Chain<T, TCallback>;
+	skip       : Chain<T, TCallback>;
+	todo       : Chain<T, TCallback>;
+	failing    : Chain<T, TCallback>;
+	only       : Chain<T, TCallback>;
+	beforeEach : Chain<T, TCallback>;
+	afterEach  : Chain<T, TCallback>;
+	cb         : Chain<TCallback, TCallback>;
+	always     : Chain<T, TCallback>;
 };
 
 type TestChain                   = Chain<TestMethod, CallbackTestMethod>;
@@ -156,20 +156,20 @@ type ContextualCallbackTestChain = Chain<ContextualCallbackTestMethod, Contextua
  */
 
 declare module.exports: {
-  (              run: ContextualTest): void;
-  (name: string, run: ContextualTest): void;
-  (              run: Macros<ContextualTestContext>, ...args: Array<any>): void;
-  (name: string, run: Macros<ContextualTestContext>, ...args: Array<any>): void;
+	(              run: ContextualTest): void;
+	(name: string, run: ContextualTest): void;
+	(              run: Macros<ContextualTestContext>, ...args: Array<any>): void;
+	(name: string, run: Macros<ContextualTestContext>, ...args: Array<any>): void;
 
-  beforeEach : TestChain;
-  afterEach  : TestChain;
-  serial     : ContextualTestChain;
-  before     : ContextualTestChain;
-  after      : ContextualTestChain;
-  skip       : ContextualTestChain;
-  todo       : ContextualTestChain;
-  failing    : ContextualTestChain;
-  only       : ContextualTestChain;
-  cb         : ContextualCallbackTestChain;
-  always     : ContextualTestChain;
+	beforeEach : TestChain;
+	afterEach  : TestChain;
+	serial     : ContextualTestChain;
+	before     : ContextualTestChain;
+	after      : ContextualTestChain;
+	skip       : ContextualTestChain;
+	todo       : ContextualTestChain;
+	failing    : ContextualTestChain;
+	only       : ContextualTestChain;
+	cb         : ContextualCallbackTestChain;
+	always     : ContextualTestChain;
 };

--- a/index.js.flow
+++ b/index.js.flow
@@ -4,37 +4,37 @@
  * Misc Setup Types
  */
 
-declare type PromiseLike<R> = {
+type PromiseLike<R> = {
   then<U>(
     onFulfill?: (value: R) => Promise<U> | U,
     onReject?: (error: any) => Promise<U> | U
   ): Promise<U>;
 }
 
-declare type ObservableLike = {
+type ObservableLike = {
   subscribe(observer: (value: {}) => void): void;
 };
 
-declare type SpecialReturnTypes =
+type SpecialReturnTypes =
   | PromiseLike<any>
   | Iterator<any>
   | ObservableLike;
 
-declare type Constructor = Class<{
+type Constructor = Class<{
   constructor(...args: Array<any>): any
 }>;
 
-declare type ErrorValidator =
+type ErrorValidator =
   | Constructor
   | RegExp
   | string
-  | (error: any) => boolean;
+  | ((error: any) => boolean);
 
 /**
  * Asertion Types
  */
 
-declare type AssertContext = {
+type AssertContext = {
   // Passing assertion.
   pass(message?: string): void;
   // Failing assertion.
@@ -84,33 +84,33 @@ declare type AssertContext = {
  * Context Types
  */
 
-declare type TestContext = AssertContext & {
+type TestContext = AssertContext & {
   plan(count: number): void;
   skip: AssertContext;
 };
-declare type CallbackTestContext           = TestContext         & { end(): void; };
-declare type ContextualTestContext         = TestContext         & { context: any; };
-declare type ContextualCallbackTestContext = CallbackTestContext & { context: any; };
+type CallbackTestContext           = TestContext         & { end(): void; };
+type ContextualTestContext         = TestContext         & { context: any; };
+type ContextualCallbackTestContext = CallbackTestContext & { context: any; };
 
 /**
  * Test Types
  */
 
-declare type Test                   = (t: TestContext)                   => SpecialReturnTypes | void;
-declare type CallbackTest           = (t: CallbackTestContext)           => void;
-declare type ContextualTest         = (t: ContextualTestContext)         => SpecialReturnTypes | void;
-declare type ContextualCallbackTest = (t: ContextualCallbackTestContext) => void;
+type Test                   = (t: TestContext)                   => SpecialReturnTypes | void;
+type CallbackTest           = (t: CallbackTestContext)           => void;
+type ContextualTest         = (t: ContextualTestContext)         => SpecialReturnTypes | void;
+type ContextualCallbackTest = (t: ContextualCallbackTestContext) => void;
 
 /**
  * Macro Types
  */
 
-declare type Macro<T> = {
+type Macro<T> = {
   (t: T, ...args: Array<any>): void;
   title?: (providedTitle: string, ...args: Array<any>) => string;
 };
 
-declare type Macros<T> =
+type Macros<T> =
   | Macro<T>
   | Array<Macro<T>>;
 
@@ -118,22 +118,22 @@ declare type Macros<T> =
  * Method Types
  */
 
-declare type Method<TestType, TestContextType> =
+type Method<TestType, TestContextType> =
   & ((              implementation: TestType) => void)
   & ((name: string, implementation: TestType) => void)
   & ((              implementation: Macros<TestContextType>, ...args: Array<any>) => void)
   & ((name: string, implementation: Macros<TestContextType>, ...args: Array<any>) => void);
 
-declare type TestMethod                   = Method<Test, TestContext>;
-declare type CallbackTestMethod           = Method<CallbackTest, CallbackTestContext>;
-declare type ContextualTestMethod         = Method<ContextualTest, ContextualTestContext>;
-declare type ContextualCallbackTestMethod = Method<ContextualCallbackTest, ContextualCallbackTestContext>;
+type TestMethod                   = Method<Test, TestContext>;
+type CallbackTestMethod           = Method<CallbackTest, CallbackTestContext>;
+type ContextualTestMethod         = Method<ContextualTest, ContextualTestContext>;
+type ContextualCallbackTestMethod = Method<ContextualCallbackTest, ContextualCallbackTestContext>;
 
 /**
  * Chain Types
  */
 
-declare type Chain<T, TCallback> = T & {
+type Chain<T, TCallback> = T & {
   serial     : Chain<T, TCallback>;
   before     : Chain<T, TCallback>;
   after      : Chain<T, TCallback>;
@@ -147,9 +147,9 @@ declare type Chain<T, TCallback> = T & {
   always     : Chain<T, TCallback>;
 };
 
-declare type TestChain                   = Chain<TestMethod, CallbackTestMethod>;
-declare type ContextualTestChain         = Chain<ContextualTestMethod, ContextualCallbackTestMethod>
-declare type ContextualCallbackTestChain = Chain<ContextualCallbackTestMethod, ContextualCallbackTestMethod>;
+type TestChain                   = Chain<TestMethod, CallbackTestMethod>;
+type ContextualTestChain         = Chain<ContextualTestMethod, ContextualCallbackTestMethod>
+type ContextualCallbackTestChain = Chain<ContextualCallbackTestMethod, ContextualCallbackTestMethod>;
 
 /**
  * Public API

--- a/index.js.flow
+++ b/index.js.flow
@@ -118,38 +118,81 @@ type Macros<T> =
  * Method Types
  */
 
-type Method<TestType, TestContextType> =
-	& ((              implementation: TestType) => void)
-	& ((name: string, implementation: TestType) => void)
-	& ((              implementation: Macros<TestContextType>, ...args: Array<any>) => void)
-	& ((name: string, implementation: Macros<TestContextType>, ...args: Array<any>) => void);
+type TestMethod = {
+	(              implementation: Test): void;
+	(name: string, implementation: Test): void;
+	(              implementation: Macros<TestContext>, ...args: Array<any>): void;
+	(name: string, implementation: Macros<TestContext>, ...args: Array<any>): void;
 
-type TestMethod                   = Method<Test, TestContext>;
-type CallbackTestMethod           = Method<CallbackTest, CallbackTestContext>;
-type ContextualTestMethod         = Method<ContextualTest, ContextualTestContext>;
-type ContextualCallbackTestMethod = Method<ContextualCallbackTest, ContextualCallbackTestContext>;
-
-/**
- * Chain Types
- */
-
-type Chain<T, TCallback> = T & {
-	serial     : Chain<T, TCallback>;
-	before     : Chain<T, TCallback>;
-	after      : Chain<T, TCallback>;
-	skip       : Chain<T, TCallback>;
-	todo       : Chain<T, TCallback>;
-	failing    : Chain<T, TCallback>;
-	only       : Chain<T, TCallback>;
-	beforeEach : Chain<T, TCallback>;
-	afterEach  : Chain<T, TCallback>;
-	cb         : Chain<TCallback, TCallback>;
-	always     : Chain<T, TCallback>;
+	serial     : TestMethod;
+	before     : TestMethod;
+	after      : TestMethod;
+	skip       : TestMethod;
+	todo       : TestMethod;
+	failing    : TestMethod;
+	only       : TestMethod;
+	beforeEach : TestMethod;
+	afterEach  : TestMethod;
+	cb         : CallbackTestMethod;
+	always     : TestMethod;
 };
 
-type TestChain                   = Chain<TestMethod, CallbackTestMethod>;
-type ContextualTestChain         = Chain<ContextualTestMethod, ContextualCallbackTestMethod>
-type ContextualCallbackTestChain = Chain<ContextualCallbackTestMethod, ContextualCallbackTestMethod>;
+type CallbackTestMethod = {
+	(              implementation: CallbackTest): void;
+	(name: string, implementation: CallbackTest): void;
+	(              implementation: Macros<CallbackTestContext>, ...args: Array<any>): void;
+	(name: string, implementation: Macros<CallbackTestContext>, ...args: Array<any>): void;
+
+	serial     : CallbackTestMethod;
+	before     : CallbackTestMethod;
+	after      : CallbackTestMethod;
+	skip       : CallbackTestMethod;
+	todo       : CallbackTestMethod;
+	failing    : CallbackTestMethod;
+	only       : CallbackTestMethod;
+	beforeEach : CallbackTestMethod;
+	afterEach  : CallbackTestMethod;
+	cb         : CallbackTestMethod;
+	always     : CallbackTestMethod;
+};
+
+type ContextualTestMethod = {
+	(              implementation: ContextualTest): void;
+	(name: string, implementation: ContextualTest): void;
+	(              implementation: Macros<ContextualTestContext>, ...args: Array<any>): void;
+	(name: string, implementation: Macros<ContextualTestContext>, ...args: Array<any>): void;
+
+	serial     : ContextualTestMethod;
+	before     : ContextualTestMethod;
+	after      : ContextualTestMethod;
+	skip       : ContextualTestMethod;
+	todo       : ContextualTestMethod;
+	failing    : ContextualTestMethod;
+	only       : ContextualTestMethod;
+	beforeEach : ContextualTestMethod;
+	afterEach  : ContextualTestMethod;
+	cb         : ContextualCallbackTestMethod;
+	always     : ContextualTestMethod;
+};
+
+type ContextualCallbackTestMethod = {
+	(              implementation: ContextualCallbackTest): void;
+	(name: string, implementation: ContextualCallbackTest): void;
+	(              implementation: Macros<ContextualCallbackTestContext>, ...args: Array<any>): void;
+	(name: string, implementation: Macros<ContextualCallbackTestContext>, ...args: Array<any>): void;
+
+	serial     : ContextualCallbackTestMethod;
+	before     : ContextualCallbackTestMethod;
+	after      : ContextualCallbackTestMethod;
+	skip       : ContextualCallbackTestMethod;
+	todo       : ContextualCallbackTestMethod;
+	failing    : ContextualCallbackTestMethod;
+	only       : ContextualCallbackTestMethod;
+	beforeEach : ContextualCallbackTestMethod;
+	afterEach  : ContextualCallbackTestMethod;
+	cb         : ContextualCallbackTestMethod;
+	always     : ContextualCallbackTestMethod;
+};
 
 /**
  * Public API
@@ -161,15 +204,15 @@ declare module.exports: {
 	(              run: Macros<ContextualTestContext>, ...args: Array<any>): void;
 	(name: string, run: Macros<ContextualTestContext>, ...args: Array<any>): void;
 
-	beforeEach : TestChain;
-	afterEach  : TestChain;
-	serial     : ContextualTestChain;
-	before     : ContextualTestChain;
-	after      : ContextualTestChain;
-	skip       : ContextualTestChain;
-	todo       : ContextualTestChain;
-	failing    : ContextualTestChain;
-	only       : ContextualTestChain;
-	cb         : ContextualCallbackTestChain;
-	always     : ContextualTestChain;
+	beforeEach : TestMethod;
+	afterEach  : TestMethod;
+	serial     : ContextualTestMethod;
+	before     : ContextualTestMethod;
+	after      : ContextualTestMethod;
+	skip       : ContextualTestMethod;
+	todo       : ContextualTestMethod;
+	failing    : ContextualTestMethod;
+	only       : ContextualTestMethod;
+	cb         : ContextualCallbackTestMethod;
+	always     : ContextualTestMethod;
 };

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,175 @@
+/* @flow */
+
+/**
+ * Misc Setup Types
+ */
+
+declare type PromiseLike<R> = {
+  then<U>(
+    onFulfill?: (value: R) => Promise<U> | U,
+    onReject?: (error: any) => Promise<U> | U
+  ): Promise<U>;
+}
+
+declare type ObservableLike = {
+  subscribe(observer: (value: {}) => void): void;
+};
+
+declare type SpecialReturnTypes =
+  | PromiseLike<any>
+  | Iterator<any>
+  | ObservableLike;
+
+declare type Constructor = Class<{
+  constructor(...args: Array<any>): any
+}>;
+
+declare type ErrorValidator =
+  | Constructor
+  | RegExp
+  | string
+  | (error: any) => boolean;
+
+/**
+ * Asertion Types
+ */
+
+declare type AssertContext = {
+  // Passing assertion.
+  pass(message?: string): void;
+  // Failing assertion.
+  fail(message?: string): void;
+  // Assert that value is truthy.
+  truthy(value: mixed, message?: string): void;
+  // Assert that value is falsy.
+  falsy(value: mixed, message?: string): void;
+  // DEPRECATED, use `truthy`. Assert that value is truthy.
+  ok(value: mixed, message?: string): void;
+  // DEPRECATED, use `falsy`. Assert that value is falsy.
+  notOk(value: mixed, message?: string): void;
+  // Assert that value is true.
+  true(value: boolean, message?: string): void;
+  // Assert that value is false.
+  false(value: boolean, message?: string): void;
+  // Assert that value is equal to expected.
+  is<U>(value: U, expected: U, message?: string): void;
+  // Assert that value is not equal to expected.
+  not<U>(value: U, expected: U, message?: string): void;
+  // Assert that value is deep equal to expected.
+  deepEqual<U>(value: U, expected: U, message?: string): void;
+  // Assert that value is not deep equal to expected.
+  notDeepEqual<U>(value: U, expected: U, message?: string): void;
+  // Assert that function throws an error or promise rejects.
+  // DEPRECATED, use `deepEqual`. Assert that value is deep equal to expected.
+  // @param error Can be a constructor, regex, error message or validation function.
+  same<U>(value: U, expected: U, message?: string): void;
+  // DEPRECATED use `notDeepEqual`. Assert that value is not deep equal to expected.
+  notSame<U>(value: U, expected: U, message?: string): void;
+  // Assert that function throws an error or promise rejects.
+  // @param error Can be a constructor, regex, error message or validation function.
+  throws(value: PromiseLike<mixed>, error?: ErrorValidator, message?: string): Promise<mixed>;
+  throws(value: () => void, error?: ErrorValidator, message?: string): mixed;
+  // Assert that function doesn't throw an error or promise resolves.
+  notThrows<U>(value: PromiseLike<U>, message?: string): Promise<U>;
+  notThrows(value: () => void, message?: string): void;
+  // Assert that contents matches regex.
+  regex(contents: string, regex: RegExp, message?: string): void;
+  // Assert that contents does not match regex.
+  notRegex(contents: string, regex: RegExp, message?: string): void;
+  // Assert that error is falsy.
+  ifError(error: any, message?: string): void;
+};
+
+/**
+ * Context Types
+ */
+
+declare type TestContext = AssertContext & {
+  plan(count: number): void;
+  skip: AssertContext;
+};
+declare type CallbackTestContext           = TestContext         & { end(): void; };
+declare type ContextualTestContext         = TestContext         & { context: any; };
+declare type ContextualCallbackTestContext = CallbackTestContext & { context: any; };
+
+/**
+ * Test Types
+ */
+
+declare type Test                   = (t: TestContext)                   => SpecialReturnTypes | void;
+declare type CallbackTest           = (t: CallbackTestContext)           => void;
+declare type ContextualTest         = (t: ContextualTestContext)         => SpecialReturnTypes | void;
+declare type ContextualCallbackTest = (t: ContextualCallbackTestContext) => void;
+
+/**
+ * Macro Types
+ */
+
+declare type Macro<T> = {
+  (t: T, ...args: Array<any>): void;
+  title?: (providedTitle: string, ...args: Array<any>) => string;
+};
+
+declare type Macros<T> =
+  | Macro<T>
+  | Array<Macro<T>>;
+
+/**
+ * Method Types
+ */
+
+declare type Method<TestType, TestContextType> =
+  & ((              implementation: TestType) => void)
+  & ((name: string, implementation: TestType) => void)
+  & ((              implementation: Macros<TestContextType>, ...args: Array<any>) => void)
+  & ((name: string, implementation: Macros<TestContextType>, ...args: Array<any>) => void);
+
+declare type TestMethod                   = Method<Test, TestContext>;
+declare type CallbackTestMethod           = Method<CallbackTest, CallbackTestContext>;
+declare type ContextualTestMethod         = Method<ContextualTest, ContextualTestContext>;
+declare type ContextualCallbackTestMethod = Method<ContextualCallbackTest, ContextualCallbackTestContext>;
+
+/**
+ * Chain Types
+ */
+
+declare type Chain<T, TCallback> = T & {
+  serial     : Chain<T, TCallback>;
+  before     : Chain<T, TCallback>;
+  after      : Chain<T, TCallback>;
+  skip       : Chain<T, TCallback>;
+  todo       : Chain<T, TCallback>;
+  failing    : Chain<T, TCallback>;
+  only       : Chain<T, TCallback>;
+  beforeEach : Chain<T, TCallback>;
+  afterEach  : Chain<T, TCallback>;
+  cb         : Chain<TCallback, TCallback>;
+  always     : Chain<T, TCallback>;
+};
+
+declare type TestChain                   = Chain<TestMethod, CallbackTestMethod>;
+declare type ContextualTestChain         = Chain<ContextualTestMethod, ContextualCallbackTestMethod>
+declare type ContextualCallbackTestChain = Chain<ContextualCallbackTestMethod, ContextualCallbackTestMethod>;
+
+/**
+ * Public API
+ */
+
+declare module.exports: {
+  (              run: ContextualTest): void;
+  (name: string, run: ContextualTest): void;
+  (              run: Macros<ContextualTestContext>, ...args: Array<any>): void;
+  (name: string, run: Macros<ContextualTestContext>, ...args: Array<any>): void;
+
+  beforeEach : TestChain;
+  afterEach  : TestChain;
+  serial     : ContextualTestChain;
+  before     : ContextualTestChain;
+  after      : ContextualTestChain;
+  skip       : ContextualTestChain;
+  todo       : ContextualTestChain;
+  failing    : ContextualTestChain;
+  only       : ContextualTestChain;
+  cb         : ContextualCallbackTestChain;
+  always     : ContextualTestChain;
+};

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "files": [
     "lib",
     "*.js",
+    "*.js.flow",
     "types/generated.d.ts"
   ],
   "keywords": [


### PR DESCRIPTION
Resolves #986

I wanted to test Flow against one of AVA's test files but it looks like the test suite isn't self-hosted and there doesn't appear to be any integration-like tests for the public api.

I would suggest doing something along those lines and testing both Flow and TypeScript against it, otherwise you'll end up with out of date type definitions like what has already happened with the TS definition and `.always`

