### PR TITLE
fix context in beforeEach and afterEach hooks - fixes #1004

### DIFF
--- a/types/make.js
+++ b/types/make.js
@@ -128,7 +128,7 @@ function testType(parts) {
 		type = 'Callback' + type;
 	}
 
-	if (!has('beforeEach') && !has('afterEach')) {
+	if (!has('before') && !has('after')) {
 		type = 'Contextual' + type;
 	}
 


### PR DESCRIPTION
This small fix fixes #1004. The statement was wrong as it provided a context to `before` and `after` but not to `beforeEach` and `afterEach`.

// @ivogabe 
