### PR TITLE
Signature of assertions true/false for flow/TS

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -48,9 +48,9 @@ type AssertContext = {
 	// DEPRECATED, use `falsy`. Assert that value is falsy.
 	notOk(value: mixed, message?: string): void;
 	// Assert that value is true.
-	true(value: boolean, message?: string): void;
+	true(value: mixed, message?: string): void;
 	// Assert that value is false.
-	false(value: boolean, message?: string): void;
+	false(value: mixed, message?: string): void;
 	// Assert that value is equal to expected.
 	is<U>(value: U, expected: U, message?: string): void;
 	// Assert that value is not equal to expected.

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -43,11 +43,11 @@ export interface AssertContext {
 	/**
 	 * Assert that value is true.
 	 */
-	true(value: boolean, message?: string): void;
+	true(value: any, message?: string): void;
 	/**
 	 * Assert that value is false.
 	 */
-	false(value: boolean, message?: string): void;
+	false(value: any, message?: string): void;
 	/**
 	 * Assert that value is equal to expected.
 	 */


### PR DESCRIPTION
## Description

The signature for the two assertions `t.true()` and `t.false()` requires the first parameter to be a `boolean` ([Link to relevant lines](https://github.com/avajs/ava/blob/8816faf6bee675213c5bfe32f628a0a683708484/types/base.d.ts#L43-L50)). This makes it cumbersome to tests if a `function` returns `true` or another non-`boolean` value.

Using `t.truthy()` or `t.falsy()` instead doesn't entirely solve this, if the function must return a `boolean` and not just something ... truthy/falsy. The below example illustrates the issue.

> This patch changes the signature of the two assertions `t.true()` and `t.false()` to `any`/`mixed` in order to allow a more convenient way to test for the exact outcome.

### Test Source

```ts
  const isNumber = x => typeof x === 'number' ? true: Error('Not a number');

  t.true(isNumber(6)); // Not working
  t.true(<boolean>isNumber(6)); // Working, even though output might not be a boolean.
```

### Error Message & Stack Trace

```
  Argument of type 'true | Error' is not assignable to parameter of type 'boolean'.
  Type 'Error' is not assignable to type 'boolean'.
```