### PR TITLE
Pass `--no-color` flag down to the forked process - fixes #843

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,6 +43,7 @@ exports.run = function () {
 		'  --source, -S       Pattern to match source files so tests can be re-run (Can be repeated)',
 		'  --timeout, -T      Set global timeout',
 		'  --concurrency, -c  Maximum number of test files running at the same time (EXPERIMENTAL)',
+		'  --no-color         Disable color output',
 		'',
 		'Examples',
 		'  ava',

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -11,11 +11,6 @@ var repeating = require('repeating');
 var objectAssign = require('object-assign');
 var colors = require('../colors');
 
-chalk.enabled = true;
-Object.keys(colors).forEach(function (key) {
-	colors[key].enabled = true;
-});
-
 function MiniReporter(options) {
 	if (!(this instanceof MiniReporter)) {
 		return new MiniReporter(options);

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -6,10 +6,6 @@ var plur = require('plur');
 var repeating = require('repeating');
 var colors = require('../colors');
 
-Object.keys(colors).forEach(function (key) {
-	colors[key].enabled = true;
-});
-
 function VerboseReporter() {
 	if (!(this instanceof VerboseReporter)) {
 		return new VerboseReporter();

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ $ ava --help
     --source, -S       Pattern to match source files so tests can be re-run (Can be repeated)
     --timeout, -T      Set global timeout
     --concurrency, -c  Maximum number of test files running at the same time (EXPERIMENTAL)
+    --no-color         Disable color output
 
   Examples
     ava

--- a/test/cli.js
+++ b/test/cli.js
@@ -6,7 +6,6 @@ var test = require('tap').test;
 global.Promise = require('bluebird');
 var getStream = require('get-stream');
 var figures = require('figures');
-var arrify = require('arrify');
 var chalk = require('chalk');
 var mkdirp = require('mkdirp');
 var touch = require('touch');
@@ -20,6 +19,10 @@ var cliPath = path.join(__dirname, '../cli.js');
 // for some reason chalk is disabled by default
 chalk.enabled = true;
 var colors = require('../lib/colors');
+
+Object.keys(colors).forEach(function (key) {
+	colors[key].enabled = true;
+});
 
 function execCli(args, opts, cb) {
 	var dirname;
@@ -43,7 +46,7 @@ function execCli(args, opts, cb) {
 	var stderr;
 
 	var processPromise = new Promise(function (resolve) {
-		child = childProcess.spawn(process.execPath, [path.relative(dirname, cliPath)].concat(arrify(args)), {
+		child = childProcess.spawn(process.execPath, [path.relative(dirname, cliPath)].concat(args, '--color'), {
 			cwd: dirname,
 			env: env,
 			stdio: [null, 'pipe', 'pipe']

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -12,6 +12,9 @@ var colors = require('../../lib/colors');
 var compareLineOutput = require('../helper/compare-line-output');
 
 chalk.enabled = true;
+Object.keys(colors).forEach(function (key) {
+	colors[key].enabled = true;
+});
 
 var graySpinner = chalk.gray.dim(process.platform === 'win32' ? '-' : '⠋');
 

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -11,6 +11,9 @@ var verboseReporter = require('../../lib/reporters/verbose');
 var compareLineOutput = require('../helper/compare-line-output');
 
 chalk.enabled = true;
+Object.keys(colors).forEach(function (key) {
+	colors[key].enabled = true;
+});
 
 // tap doesn't emulate a tty environment and thus process.stdout.columns is
 // undefined. Expect an 80 character wide line to be rendered.


### PR DESCRIPTION
Sorry that I accidentally deleted last one.

Also I want to notice that just `chalk.enabled = true` not working, because functions from `lib/colors.js` has own `enabled` property. So we need that loop
```
Object.keys(colors).forEach(function (key) {
	colors[key].enabled = true;
});
```