### PR TITLE
Upgrade tap and ensure asynchronous tests return promises 

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "signal-exit": "^3.0.0",
     "sinon": "^1.17.2",
     "source-map-fixtures": "^2.1.0",
-    "tap": "^6.3.0",
+    "tap": "^5.8.0",
     "touch": "^1.0.0",
     "xo": "*",
     "zen-observable": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "signal-exit": "^3.0.0",
     "sinon": "^1.17.2",
     "source-map-fixtures": "^2.1.0",
-    "tap": "^5.8.0",
+    "tap": "^6.3.0",
     "touch": "^1.0.0",
     "xo": "*",
     "zen-observable": "^0.3.0"

--- a/test/api.js
+++ b/test/api.js
@@ -33,7 +33,7 @@ test('Without Pool: test file with exclusive tests causes non-exclusive tests in
 
 	var api = new Api();
 
-	api.run(files)
+	return api.run(files)
 		.then(function (result) {
 			t.ok(result.hasExclusive);
 			t.is(result.testCount, 2);
@@ -69,7 +69,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/es2015.js')])
+		return api.run([path.join(__dirname, 'fixture/es2015.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -80,7 +80,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/generators.js')])
+		return api.run([path.join(__dirname, 'fixture/generators.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -91,7 +91,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/async-await.js')])
+		return api.run([path.join(__dirname, 'fixture/async-await.js')])
 			.then(function (result) {
 				t.is(result.passCount, 2);
 			});
@@ -215,7 +215,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run(files)
+		return api.run(files)
 			.then(function (result) {
 				t.is(result.passCount, 2);
 				t.is(result.failCount, 1);
@@ -235,7 +235,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run(files)
+		return api.run(files)
 			.then(function (result) {
 				t.is(result.passCount, 1);
 				t.is(result.failCount, 1);
@@ -261,7 +261,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/fail-fast.js')])
+		return api.run([path.join(__dirname, 'fixture/fail-fast.js')])
 			.then(function (result) {
 				t.ok(api.options.failFast);
 				t.strictDeepEqual(tests, [{
@@ -284,7 +284,7 @@ function generateTests(prefix, apiCreator) {
 			serial: true
 		});
 
-		api.run([path.join(__dirname, 'fixture/serial.js')])
+		return api.run([path.join(__dirname, 'fixture/serial.js')])
 			.then(function (result) {
 				t.ok(api.options.serial);
 				t.is(result.passCount, 3);
@@ -297,7 +297,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/circular-reference-on-assertion.js')])
+		return api.run([path.join(__dirname, 'fixture/circular-reference-on-assertion.js')])
 			.then(function (result) {
 				t.is(result.failCount, 1);
 				t.match(result.errors[0].error.message, /'c'.*?'d'/);
@@ -309,7 +309,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/process-cwd.js')])
+		return api.run([path.join(__dirname, 'fixture/process-cwd.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -327,7 +327,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/loud-rejection.js')])
+		return api.run([path.join(__dirname, 'fixture/loud-rejection.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -345,7 +345,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/uncaught-exception.js')])
+		return api.run([path.join(__dirname, 'fixture/uncaught-exception.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -356,7 +356,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/error-without-message.js')])
+		return api.run([path.join(__dirname, 'fixture/error-without-message.js')])
 			.then(function (result) {
 				t.is(result.failCount, 1);
 				t.is(result.errors.length, 1);
@@ -378,7 +378,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/source-map-file.js')])
+		return api.run([path.join(__dirname, 'fixture/source-map-file.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -399,7 +399,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/source-map-file-browser-env.js')])
+		return api.run([path.join(__dirname, 'fixture/source-map-file-browser-env.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -420,7 +420,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/source-map-file.js')])
+		return api.run([path.join(__dirname, 'fixture/source-map-file.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -441,7 +441,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/source-map-initial.js')])
+		return api.run([path.join(__dirname, 'fixture/source-map-initial.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -462,7 +462,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/source-map-initial.js')])
+		return api.run([path.join(__dirname, 'fixture/source-map-initial.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -473,7 +473,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.resolve('test/fixture/es2015.js')])
+		return api.run([path.resolve('test/fixture/es2015.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -484,7 +484,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/subdir')])
+		return api.run([path.join(__dirname, 'fixture/subdir')])
 			.then(function (result) {
 				t.is(result.passCount, 2);
 				t.is(result.failCount, 1);
@@ -496,7 +496,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/one-pass-one-fail.js')])
+		return api.run([path.join(__dirname, 'fixture/one-pass-one-fail.js')])
 			.then(function (result) {
 				t.match(result.errors[0].title, /this is a failing test/);
 				t.match(result.tests[0].title, /this is a passing test/);
@@ -634,7 +634,7 @@ function generateTests(prefix, apiCreator) {
 			require: [requirePath]
 		});
 
-		api.run([path.join(__dirname, 'fixture/validate-installed-global.js')])
+		return api.run([path.join(__dirname, 'fixture/validate-installed-global.js')])
 			.then(function (result) {
 				t.is(result.passCount, 1);
 			});
@@ -658,7 +658,7 @@ function generateTests(prefix, apiCreator) {
 			}
 		});
 
-		api.run([path.join(__dirname, 'fixture/power-assert.js')])
+		return api.run([path.join(__dirname, 'fixture/power-assert.js')])
 			.then(function (result) {
 				t.match(
 					result.errors[0].error.message,
@@ -687,7 +687,7 @@ function generateTests(prefix, apiCreator) {
 		rimraf.sync(path.join(__dirname, 'fixture/caching/node_modules'));
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/caching/test.js')])
+		return api.run([path.join(__dirname, 'fixture/caching/test.js')])
 			.then(function () {
 				var files = fs.readdirSync(path.join(__dirname, 'fixture/caching/node_modules/.cache/ava'));
 				t.is(files.length, 2);
@@ -710,7 +710,7 @@ function generateTests(prefix, apiCreator) {
 		rimraf.sync(path.join(__dirname, 'fixture/caching/node_modules'));
 		var api = apiCreator({cacheEnabled: false});
 
-		api.run([path.join(__dirname, 'fixture/caching/test.js')])
+		return api.run([path.join(__dirname, 'fixture/caching/test.js')])
 			.then(function () {
 				t.false(fs.existsSync(path.join(__dirname, 'fixture/caching/node_modules/.cache/ava')));
 				t.end();
@@ -722,7 +722,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.join(__dirname, 'fixture/skip-only.js')])
+		return api.run([path.join(__dirname, 'fixture/skip-only.js')])
 			.then(function (result) {
 				t.is(result.tests.length, 1);
 				t.true(result.tests[0].skip);
@@ -734,7 +734,7 @@ function generateTests(prefix, apiCreator) {
 
 		var api = apiCreator();
 
-		api.run([path.resolve('test/fixture/es2015.js')]).then(function (result) {
+		return api.run([path.resolve('test/fixture/es2015.js')]).then(function (result) {
 			t.is(result.passCount, 1);
 			return api.run([path.resolve('test/fixture/es2015.js')]);
 		}).then(function (result) {
@@ -840,7 +840,7 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		api.run([path.join(__dirname, 'fixture/babelrc/test.js')])
+		return api.run([path.join(__dirname, 'fixture/babelrc/test.js')])
 			.then(
 				function (result) {
 					t.is(result.passCount, 1);

--- a/test/assert.js
+++ b/test/assert.js
@@ -317,7 +317,7 @@ test('.throws() returns the thrown error', function (t) {
 test('.throws() returns the rejection reason of promise', function (t) {
 	var expected = new Error();
 
-	assert.throws(Promise.reject(expected)).then(function (actual) {
+	return assert.throws(Promise.reject(expected)).then(function (actual) {
 		t.is(actual, expected);
 		t.end();
 	});

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -331,7 +331,7 @@ test('all sync - end failure - bail', function (t) {
 });
 
 test('all async - no failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			passAsync('b'),
@@ -362,7 +362,7 @@ test('all async - no failure - no bail', function (t) {
 });
 
 test('all async - no failure - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			passAsync('b'),
@@ -393,7 +393,7 @@ test('all async - no failure - bail', function (t) {
 });
 
 test('last async - no failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			pass('a'),
 			pass('b'),
@@ -424,7 +424,7 @@ test('last async - no failure - no bail', function (t) {
 });
 
 test('mid async - no failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			pass('a'),
 			passAsync('b'),
@@ -455,7 +455,7 @@ test('mid async - no failure - no bail', function (t) {
 });
 
 test('first async - no failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			pass('b'),
@@ -486,7 +486,7 @@ test('first async - no failure - no bail', function (t) {
 });
 
 test('last async - no failure - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			pass('a'),
 			pass('b'),
@@ -517,7 +517,7 @@ test('last async - no failure - bail', function (t) {
 });
 
 test('mid async - no failure - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			pass('a'),
 			passAsync('b'),
@@ -548,7 +548,7 @@ test('mid async - no failure - bail', function (t) {
 });
 
 test('first async - no failure - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			pass('b'),
@@ -579,7 +579,7 @@ test('first async - no failure - bail', function (t) {
 });
 
 test('all async - begin failure - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			failAsync('a'),
 			passAsync('b'),
@@ -602,7 +602,7 @@ test('all async - begin failure - bail', function (t) {
 });
 
 test('all async - mid failure - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			failAsync('b'),
@@ -629,7 +629,7 @@ test('all async - mid failure - bail', function (t) {
 });
 
 test('all async - end failure - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			passAsync('b'),
@@ -660,7 +660,7 @@ test('all async - end failure - bail', function (t) {
 });
 
 test('all async - begin failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			failAsync('a'),
 			passAsync('b'),
@@ -691,7 +691,7 @@ test('all async - begin failure - no bail', function (t) {
 });
 
 test('all async - mid failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			failAsync('b'),
@@ -722,7 +722,7 @@ test('all async - mid failure - no bail', function (t) {
 });
 
 test('all async - end failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			passAsync('a'),
 			passAsync('b'),
@@ -753,7 +753,7 @@ test('all async - end failure - no bail', function (t) {
 });
 
 test('all async - multiple failure - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			failAsync('a'),
 			passAsync('b'),
@@ -784,7 +784,7 @@ test('all async - multiple failure - no bail', function (t) {
 });
 
 test('rejections are just passed through - no bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			pass('a'),
 			pass('b'),
@@ -798,7 +798,7 @@ test('rejections are just passed through - no bail', function (t) {
 });
 
 test('rejections are just passed through - bail', function (t) {
-	new Concurrent(
+	return new Concurrent(
 		[
 			pass('a'),
 			pass('b'),

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -357,7 +357,6 @@ test('all async - no failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -388,7 +387,6 @@ test('all async - no failure - bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -419,7 +417,6 @@ test('last async - no failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -450,7 +447,6 @@ test('mid async - no failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -481,7 +477,6 @@ test('first async - no failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -512,7 +507,6 @@ test('last async - no failure - bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -543,7 +537,6 @@ test('mid async - no failure - bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -574,7 +567,6 @@ test('first async - no failure - bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -597,7 +589,6 @@ test('all async - begin failure - bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -624,7 +615,6 @@ test('all async - mid failure - bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -655,7 +645,6 @@ test('all async - end failure - bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -686,7 +675,6 @@ test('all async - begin failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -717,7 +705,6 @@ test('all async - mid failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -748,7 +735,6 @@ test('all async - end failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -779,7 +765,6 @@ test('all async - multiple failure - no bail', function (t) {
 				}
 			]
 		});
-		t.end();
 	});
 });
 
@@ -793,7 +778,6 @@ test('rejections are just passed through - no bail', function (t) {
 		false
 	).run().catch(function (err) {
 		t.is(err, 'foo');
-		t.end();
 	});
 });
 
@@ -807,7 +791,6 @@ test('rejections are just passed through - bail', function (t) {
 		true
 	).run().catch(function (err) {
 		t.is(err, 'foo');
-		t.end();
 	});
 });
 

--- a/test/fork.js
+++ b/test/fork.js
@@ -38,7 +38,7 @@ test('resolves promise with tests info', function (t) {
 
 	var file = fixture('generators.js');
 
-	fork(file)
+	return fork(file)
 		.run({})
 		.then(function (info) {
 			t.is(info.stats.passCount, 1);
@@ -94,7 +94,7 @@ test('rejects promise if the process is killed', function (t) {
 });
 
 test('fake timers do not break duration', function (t) {
-	fork(fixture('fake-timers.js'))
+	return fork(fixture('fake-timers.js'))
 		.run({})
 		.then(function (info) {
 			var duration = info.tests[0].duration;
@@ -118,7 +118,7 @@ test('destructuring of `t` is allowed', function (t) {
 */
 
 test('babelrc is ignored', function (t) {
-	fork(fixture('babelrc/test.js'))
+	return fork(fixture('babelrc/test.js'))
 	.run({})
 	.then(function (info) {
 		t.is(info.stats.passCount, 1);

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -33,7 +33,7 @@ test('before', function (t) {
 		arr.push('b');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['a', 'b']);
 	});
 });
@@ -52,7 +52,7 @@ test('after', function (t) {
 		arr.push('a');
 	});
 
-	runner.run({}).then(function (stats) {
+	return runner.run({}).then(function (stats) {
 		t.is(stats.passCount, 1);
 		t.is(stats.failCount, 0);
 		t.strictDeepEqual(arr, ['a', 'b']);
@@ -73,7 +73,7 @@ test('after not run if test failed', function (t) {
 	runner.test(function () {
 		throw new Error('something went wrong');
 	});
-	runner.run({}).then(function (stats) {
+	return runner.run({}).then(function (stats) {
 		t.is(stats.passCount, 0);
 		t.is(stats.failCount, 1);
 		t.strictDeepEqual(arr, []);
@@ -94,7 +94,7 @@ test('after.always run even if test failed', function (t) {
 	runner.test(function () {
 		throw new Error('something went wrong');
 	});
-	runner.run({}).then(function (stats) {
+	return runner.run({}).then(function (stats) {
 		t.is(stats.passCount, 0);
 		t.is(stats.failCount, 1);
 		t.strictDeepEqual(arr, ['a']);
@@ -116,7 +116,7 @@ test('after.always run even if before failed', function (t) {
 		arr.push('a');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['a']);
 		t.end();
 	});
@@ -141,7 +141,7 @@ test('stop if before hooks failed', function (t) {
 		a.end();
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['a']);
 		t.end();
 	});
@@ -171,7 +171,7 @@ test('before each with concurrent tests', function (t) {
 		arr[1].push('d');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, [['a', 'b', 'c'], ['a', 'b', 'd']]);
 		t.end();
 	});
@@ -199,7 +199,7 @@ test('before each with serial tests', function (t) {
 		arr.push('d');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['a', 'b', 'c', 'a', 'b', 'd']);
 		t.end();
 	});
@@ -221,7 +221,7 @@ test('fail if beforeEach hook fails', function (t) {
 		a.pass();
 	});
 
-	runner.run({}).then(function (stats) {
+	return runner.run({}).then(function (stats) {
 		t.is(stats.failCount, 1);
 		t.strictDeepEqual(arr, ['a']);
 		t.end();
@@ -252,7 +252,7 @@ test('after each with concurrent tests', function (t) {
 		arr[1].push('d');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, [['c', 'a', 'b'], ['d', 'a', 'b']]);
 		t.end();
 	});
@@ -280,7 +280,7 @@ test('after each with serial tests', function (t) {
 		arr.push('d');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['c', 'a', 'b', 'd', 'a', 'b']);
 		t.end();
 	});
@@ -300,7 +300,7 @@ test('afterEach not run if concurrent tests failed', function (t) {
 		throw new Error('something went wrong');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, []);
 		t.end();
 	});
@@ -320,7 +320,7 @@ test('afterEach not run if serial tests failed', function (t) {
 		throw new Error('something went wrong');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, []);
 		t.end();
 	});
@@ -340,7 +340,7 @@ test('afterEach.always run even if concurrent tests failed', function (t) {
 		throw new Error('something went wrong');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['a']);
 		t.end();
 	});
@@ -360,7 +360,7 @@ test('afterEach.always run even if serial tests failed', function (t) {
 		throw new Error('something went wrong');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['a']);
 		t.end();
 	});
@@ -384,7 +384,7 @@ test('afterEach.always run even if beforeEach failed', function (t) {
 		arr.push('b');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['b']);
 		t.end();
 	});
@@ -416,7 +416,7 @@ test('ensure hooks run only around tests', function (t) {
 		arr.push('test');
 	});
 
-	runner.run({}).then(function () {
+	return runner.run({}).then(function () {
 		t.strictDeepEqual(arr, ['before', 'beforeEach', 'test', 'afterEach', 'after']);
 		t.end();
 	});
@@ -449,7 +449,7 @@ test('shared context', function (t) {
 		a.deepEqual(a.context.arr, ['a', 'b', 'c']);
 	});
 
-	runner.run({}).then(function (stats) {
+	return runner.run({}).then(function (stats) {
 		t.is(stats.failCount, 0);
 		t.end();
 	});
@@ -468,7 +468,7 @@ test('shared context of any type', function (t) {
 		a.is(a.context, 'foo');
 	});
 
-	runner.run({}).then(function (stats) {
+	return runner.run({}).then(function (stats) {
 		t.is(stats.failCount, 0);
 		t.end();
 	});
@@ -477,7 +477,7 @@ test('shared context of any type', function (t) {
 test('don\'t display hook title if it did not fail', function (t) {
 	t.plan(2);
 
-	fork(path.join(__dirname, 'fixture', 'hooks-passing.js'))
+	return fork(path.join(__dirname, 'fixture', 'hooks-passing.js'))
 		.run({})
 		.on('test', function (test) {
 			t.strictDeepEqual(test.error, null);
@@ -491,7 +491,7 @@ test('don\'t display hook title if it did not fail', function (t) {
 test('display hook title if it failed', function (t) {
 	t.plan(2);
 
-	fork(path.join(__dirname, 'fixture', 'hooks-failing.js'))
+	return fork(path.join(__dirname, 'fixture', 'hooks-failing.js'))
 		.run({})
 		.on('test', function (test) {
 			t.is(test.error.name, 'AssertionError');


### PR DESCRIPTION
Fixes #935.

Added `return` when a test finished with a promise and didn't use `t.end`.

There's probably stuff I missed, so let me know!