### PR TITLE
Add test for ava-throws-helper hoisting await and yield

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -123,6 +123,14 @@ test('improper use of t.throws from within an async callback will be reported to
 	});
 });
 
+test('improper use of t.throws (with an awaited argument) will be reported to the console', function (t) {
+	execCli('fixture/improper-t-throws-await-argument.js', function (err, stdout, stderr) {
+		t.ok(err);
+		t.match(stderr, /Improper usage of t\.throws detected at .*improper-t-throws-await-argument.js \(5:10\)/);
+		t.end();
+	});
+});
+
 test('babel require hook only applies to the test file', function (t) {
 	t.plan(3);
 

--- a/test/fixture/improper-t-throws-await-argument.js
+++ b/test/fixture/improper-t-throws-await-argument.js
@@ -1,0 +1,10 @@
+import test from '../../';
+
+test(async t => {
+	const promise = Promise.resolve;
+	t.throws(throwSync(await promise));
+});
+
+function throwSync() {
+	throw new Error('should be detected');
+}


### PR DESCRIPTION
Needs https://github.com/avajs/babel-plugin-ava-throws-helper/pull/6 so CI should fail until that is shipped. We should bump the minimum version in `package.json`.

Fixes #987.
