### PR TITLE
Remove --require CLI option (completes #1069)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -60,7 +60,6 @@ var cli = meow([
 	'  --init             Add AVA to your project',
 	'  --fail-fast        Stop after first test failure',
 	'  --serial, -s       Run tests serially',
-	'  --require, -r      Module to preload (Can be repeated)',
 	'  --tap, -t          Generate TAP output',
 	'  --verbose, -v      Enable verbose output',
 	'  --no-cache         Disable the transpiler cache',
@@ -84,7 +83,6 @@ var cli = meow([
 ], {
 	string: [
 		'_',
-		'require',
 		'timeout',
 		'source',
 		'match',
@@ -101,7 +99,6 @@ var cli = meow([
 	alias: {
 		t: 'tap',
 		v: 'verbose',
-		r: 'require',
 		s: 'serial',
 		m: 'match',
 		w: 'watch',
@@ -129,7 +126,6 @@ if (
 var api = new Api({
 	failFast: cli.flags.failFast,
 	serial: cli.flags.serial,
-	require: arrify(cli.flags.require),
 	cacheEnabled: cli.flags.cache !== false,
 	powerAssert: cli.flags.powerAssert !== false,
 	explicitTitles: cli.flags.watch,

--- a/cli.js
+++ b/cli.js
@@ -123,9 +123,15 @@ if (
 	process.exit(1);
 }
 
+if (hasFlag('--require') || hasFlag('-r')) {
+	console.error('  ' + colors.error(figures.cross) + ' The --require and -r flags are deprecated. Requirements should be configured in package.json - see documentation.');
+	process.exit(1);
+}
+
 var api = new Api({
 	failFast: cli.flags.failFast,
 	serial: cli.flags.serial,
+	require: arrify(conf.require),
 	cacheEnabled: cli.flags.cache !== false,
 	powerAssert: cli.flags.powerAssert !== false,
 	explicitTitles: cli.flags.watch,

--- a/docs/recipes/code-coverage.md
+++ b/docs/recipes/code-coverage.md
@@ -99,8 +99,6 @@ To use the Babel require hook, add `babel-core/register` to the `require` sectio
 }
 ```
 
-*Note*: You can also set the require hook from the command line: `ava --require=babel-core/register`. However, configuring it in `package.json` saves you from repeatedly typing that flag.
-
 ### Putting it all together
 
 Combining the above steps, your complete `package.json` should look something like this:

--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -77,7 +77,7 @@ If your tests write to disk they may trigger the watcher to rerun your tests. If
 
 AVA tracks which source files your test files depend on. If you change such a dependency only the test file that depends on it will be rerun. AVA will rerun all tests if it cannot determine which test file depends on the changed source file.
 
-Dependency tracking works for required modules. Custom extensions and transpilers are supported, provided you loaded them using the [`--require` CLI flag] and not from inside your test file. Files accessed using the `fs` module are not tracked.
+Dependency tracking works for required modules. Custom extensions and transpilers are supported, provided you [added them in your `package.json`](#configuration), and not from inside your test file. Files accessed using the `fs` module are not tracked.
 
 ## Watch mode and the `.only` modifier
 
@@ -109,7 +109,6 @@ Watch mode is relatively new and there might be some rough edges. Please [report
 [`chokidar`]: https://github.com/paulmillr/chokidar
 [Install Troubleshooting]: https://github.com/paulmillr/chokidar#install-troubleshooting
 [`ignore-by-default`]: https://github.com/novemberborn/ignore-by-default
-[`--require` CLI flag]: https://github.com/avajs/ava#cli
 [`--source` CLI flag]: https://github.com/avajs/ava#cli
 [`.only` modifier]: https://github.com/avajs/ava#running-specific-tests
 [`ava` section of your `package.json`]: https://github.com/avajs/ava#configuration

--- a/profile.js
+++ b/profile.js
@@ -9,7 +9,6 @@ var EventEmitter = require('events').EventEmitter;
 var meow = require('meow');
 var Promise = require('bluebird');
 var pkgConf = require('pkg-conf');
-var arrify = require('arrify');
 var findCacheDir = require('find-cache-dir');
 var uniqueTempDir = require('unique-temp-dir');
 var CachingPrecompiler = require('./lib/caching-precompiler');
@@ -35,12 +34,10 @@ var cli = meow([
 	'Options',
 	'  --fail-fast    Stop after first test failure',
 	'  --serial, -s   Run tests serially',
-	'  --require, -r  Module to preload (Can be repeated)',
 	''
 ], {
 	string: [
-		'_',
-		'require'
+		'_'
 	],
 	boolean: [
 		'fail-fast',
@@ -50,7 +47,6 @@ var cli = meow([
 	],
 	default: conf,
 	alias: {
-		r: 'require',
 		s: 'serial'
 	}
 });
@@ -71,7 +67,6 @@ var opts = {
 	file: file,
 	failFast: cli.flags.failFast,
 	serial: cli.flags.serial,
-	require: arrify(cli.flags.require),
 	tty: false,
 	cacheDir: cacheDir,
 	precompiled: precompiled

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,6 @@ $ ava --help
     --init             Add AVA to your project
     --fail-fast        Stop after first test failure
     --serial, -s       Run tests serially
-    --require, -r      Module to preload (Can be repeated)
     --tap, -t          Generate TAP output
     --verbose, -v      Enable verbose output
     --no-cache         Disable the transpiler cache
@@ -705,7 +704,7 @@ See AVA's [TypeScript recipe](docs/recipes/typescript.md) for a more detailed ex
 
 AVA currently only transpiles the tests you ask it to run. *It will not transpile modules you `import` from outside of the test.* This may be unexpected but there are workarounds.
 
-If you use Babel you can use its [require hook](https://babeljs.io/docs/usage/require/) to transpile imported modules on-the-fly. Run AVA with `--require babel-register` (see [CLI](#cli)) or [configure it in your `package.json`](#configuration).
+If you use Babel you can use its [require hook](https://babeljs.io/docs/usage/require/) to transpile imported modules on-the-fly. To add it, [configure it in your `package.json`](#configuration).
 
 You can also transpile your modules in a separate process and refer to the transpiled files rather than the sources from your tests.
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -167,7 +167,7 @@ test('pkg-conf: pkg-overrides', function (t) {
 });
 
 test('pkg-conf: cli takes precedence', function (t) {
-	execCli(['--match=foo*', '--no-serial', '--cache', '--no-fail-fast', '--require=./required.js', 'c.js'], {dirname: 'fixture/pkg-conf/precedence'}, function (err) {
+	execCli(['--match=foo*', '--no-serial', '--cache', '--no-fail-fast', 'c.js'], {dirname: 'fixture/pkg-conf/precedence'}, function (err) {
 		t.ifError(err);
 		t.end();
 	});

--- a/test/fixture/pkg-conf/pkg-overrides/actual.js
+++ b/test/fixture/pkg-conf/pkg-overrides/actual.js
@@ -7,7 +7,4 @@ test(t => {
 	t.is(opts.failFast, true);
 	t.is(opts.serial, true);
 	t.is(opts.cacheEnabled, false);
-	t.deepEqual(opts.require, [
-		path.join(__dirname, "required.js")
-	]);
 });

--- a/test/fixture/pkg-conf/precedence/c.js
+++ b/test/fixture/pkg-conf/precedence/c.js
@@ -8,7 +8,4 @@ test('foo', t => {
 	t.is(opts.serial, false);
 	t.is(opts.cacheEnabled, true);
 	t.deepEqual(opts.match, ['foo*']);
-	t.deepEqual(opts.require, [
-		path.join(__dirname, "required.js")
-	]);
 });


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

This completes #1069 as part of #1048 - removes `--require`/`-r` from the CLI interface, corrects documentation where relevant, modifies CLI tests accordingly.

Not sure if it makes sense to add a deprecation notice or any clarifications to docs - these changes remove mentions of the flag and defer to `package.json` configuration guidelines.

