### PR TITLE
Speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.npm
     - node_modules
 before_install:
-  - 'node -e "process.exit(Number(process.version.match(/^v(\d+)/)[1])>=6?0:1)" || npm install -g npm@latest'
+  - 'node -e "process.exit(Number(process.version.match(/^v(\d+)/)[1])>=6?0:1)" || npm install -g npm@3.x-latest'
 before_script:
   - npm prune
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ node_js:
   - '4'
   - '0.12'
   - '0.10'
+cache:
+  directories:
+    - $HOME/.npm
+    - node_modules
 before_install:
-  - 'node -e"process.exit(Number(process.version.match(/^v(\d+)/)[1])>=6?0:1)" || npm install -g npm@latest'
+  - 'node -e "process.exit(Number(process.version.match(/^v(\d+)/)[1])>=6?0:1)" || npm install -g npm@latest'
 after_success:
   - '[ -z "$COVERALLS_REPO_TOKEN" ] && tap --coverage-report=text-lcov | ./node_modules/.bin/coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - '6'
-  - '5'
   - '4'
   - '0.12'
   - '0.10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ cache:
     - node_modules
 before_install:
   - 'node -e "process.exit(Number(process.version.match(/^v(\d+)/)[1])>=6?0:1)" || npm install -g npm@latest'
+before_script:
+  - npm prune
 after_success:
   - '[ -z "$COVERALLS_REPO_TOKEN" ] && tap --coverage-report=text-lcov | ./node_modules/.bin/coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
   - '0.12'
   - '0.10'
 before_install:
-  - 'npm install -g npm@latest'
+  - 'node -e"process.exit(Number(process.version.match(/^v(\d+)/)[1])>=6?0:1)" || npm install -g npm@latest'
 after_success:
   - '[ -z "$COVERALLS_REPO_TOKEN" ] && tap --coverage-report=text-lcov | ./node_modules/.bin/coveralls'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
     - nodejs_version: '6'
-    - nodejs_version: '5'
     - nodejs_version: '4'
     - nodejs_version: '0.12'
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
   - set AVA_APPVEYOR=true
-  - npm install -g npm@latest
+  - npm install -g npm@3.x-latest
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
   - npm prune

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ matrix:
   fast_finish: true
 build: off
 shallow_clone: true
+cache:
+  - node_modules
+  - '%APPDATA%\npm-cache'
 test_script:
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ matrix:
 build: off
 version: '{build}'
 shallow_clone: true
-clone_depth: 1
 test_script:
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ install:
   - npm install -g npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
+  - npm prune
 matrix:
   fast_finish: true
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ install:
 matrix:
   fast_finish: true
 build: off
-version: '{build}'
 shallow_clone: true
 test_script:
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
   - set AVA_APPVEYOR=true
-  - npm install -g npm@latest || (timeout 30 && npm install -g npm@latest)
+  - npm install -g npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
-  - npm install || (timeout 30 && npm install)
+  - npm install
 matrix:
   fast_finish: true
 build: off
@@ -19,4 +19,4 @@ clone_depth: 1
 test_script:
   - node --version
   - npm --version
-  - npm run test-win || (timeout 30 && npm run test-win)
+  - npm run test-win


### PR DESCRIPTION
Inspired by <https://twitter.com/kentcdodds/status/786282951210262528> I looked into caching npm and `node_modules`, which led to some more improvements:

* Stop testing Node.js v5
* In Travis, only install latest npm if the Node.js version is older than v6 (though I suppose when v4 ships we may want to change that again, or actually force it to install v3)
* Cache npm cache and `node_modules` in both Travis and Appveyor
* Clean up Appveyor config a little

On Travis the first, non-cached run took 5m59s. The second run took 4m15s. I think it saves on nyc instrumentation too since that's cached in `node_modules`. On Appveyor the time went from 13m3s to 9m30s (note that Appveyor doesn't run builds in parallel for us).