### PR TITLE
Implemented t.finally, which runs after test is finished

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -3,6 +3,7 @@ var inspect = require('util').inspect;
 var isGeneratorFn = require('is-generator-fn');
 var maxTimeout = require('max-timeout');
 var Promise = require('bluebird');
+var optionChain = require('option-chain');
 var fnName = require('fn-name');
 var co = require('co-with-promise');
 var observableToPromise = require('observable-to-promise');
@@ -46,6 +47,10 @@ function Test(title, fn, contextRef, report) {
 	// store the time point before test execution
 	// to calculate the total time spent in test
 	this._timeStart = null;
+
+	this._finalizing = false;
+	this._finalizers = [];
+	this._finalized = null;
 
 	// workaround for Babel giving anonymous functions a name
 	if (this.title === 'callee$0$0') {
@@ -255,10 +260,95 @@ Test.prototype._checkPlanCount = function () {
 	}
 };
 
+Test.prototype._finalize = function () {
+	var self = this;
+
+	var toError = function (err) {
+		return new assert.AssertionError({
+			actual: err,
+			message: 'Finalizer failed with an error: ' + inspect(err, {depth: null}),
+			operator: 'finally'
+		});
+	};
+
+	var toPromise = function (fn) {
+		return new Promise(function (resolve, reject) {
+			fn({
+				end: function (err) {
+					if (err) {
+						reject(err);
+					} else {
+						resolve(err);
+					}
+				}
+			});
+		});
+	};
+
+	var call = function (finalizer) {
+		var fn = finalizer.fn;
+		var isCallback = finalizer.metadata.callback;
+
+		if (isCallback) {
+			return {promise: toPromise(fn)};
+		}
+		try {
+			var ret = fn();
+
+			if (isPromise(ret)) {
+				return {promise: ret};
+			}
+			if (isObservable(ret)) {
+				return {promise: observableToPromise(ret)};
+			}
+			return {ok: ret};
+		} catch (err) {
+			return {error: err};
+		}
+	};
+
+	var chain = function (finalizer) {
+		self._finalized = self._finalized.then(function () {
+			var result = call(finalizer);
+			if ('error' in result) {
+				return Promise.reject(result.error);
+			}
+			return Promise.resolve(result.promise || result.ok);
+		});
+	};
+
+	this._finalizing = true;
+	while (this._finalizers.length !== 0) {
+		var finalizer = this._finalizers.pop();
+
+		if (this._finalized === null) {
+			var result = call(finalizer);
+
+			if ('error' in result) {
+				self._setAssertError(toError(result.error));
+				break;
+			} else if ('promise' in result) {
+				this._finalized = result.promise;
+				continue;
+			}
+		} else {
+			chain(finalizer);
+		}
+	}
+
+	if (this._finalized !== null) {
+		this.sync = false;
+		this._finalized = this._finalized.catch(function (err) {
+			self._setAssertError(toError(err));
+		});
+	}
+};
+
 Test.prototype.exit = function () {
 	var self = this;
 
 	this._checkPlanCount();
+	self._finalize();
 
 	if (this.sync || this.threwSync) {
 		self.duration = globals.now() - self._timeStart;
@@ -278,15 +368,21 @@ Test.prototype.exit = function () {
 			self._setAssertError(err);
 		})
 		.finally(function () {
-			// calculate total time spent in test
-			self.duration = globals.now() - self._timeStart;
+			var cleanup = function () {
+				// calculate total time spent in test
+				self.duration = globals.now() - self._timeStart;
+				// stop infinite timer
+				globals.clearTimeout(self._timeout);
 
-			// stop infinite timer
-			globals.clearTimeout(self._timeout);
+				self._checkPlanCount();
+				self.promise().resolve(self._result());
+			};
 
-			self._checkPlanCount();
-
-			self.promise().resolve(self._result());
+			if (self._finalized === null) {
+				cleanup();
+			} else {
+				self._finalized.then(cleanup);
+			}
 		});
 
 	return self.promise().promise;
@@ -296,9 +392,34 @@ Test.prototype._publicApi = function () {
 	return new PublicApi(this);
 };
 
+function publicApiFinally(metadata, params) {
+	assert.is(typeof params[0], 'function', 'you must provide a callback');
+	assert.is(this._test._finalizing, false, 'you can not call finally from finally');
+
+	this._test._finalizers.push({
+		fn: params[0],
+		metadata: metadata
+	});
+}
+
+var publicApiFinallyChainableMethods = {
+	defaults: {
+		callback: false
+	},
+	chainableMethods: {
+		cb: {
+			callback: true
+		}
+	}
+};
+
 function PublicApi(test) {
 	this._test = test;
 	this.skip = new SkipApi(test);
+	this.finally = optionChain(
+		publicApiFinallyChainableMethods,
+		publicApiFinally.bind(this)
+	);
 }
 
 function onAssertionEvent(event) {

--- a/test/api.js
+++ b/test/api.js
@@ -1024,6 +1024,17 @@ function generateTests(prefix, apiCreator) {
 			path.join(__dirname, 'fixture/syntax-error.js')
 		]);
 	});
+
+	test(prefix + 'finally', function (t) {
+		t.plan(1);
+
+		var api = apiCreator();
+
+		return api.run([path.join(__dirname, 'fixture/finally.js')])
+			.then(function (result) {
+				t.is(result.passCount, 2);
+			});
+	});
 }
 
 function generatePassDebugTests(execArgv, expectedInspectIndex) {

--- a/test/fixture/finally.js
+++ b/test/fixture/finally.js
@@ -1,0 +1,13 @@
+import test from '../../';
+
+let val = 0
+
+test.serial('finally setting', t => {
+	t.finally(() => {
+		val = 1;
+	});
+});
+
+test.serial('getting the value that was set', t => {
+	t.is(val, 1);
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -180,20 +180,22 @@ test('include skipped tests in results', function (t) {
 test('test types and titles', function (t) {
 	t.plan(10);
 
-	var fn = function (a) {
-		a.pass();
-	};
-
 	function named(a) {
 		a.pass();
 	}
 
 	var runner = new Runner();
 	runner.before(named);
-	runner.beforeEach(fn);
-	runner.after(fn);
+	runner.beforeEach(function (a) {
+		a.pass();
+	});
+	runner.after(function (a) {
+		a.pass();
+	});
 	runner.afterEach(named);
-	runner.test('test', fn);
+	runner.test('test', function (a) {
+		a.pass();
+	});
 
 	var tests = [
 		{


### PR DESCRIPTION
So I've implemented `t.finally`. It's somewhat similar to test.afterEach.always, but it's easier to use and more flexible. For example:

```js
test("mock, subscribe, create files, etc", async t => {
  sinon.spy(console, "log");
  t.finally(() => console.log.restore());

  // might throw for whatever reason
  const connection = await connectSomewhere();
  t.finally(async () => await connection.disconnect());

  const server = mockAxios();
  server.onGet("/definitions", 200, []);
  server.onGet("/our/data", 200, [ { hello: "world" } ]);
  t.finally(() => server.restore());
  
  const data = await connection.query();
  t.is(data.length, 1); // throwing is totally expected

  storage.__Rewire__("fs", fakeFs);
  t.finally(() => storage.__ResetDependency__("fs"));
  
  const file = await store.write(data);
  sinon.aseert.called(fakeFs.write);
});
```

Finalizers are called in reverse order. They can fail test, transition it into async state, etc. Callback can be synchronous, return Promise, or Observable. Also `t.finally.cb` passes object into callback with a single function `end`.

I didn't updated base.d.ts, is it valid?

Closer to real world example when working with mobx

```js
test('using mobx', async t => {
  sinon.spy(store.local.preferences, "save");
  sinon.spy(store.local.preferences, "load");
  t.finally(() => store.local.preferences.save.restore());
  t.finally(() => store.local.preferences.load.restore());
  
  const user = store.users.byId(3);
  const dispose = user.autorun();
  t.finally(dispose)

  t.true(store.local.preferences.load.calledWith(3));
  await store.local.preferences.load.returnValues[0];
  t.is(user.preferences.color, "#ccc");

  mobx.runInAction(() => {
    user.preferences.color = "#fff";
  });

  t.true(store.local.preferences.save.calledWith(
    3, { color: "#fff" }
  ));
  await store.local.preferences.save.returnValues[0];
});
```