### PR TITLE
Precompile helpers

### DIFF
--- a/api.js
+++ b/api.js
@@ -67,7 +67,7 @@ module.exports = Api;
 
 Api.prototype._runFile = function (file, runStatus, execArgv) {
 	var hash = this.precompiler.precompileFile(file);
-	var precompiled = {};
+	var precompiled = objectAssign({}, this._precompiledHelpers);
 	var resolvedfpath = fs.realpathSync(file);
 	precompiled[resolvedfpath] = hash;
 
@@ -139,7 +139,22 @@ Api.prototype._setupPrecompiler = function (files) {
 	});
 };
 
+Api.prototype._precompileHelpers = function () {
+	var self = this;
+
+	this._precompiledHelpers = {};
+
+	return new AvaFiles({cwd: this.options.resolveTestsFrom})
+		.findTestHelpers()
+		.map(function (file) { // eslint-disable-line array-callback-return
+			var hash = self.precompiler.precompileFile(file);
+			self._precompiledHelpers[file] = hash;
+		});
+};
+
 Api.prototype._run = function (files, options) {
+	var self = this;
+
 	options = options || {};
 
 	var runStatus = new RunStatus({
@@ -159,20 +174,23 @@ Api.prototype._run = function (files, options) {
 
 	this._setupPrecompiler(files);
 
-	if (this.options.timeout) {
-		this._setupTimeout(runStatus);
-	}
+	return this._precompileHelpers()
+		.then(function () {
+			if (self.options.timeout) {
+				self._setupTimeout(runStatus);
+			}
 
-	var overwatch;
-	if (this.options.concurrency > 0) {
-		var concurrency = this.options.serial ? 1 : this.options.concurrency;
-		overwatch = this._runWithPool(files, runStatus, concurrency);
-	} else {
-		// _runWithoutPool exists to preserve legacy behavior, specifically around `.only`
-		overwatch = this._runWithoutPool(files, runStatus);
-	}
+			var overwatch;
+			if (self.options.concurrency > 0) {
+				var concurrency = self.options.serial ? 1 : self.options.concurrency;
+				overwatch = self._runWithPool(files, runStatus, concurrency);
+			} else {
+				// _runWithoutPool exists to preserve legacy behavior, specifically around `.only`
+				overwatch = self._runWithoutPool(files, runStatus);
+			}
 
-	return overwatch;
+			return overwatch;
+		});
 };
 
 Api.prototype._computeForkExecArgs = function (files) {

--- a/readme.md
+++ b/readme.md
@@ -735,7 +735,7 @@ See AVA's [TypeScript recipe](docs/recipes/typescript.md) for a more detailed ex
 
 ### Transpiling imported modules
 
-AVA currently only transpiles the tests you ask it to run, as well as test helpers (files starting with `_` or in `helpers` directory). *It will not transpile modules you `import` from outside of the test.* This may be unexpected but there are workarounds.
+AVA currently only transpiles the tests you ask it to run, as well as test helpers (files starting with `_` or in `helpers` directory) inside the test directory. *It will not transpile modules you `import` from outside of the test.* This may be unexpected but there are workarounds.
 
 If you use Babel you can use its [require hook](https://babeljs.io/docs/usage/require/) to transpile imported modules on-the-fly. To add it, [configure it in your `package.json`](#configuration).
 

--- a/readme.md
+++ b/readme.md
@@ -735,7 +735,7 @@ See AVA's [TypeScript recipe](docs/recipes/typescript.md) for a more detailed ex
 
 ### Transpiling imported modules
 
-AVA currently only transpiles the tests you ask it to run. *It will not transpile modules you `import` from outside of the test.* This may be unexpected but there are workarounds.
+AVA currently only transpiles the tests you ask it to run, as well as test helpers (files starting with `_` or in `helpers` directory). *It will not transpile modules you `import` from outside of the test.* This may be unexpected but there are workarounds.
 
 If you use Babel you can use its [require hook](https://babeljs.io/docs/usage/require/) to transpile imported modules on-the-fly. To add it, [configure it in your `package.json`](#configuration).
 

--- a/test/api.js
+++ b/test/api.js
@@ -76,6 +76,17 @@ function generateTests(prefix, apiCreator) {
 			});
 	});
 
+	test(prefix + 'precompile helpers', function (t) {
+		t.plan(1);
+
+		var api = apiCreator();
+
+		return api.run([path.join(__dirname, 'fixture/precompile-helpers/test/test.js')])
+			.then(function (result) {
+				t.is(result.passCount, 1);
+			});
+	});
+
 	test(prefix + 'generators support', function (t) {
 		t.plan(1);
 
@@ -719,7 +730,10 @@ function generateTests(prefix, apiCreator) {
 	test(prefix + 'caching is enabled by default', function (t) {
 		t.plan(3);
 		rimraf.sync(path.join(__dirname, 'fixture/caching/node_modules'));
-		var api = apiCreator();
+
+		var api = apiCreator({
+			resolveTestsFrom: path.join(__dirname, 'fixture/caching')
+		});
 
 		return api.run([path.join(__dirname, 'fixture/caching/test.js')])
 			.then(function () {
@@ -742,7 +756,11 @@ function generateTests(prefix, apiCreator) {
 	test(prefix + 'caching can be disabled', function (t) {
 		t.plan(1);
 		rimraf.sync(path.join(__dirname, 'fixture/caching/node_modules'));
-		var api = apiCreator({cacheEnabled: false});
+
+		var api = apiCreator({
+			resolveTestsFrom: path.join(__dirname, 'fixture/caching'),
+			cacheEnabled: false
+		});
 
 		return api.run([path.join(__dirname, 'fixture/caching/test.js')])
 			.then(function () {

--- a/test/fixture/precompile-helpers/test/_b.js
+++ b/test/fixture/precompile-helpers/test/_b.js
@@ -1,0 +1,1 @@
+export default async function () {}

--- a/test/fixture/precompile-helpers/test/helpers/a.js
+++ b/test/fixture/precompile-helpers/test/helpers/a.js
@@ -1,0 +1,1 @@
+export default async function () {}

--- a/test/fixture/precompile-helpers/test/test.js
+++ b/test/fixture/precompile-helpers/test/test.js
@@ -1,0 +1,10 @@
+import test from '../../../../';
+import a from './helpers/a';
+import b from './_b';
+
+test(async t => {
+	await a();
+	await b();
+
+	t.pass();
+});


### PR DESCRIPTION
Fixes #720 and potentially #1049.

Lack of this feature has been bugging me for a long time, glad I've finally found a time to fix it. It's still WIP, need to:
- [x] Submit a PR to `ava-files` to support `findHelpers()` (currently named as `findTestDependencies()`).
- [x] Fix tests.
- [x] Write new tests.

As for #1049 (external macros are not precompiled), we could add a special glob for that, like `**/macros/**` to precompile those files as well.
