### PR TITLE
Add test run duration

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -157,7 +157,7 @@ logger.start();
 
 api.on('test-run', function (runStatus) {
 	reporter.api = runStatus;
-	runStatus.testRunStart = process.hrtime();
+	runStatus.testRunStart = Date.now();
 	runStatus.on('test', logger.test);
 	runStatus.on('error', logger.unhandledError);
 
@@ -184,7 +184,7 @@ if (cli.flags.watch) {
 } else {
 	api.run(files)
 		.then(function (runStatus) {
-			runStatus.testRunElapsed = runStatus.testRunStart && process.hrtime(runStatus.testRunStart);
+			runStatus.testRunElapsed = runStatus.testRunStart && Date.now() - runStatus.testRunStart;
 			logger.finish(runStatus);
 			logger.exit(runStatus.failCount > 0 || runStatus.rejectionCount > 0 || runStatus.exceptionCount > 0 ? 1 : 0);
 		})

--- a/cli.js
+++ b/cli.js
@@ -157,6 +157,7 @@ logger.start();
 
 api.on('test-run', function (runStatus) {
 	reporter.api = runStatus;
+	runStatus.testRunStart = process.hrtime();
 	runStatus.on('test', logger.test);
 	runStatus.on('error', logger.unhandledError);
 
@@ -183,6 +184,7 @@ if (cli.flags.watch) {
 } else {
 	api.run(files)
 		.then(function (runStatus) {
+			runStatus.testRunElapsed = runStatus.testRunStart && process.hrtime(runStatus.testRunStart);
 			logger.finish(runStatus);
 			logger.exit(runStatus.failCount > 0 || runStatus.rejectionCount > 0 || runStatus.exceptionCount > 0 ? 1 : 0);
 		})

--- a/lib/duration.js
+++ b/lib/duration.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var second = 1000;
+var minute = 60 * second;
+var hour = 60 * minute;
+var day = 24 * hour;
+
+function round(value) {
+	return Number(Math.round(value * 1000) / 1000);
+}
+
+function duration(ms) {
+	if (ms >= day) {
+		return round(ms / day) + 'd';
+	}
+
+	if (ms >= hour) {
+		return round(ms / hour) + 'h';
+	}
+
+	if (ms >= minute) {
+		return round(ms / minute) + 'm';
+	}
+
+	if (ms >= second) {
+		return round(ms / second) + 's';
+	}
+
+	return round(ms) + 'ms';
+}
+
+function hrtimeToDuration(hrtime) {
+	return duration(((hrtime[0] * 1e6) + (hrtime[1] / 1e3)) / 1e3);
+}
+
+module.exports = exports = hrtimeToDuration;
+
+// exposed for testing purposes
+exports.duration = duration;

--- a/lib/duration.js
+++ b/lib/duration.js
@@ -29,11 +29,4 @@ function duration(ms) {
 	return round(ms) + 'ms';
 }
 
-function hrtimeToDuration(hrtime) {
-	return duration(((hrtime[0] * 1e6) + (hrtime[1] / 1e3)) / 1e3);
-}
-
-module.exports = exports = hrtimeToDuration;
-
-// exposed for testing purposes
-exports.duration = duration;
+module.exports = duration;

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -10,6 +10,7 @@ var cross = require('figures').cross;
 var repeating = require('repeating');
 var objectAssign = require('object-assign');
 var colors = require('../colors');
+var duration = require('../duration');
 
 chalk.enabled = true;
 Object.keys(colors).forEach(function (key) {
@@ -121,7 +122,7 @@ MiniReporter.prototype.unhandledError = function (err) {
 	}
 };
 
-MiniReporter.prototype.reportCounts = function (time) {
+MiniReporter.prototype.reportCounts = function (time, testRunElapsed) {
 	var lines = [
 		this.passCount > 0 ? '\n  ' + colors.pass(this.passCount, 'passed') : '',
 		this.knownFailureCount > 0 ? '\n  ' + colors.error(this.knownFailureCount, plur('known failure', this.knownFailureCount)) : '',
@@ -130,8 +131,14 @@ MiniReporter.prototype.reportCounts = function (time) {
 		this.todoCount > 0 ? '\n  ' + colors.todo(this.todoCount, 'todo') : ''
 	].filter(Boolean);
 
-	if (time && lines.length > 0) {
-		lines[0] += ' ' + time;
+	if (lines.length > 0) {
+		if (time) {
+			lines[0] += ' ' + time;
+		}
+
+		if (testRunElapsed) {
+			lines[0] += ' (' + duration(testRunElapsed) + ')';
+		}
 	}
 
 	return lines.join('');
@@ -145,7 +152,7 @@ MiniReporter.prototype.finish = function (runStatus) {
 		time = chalk.gray.dim('[' + new Date().toLocaleTimeString('en-US', {hour12: false}) + ']');
 	}
 
-	var status = this.reportCounts(time);
+	var status = this.reportCounts(time, runStatus.testRunElapsed);
 
 	if (this.rejectionCount > 0) {
 		status += '\n  ' + colors.error(this.rejectionCount, plur('rejection', this.rejectionCount));

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -61,6 +61,8 @@ function Watcher(logger, api, files, sources) {
 		this.busy = api.run(specificFiles || files, {
 			runOnlyExclusive: runOnlyExclusive
 		}).then(function (runStatus) {
+			runStatus.testRunElapsed = runStatus.testRunStart && process.hrtime(runStatus.testRunStart);
+
 			runStatus.previousFailCount = self.sumPreviousFailures(currentVector);
 			logger.finish(runStatus);
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -61,7 +61,7 @@ function Watcher(logger, api, files, sources) {
 		this.busy = api.run(specificFiles || files, {
 			runOnlyExclusive: runOnlyExclusive
 		}).then(function (runStatus) {
-			runStatus.testRunElapsed = runStatus.testRunStart && process.hrtime(runStatus.testRunStart);
+			runStatus.testRunElapsed = runStatus.testRunStart && Date.now() - runStatus.testRunStart;
 
 			runStatus.previousFailCount = self.sumPreviousFailures(currentVector);
 			logger.finish(runStatus);

--- a/test/duration.js
+++ b/test/duration.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var lolex = require('lolex');
+var test = require('tap').test;
+var hrtimeToDuration = require('../lib/duration');
+var duration = hrtimeToDuration.duration;
+
+test('displays milliseconds', function (t) {
+	t.is(duration(0), '0ms');
+	t.is(duration(1), '1ms');
+	t.is(duration(500), '500ms');
+	t.is(duration(999), '999ms');
+	t.end();
+});
+
+test('calculates seconds', function (t) {
+	var second = 1000;
+
+	t.is(duration(second), '1s');
+	t.is(duration(second + 49), '1.049s');
+	t.is(duration((second * 6) - 1), '5.999s');
+	t.is(duration((second * 60) - 1), '59.999s');
+	t.end();
+});
+
+test('calculates minutes', function (t) {
+	var minute = 1000 * 60;
+
+	t.is(duration(minute), '1m');
+	t.is(duration(minute * 5 / 3), '1.667m');
+	t.is(duration(minute * 59.5), '59.5m');
+	t.is(duration((minute * 60) - 1), '60m');
+	t.end();
+});
+
+test('calculates hours', function (t) {
+	var hour = 1000 * 60 * 60;
+
+	t.is(duration(hour), '1h');
+	t.is(duration(hour * 5 / 3), '1.667h');
+	t.is(duration(hour * 23.5), '23.5h');
+	t.is(duration((hour * 24) - 1), '24h');
+	t.end();
+});
+
+test('calculates days', function (t) {
+	var day = 1000 * 60 * 60 * 24;
+
+	t.is(duration(day), '1d');
+	t.is(duration(day * 5 / 3), '1.667d');
+	t.is(duration(day * 364.5), '364.5d');
+	t.is(duration(day * 500), '500d');
+	t.end();
+});
+
+test('converts hrtime difference to duration', function (t) {
+	var clock = lolex.install(0, ['hrtime']);
+	var start = process.hrtime();
+
+	clock.tick('07:07');
+	t.is(hrtimeToDuration(process.hrtime(start)), '7.117m');
+
+	clock.tick('24:25');
+	t.is(hrtimeToDuration(process.hrtime(start)), '31.533m');
+
+	clock.tick('06:01:01');
+	t.is(hrtimeToDuration(process.hrtime(start)), '6.543h');
+
+	t.end();
+});

--- a/test/duration.js
+++ b/test/duration.js
@@ -1,9 +1,7 @@
 'use strict';
 
-var lolex = require('lolex');
 var test = require('tap').test;
-var hrtimeToDuration = require('../lib/duration');
-var duration = hrtimeToDuration.duration;
+var duration = require('../lib/duration');
 
 test('displays milliseconds', function (t) {
 	t.is(duration(0), '0ms');
@@ -50,21 +48,5 @@ test('calculates days', function (t) {
 	t.is(duration(day * 5 / 3), '1.667d');
 	t.is(duration(day * 364.5), '364.5d');
 	t.is(duration(day * 500), '500d');
-	t.end();
-});
-
-test('converts hrtime difference to duration', function (t) {
-	var clock = lolex.install(0, ['hrtime']);
-	var start = process.hrtime();
-
-	clock.tick('07:07');
-	t.is(hrtimeToDuration(process.hrtime(start)), '7.117m');
-
-	clock.tick('24:25');
-	t.is(hrtimeToDuration(process.hrtime(start)), '31.533m');
-
-	clock.tick('06:01:01');
-	t.is(hrtimeToDuration(process.hrtime(start)), '6.543h');
-
 	t.end();
 });

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -543,3 +543,52 @@ test('stderr and stdout should call _update', function (t) {
 	reporter._update.restore();
 	t.end();
 });
+
+test('shows cumulative test run duration on first line of output', function (t) {
+	var clock = lolex.install(0, ['hrtime']);
+	var reporter = miniReporter();
+
+	reporter.failCount = 1;
+	reporter.skipCount = 1;
+
+	clock.tick('07');
+
+	var actualOutput = reporter.finish({
+		errors: [{}, {}],
+		testRunElapsed: clock.hrtime()
+	});
+	var expectedOutput = [
+		'\n  ' + colors.error('1 failed') + ' (7s)',
+		'  ' + colors.skip('1 skipped'),
+		'\n'
+	].join('\n');
+
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});
+
+test('shows cumulative test run duration during watch', function (t) {
+	var clock = lolex.install(new Date(2014, 11, 19, 17, 12, 5, 200).getTime(), ['hrtime']);
+	var time = ' ' + chalk.grey.dim('[17:19:12]');
+	var reporter = _miniReporter({watching: true});
+
+	t.is(reporter.start(), ' \n ' + graySpinner + ' ');
+	reporter.clearInterval();
+
+	clock.tick('07:07');
+
+	reporter.passCount = 1;
+	reporter.todoCount = 1;
+
+	var actualOutput = reporter.finish({
+		testRunElapsed: clock.hrtime()
+	});
+	var expectedOutput = [
+		'\n  ' + colors.pass('1 passed') + time + ' (7.117m)',
+		'  ' + colors.todo('1 todo'),
+		'\n'
+	].join('\n');
+
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -545,7 +545,7 @@ test('stderr and stdout should call _update', function (t) {
 });
 
 test('shows cumulative test run duration on first line of output', function (t) {
-	var clock = lolex.install(0, ['hrtime']);
+	var clock = lolex.install(0);
 	var reporter = miniReporter();
 
 	reporter.failCount = 1;
@@ -555,7 +555,7 @@ test('shows cumulative test run duration on first line of output', function (t) 
 
 	var actualOutput = reporter.finish({
 		errors: [{}, {}],
-		testRunElapsed: clock.hrtime()
+		testRunElapsed: Date.now()
 	});
 	var expectedOutput = [
 		'\n  ' + colors.error('1 failed') + ' (7s)',
@@ -568,7 +568,8 @@ test('shows cumulative test run duration on first line of output', function (t) 
 });
 
 test('shows cumulative test run duration during watch', function (t) {
-	var clock = lolex.install(new Date(2014, 11, 19, 17, 12, 5, 200).getTime(), ['hrtime']);
+	var startDate = new Date(2014, 11, 19, 17, 12, 5, 200);
+	var clock = lolex.install(startDate.getTime());
 	var time = ' ' + chalk.grey.dim('[17:19:12]');
 	var reporter = _miniReporter({watching: true});
 
@@ -581,7 +582,7 @@ test('shows cumulative test run duration during watch', function (t) {
 	reporter.todoCount = 1;
 
 	var actualOutput = reporter.finish({
-		testRunElapsed: clock.hrtime()
+		testRunElapsed: Date.now() - startDate
 	});
 	var expectedOutput = [
 		'\n  ' + colors.pass('1 passed') + time + ' (7.117m)',


### PR DESCRIPTION
## Changes

This does 2 new things:
- Send test run duration to reporters
- Show test duration in mini reporter (I added a utility to calculate this)

I added 2 properties to the `runStatus`:
- `testRunStart`
- `testRunElapsed`
## Duration Utility
- `hrtimeToDuration` - converts `process.hrtime()` to duration
- `httimeToDuration.duration` - converts milliseconds to duration
## Mini Reporter

In the mini reporter, I convert the `hrtime` back to a human-readable duration to show the end user. This could be added to any reporter, but I started with just this one.
## Notes

Currently I'm calculating the elapsed time in two places (`cli` and `watcher`). The best place to calculate this was in the logger (`Logger.prototype.finish`). However the lgoger seems to be logic-less and a complete pass-through so I didn't want to add functionality there.
