### PR TITLE
Supertest ^2.0.0 supports Promises by default

### DIFF
--- a/docs/recipes/endpoint-testing.md
+++ b/docs/recipes/endpoint-testing.md
@@ -2,7 +2,7 @@
 
 Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/docs/recipes/endpoint-testing.md), [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/recipes/endpoint-testing.md), [Italiano](https://github.com/avajs/ava-docs/blob/master/it_IT/docs/recipes/endpoint-testing.md), [日本語](https://github.com/avajs/ava-docs/blob/master/ja_JP/docs/recipes/endpoint-testing.md), [Português](https://github.com/avajs/ava-docs/blob/master/pt_BR/docs/recipes/endpoint-testing.md), [Русский](https://github.com/avajs/ava-docs/blob/master/ru_RU/docs/recipes/endpoint-testing.md), [简体中文](https://github.com/avajs/ava-docs/blob/master/zh_CN/docs/recipes/endpoint-testing.md)
 
-AVA doesn't have a builtin method for testing endpoints, but you can use any assertion library with it. Let's use [`supertest-as-promised`](https://github.com/WhoopInc/supertest-as-promised).
+AVA doesn't have a builtin method for testing endpoints, but you can use any assertion library with it. Let's use [`supertest`](https://github.com/visionmedia/supertest).
 
 Since tests run concurrently, it's best to create a fresh server instance for each test, because if we referenced the same instance, it could be mutated between tests. This can be accomplished with a `test.beforeEach` and `t.context`, or with simply a factory function:
 


### PR DESCRIPTION
Hi! :wave: The `endpoint-testing` recipe mentions using SuperTest-as-promised, but it's deprecated since SuperTest now supports Promises itself.

See https://github.com/visionmedia/supertest/blob/master/History.md#200--2016-07-29

Thanks for y'all's work on Ava, it's great :tada: 