### PR TITLE
Print out warning in verbose & mini reporter when `--fail-fast` is enabled

### DIFF
--- a/api.js
+++ b/api.js
@@ -145,7 +145,8 @@ Api.prototype._run = function (files, options) {
 	var runStatus = new RunStatus({
 		runOnlyExclusive: options.runOnlyExclusive,
 		prefixTitles: this.options.explicitTitles || files.length > 1,
-		base: path.relative('.', commonPathPrefix(files)) + path.sep
+		base: path.relative('.', commonPathPrefix(files)) + path.sep,
+		failFast: this.options.failFast
 	});
 
 	this.emit('test-run', runStatus, files);

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -9,5 +9,6 @@ module.exports = {
 	pass: chalk.green,
 	duration: chalk.gray.dim,
 	errorStack: chalk.gray,
-	stack: chalk.red
+	stack: chalk.red,
+	failFast: chalk.magenta
 };

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -216,6 +216,10 @@ MiniReporter.prototype.finish = function (runStatus) {
 		});
 	}
 
+	if (runStatus.failFastEnabled === true) {
+		status += '\n\n  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped');
+	}
+
 	return status + '\n\n';
 };
 

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -114,6 +114,10 @@ VerboseReporter.prototype.finish = function (runStatus) {
 		});
 	}
 
+	if (runStatus.failFastEnabled === true) {
+		output += '\n\n\n  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped');
+	}
+
 	return output + '\n';
 };
 

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -50,6 +50,7 @@ class RunStatus extends EventEmitter {
 		this.errors = [];
 		this.stats = [];
 		this.tests = [];
+		this.failFastEnabled = opts.failFast || false;
 
 		autoBind(this);
 	}

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -414,6 +414,21 @@ test('results with unhandled errors', function (t) {
 	t.end();
 });
 
+test('results when fail-fast is enabled', function (t) {
+	var reporter = miniReporter();
+	var runStatus = {
+		failFastEnabled: true
+	};
+
+	var output = reporter.finish(runStatus);
+	compareLineOutput(t, output, [
+		'',
+		'',
+		'  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped')
+	]);
+	t.end();
+});
+
 test('results with 1 previous failure', function (t) {
 	var reporter = miniReporter();
 	reporter.todoCount = 1;

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -381,6 +381,29 @@ test('results with errors', function (t) {
 	t.end();
 });
 
+test('results when fail-fast is enabled', function (t) {
+	var reporter = verboseReporter();
+	var runStatus = createRunStatus();
+	runStatus.failCount = 1;
+	runStatus.failFastEnabled = true;
+	runStatus.tests = [{
+		title: 'failed test'
+	}];
+
+	var output = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'  ' + chalk.red('1 test failed') + time,
+		'',
+		'',
+		'  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped'),
+		''
+	].join('\n');
+
+	t.is(output, expectedOutput);
+	t.end();
+});
+
 test('results with 1 previous failure', function (t) {
 	var reporter = createReporter();
 


### PR DESCRIPTION
Hi there,

This PR fixes #1134. If --fail-fast is enabled it will print out the following message at the end of the report for both mini and verbose.

> `--fail-fast` is on. Any number of tests may have been skipped

**Mini:**
![screen shot 2016-12-21 at 14 42 39](https://cloud.githubusercontent.com/assets/3599597/21391383/d116765c-c78b-11e6-9c30-29541edcf720.png)

**Verbose:**
![screen shot 2016-12-21 at 14 44 03](https://cloud.githubusercontent.com/assets/3599597/21391417/f222abcc-c78b-11e6-81ec-e10b9ce56698.png)

This works for now, but i´m not sure if the way I have done it is the best. 

I have been thinking that maybe instead of going through all the results in run-status looking for a stat element that has failFastEnabled=true. 

It might be better to send a event or something if the Runner is created with the fail-fast option enabled. Then run-status could pickup on this and just set:
 this.failFastEnabled = true

Let me know what you guys think!

Also i appreciate the support in the issue section helping me out with this :)