### PR TITLE
Add `--no-color` flag - fixes #843

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,6 +8,7 @@ var Promise = require('bluebird');
 var pkgConf = require('pkg-conf');
 var isCi = require('is-ci');
 var hasFlag = require('has-flag');
+var chalk = require('chalk');
 var Api = require('../api');
 var colors = require('./colors');
 var verboseReporter = require('./reporters/verbose');
@@ -41,6 +42,7 @@ exports.run = function () {
 		'  --source, -S       Pattern to match source files so tests can be re-run (Can be repeated)',
 		'  --timeout, -T      Set global timeout',
 		'  --concurrency, -c  Maximum number of test files running at the same time (EXPERIMENTAL)',
+		'  --no-color         Disable color output',
 		'',
 		'Examples',
 		'  ava',
@@ -85,6 +87,16 @@ exports.run = function () {
 	if (cli.flags.init) {
 		require('ava-init')();
 		return;
+	}
+
+	if (
+		hasFlag('--no-color') ||
+		conf.noColor
+	) {
+		chalk.enabled = false;
+		Object.keys(colors).forEach(function (key) {
+			colors[key].enabled = false;
+		});
 	}
 
 	if (

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ $ ava --help
     --source, -S       Pattern to match source files so tests can be re-run (Can be repeated)
     --timeout, -T      Set global timeout
     --concurrency, -c  Maximum number of test files running at the same time (EXPERIMENTAL)
+    --no-color         Disable color output
 
   Examples
     ava
@@ -228,7 +229,8 @@ All of the CLI options can be configured in the `ava` section of your `package.j
     "require": [
       "babel-register"
     ],
-    "babel": "inherit"
+    "babel": "inherit",
+    "noColor": true
   }
 }
 ```


### PR DESCRIPTION
Disables color output with `--no-color` option for CLI and 
`"noColor": true` for package.json
Resolves #843
