### PR TITLE
Fix Flow type ambiguity

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -93,26 +93,23 @@ type ContextualTestContext         = TestContext         & { context: any; };
 type ContextualCallbackTestContext = CallbackTestContext & { context: any; };
 
 /**
- * Test Types
+ * Test Implementations
  */
 
-type Test                   = (t: TestContext)                   => SpecialReturnTypes | void;
-type CallbackTest           = (t: CallbackTestContext)           => void;
-type ContextualTest         = (t: ContextualTestContext)         => SpecialReturnTypes | void;
-type ContextualCallbackTest = (t: ContextualCallbackTestContext) => void;
-
-/**
- * Macro Types
- */
-
-type Macro<T> = {
-	(t: T, ...args: Array<any>): void;
+type TestFunction<T, R> = {
+	(t: T, ...args: Array<any>): R;
 	title?: (providedTitle: string, ...args: Array<any>) => string;
 };
 
-type Macros<T> =
-	| Macro<T>
-	| Array<Macro<T>>;
+type TestImplementation<T, R> =
+	| TestFunction<T, R>
+	| Array<TestFunction<T, R>>;
+
+type Test                   = TestImplementation<TestContext, SpecialReturnTypes | void>;
+type CallbackTest           = TestImplementation<CallbackTestContext, void>;
+type ContextualTest         = TestImplementation<ContextualTestContext, SpecialReturnTypes | void>;
+type ContextualCallbackTest = TestImplementation<ContextualCallbackTestContext, void>;
+
 
 /**
  * Method Types
@@ -121,8 +118,6 @@ type Macros<T> =
 type TestMethod = {
 	(              implementation: Test): void;
 	(name: string, implementation: Test): void;
-	(              implementation: Macros<TestContext>, ...args: Array<any>): void;
-	(name: string, implementation: Macros<TestContext>, ...args: Array<any>): void;
 
 	serial     : TestMethod;
 	before     : TestMethod;
@@ -140,8 +135,6 @@ type TestMethod = {
 type CallbackTestMethod = {
 	(              implementation: CallbackTest): void;
 	(name: string, implementation: CallbackTest): void;
-	(              implementation: Macros<CallbackTestContext>, ...args: Array<any>): void;
-	(name: string, implementation: Macros<CallbackTestContext>, ...args: Array<any>): void;
 
 	serial     : CallbackTestMethod;
 	before     : CallbackTestMethod;
@@ -159,8 +152,6 @@ type CallbackTestMethod = {
 type ContextualTestMethod = {
 	(              implementation: ContextualTest): void;
 	(name: string, implementation: ContextualTest): void;
-	(              implementation: Macros<ContextualTestContext>, ...args: Array<any>): void;
-	(name: string, implementation: Macros<ContextualTestContext>, ...args: Array<any>): void;
 
 	serial     : ContextualTestMethod;
 	before     : ContextualTestMethod;
@@ -178,8 +169,6 @@ type ContextualTestMethod = {
 type ContextualCallbackTestMethod = {
 	(              implementation: ContextualCallbackTest): void;
 	(name: string, implementation: ContextualCallbackTest): void;
-	(              implementation: Macros<ContextualCallbackTestContext>, ...args: Array<any>): void;
-	(name: string, implementation: Macros<ContextualCallbackTestContext>, ...args: Array<any>): void;
 
 	serial     : ContextualCallbackTestMethod;
 	before     : ContextualCallbackTestMethod;
@@ -201,8 +190,6 @@ type ContextualCallbackTestMethod = {
 declare module.exports: {
 	(              run: ContextualTest): void;
 	(name: string, run: ContextualTest): void;
-	(              run: Macros<ContextualTestContext>, ...args: Array<any>): void;
-	(name: string, run: Macros<ContextualTestContext>, ...args: Array<any>): void;
 
 	beforeEach : TestMethod;
 	afterEach  : TestMethod;


### PR DESCRIPTION
Fixes #1114

As reported in #1114, flow reports ambiguity when defining tests:

```js
test('my test', t => {})
```

Flow will report that it could apply either the `Test` type or the `Macro` type. The `Test` type is an obvious fit, but `Macro` also applies since the `...args` resolves to the empty array, and the optional `title?` attribute happens to be not provided.

My suggested fix is to merge the `Test` and `Macro` types together since `Macro` is really a superset of the `Test` type, and we don't lose any type safety by just expecting to always get Macros.

I tested this locally on a flow-typed repository and confirmed that the type ambiguity errors are solved.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
