### PR TITLE
Add docs for test parameter need to be named `t`

### DIFF
--- a/docs/common-pitfalls.md
+++ b/docs/common-pitfalls.md
@@ -63,6 +63,16 @@ test(async t => {
 
 AVA [can't trace uncaught exceptions](https://github.com/avajs/ava/issues/214) back to the test that triggered them. Callback-taking functions may lead to uncaught exceptions that can then be hard to debug. Consider promisifying and using `async`/`await`, as in the above example. This should allow AVA to catch the exception and attribute it to the correct test.
 
+### Why is the power-assert information not shown?
+
+Ensure that the first parameter passed into your test is named `t`. This is a byproduct of the way power-assert works. It uses a pattern matching scheme that makes it easier for implementors to wrap any assertion library with power-assert goodness without having to understand the ES AST at all. See [#1031](https://github.com/avajs/ava/issues/1031) for more details.
+
+```js
+test(t => {
+	t.is(1, 1);
+}
+```
+
 ---
 
 Is your problem not listed here? Submit a pull request or comment on [this issue](https://github.com/avajs/ava/issues/404).

--- a/docs/common-pitfalls.md
+++ b/docs/common-pitfalls.md
@@ -63,14 +63,13 @@ test(async t => {
 
 AVA [can't trace uncaught exceptions](https://github.com/avajs/ava/issues/214) back to the test that triggered them. Callback-taking functions may lead to uncaught exceptions that can then be hard to debug. Consider promisifying and using `async`/`await`, as in the above example. This should allow AVA to catch the exception and attribute it to the correct test.
 
-### Why is the power-assert information not shown?
-
-Ensure that the first parameter passed into your test is named `t`. This is a byproduct of the way power-assert works. It uses a pattern matching scheme that makes it easier for implementors to wrap any assertion library with power-assert goodness without having to understand the ES AST at all. See [#1031](https://github.com/avajs/ava/issues/1031) for more details.
+### Why are the enhanced assertion messages not shown?
+Ensure that the first parameter passed into your test is named `t`. This is a requirement of how AVA uses [`power-assert`](https://github.com/power-assert-js/power-assert), the library that provides the enhanced messages. works.
 
 ```js
 test(t => {
 	t.is(1, 1);
-}
+});
 ```
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -251,7 +251,9 @@ AVA tries to run test files with their current working directory set to the dire
 
 ### Creating tests
 
-To create a test you call the `test` function you imported from AVA. Provide the optional title and implementation function. The function will be called when your test is run. It's passed an [execution object](#t) as its first argument. By convention this argument is named `t`.
+To create a test you call the `test` function you imported from AVA. Provide the optional title and implementation function. The function will be called when your test is run. It's passed an [execution object](#t) as its first argument.
+
+**Note:** In order for the [enhanced assertion messages](#enhanced-assertion-messages) to behave correctly the first argument **must** be named `t`.
 
 ```js
 import test from 'ava';


### PR DESCRIPTION
- Reworded the statement in the readme regarding the first parameter needing to be `t` to make it stronger and explain why its required.
- Add a note in common-pitfalls regarding the same issue
- Make the indentation style consistent in the code samples 

Closes #1031 
