### PR TITLE
Ensure assertion message is a string - Fixes #1125

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -35,7 +35,7 @@ function stringMsg(msg) {
 }
 
 x.pass = msg => {
-	test(true, create(true, true, 'pass', msg, x.pass));
+	test(true, create(true, true, 'pass', stringMsg(msg), x.pass));
 };
 
 x.fail = msg => {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -18,6 +18,7 @@ function create(val, expected, operator, msg, fn) {
 	if (msg !== undefined && typeof msg !== 'string') {
 		throw new TypeError('Assertion message must be a string');
 	}
+
 	return {
 		actual: val,
 		expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -15,13 +15,16 @@ const noop = () => {};
 Object.defineProperty(x, 'AssertionError', {value: assert.AssertionError});
 
 function create(val, expected, operator, msg, fn) {
-	return {
-		actual: val,
-		expected,
-		message: msg,
-		operator,
-		stackStartFunction: fn
-	};
+	if (msg === undefined || typeof msg === 'string'){
+		return {
+			actual: val,
+			expected,
+			message: msg,
+			operator,
+			stackStartFunction: fn
+		};
+	}
+	throw new TypeError('assertion message must be a string');
 }
 
 function test(ok, opts) {
@@ -30,49 +33,45 @@ function test(ok, opts) {
 	}
 }
 
-function stringMsg(msg) {
-	return msg instanceof Error ? msg.message : typeof msg === "string" ? msg : msg ? JSON.stringify(msg) : null;
-}
-
 x.pass = msg => {
-	test(true, create(true, true, 'pass', stringMsg(msg), x.pass));
+	test(true, create(true, true, 'pass', msg, x.pass));
 };
 
 x.fail = msg => {
-	msg = stringMsg(msg) || 'Test failed via t.fail()';
+	msg = msg || 'Test failed via t.fail()';
 	test(false, create(false, false, 'fail', msg, x.fail));
 };
 
 x.truthy = (val, msg) => {
-	test(val, create(val, true, '==', stringMsg(msg), x.truthy));
+	test(val, create(val, true, '==', msg, x.truthy));
 };
 
 x.falsy = (val, msg) => {
-	test(!val, create(val, false, '==', stringMsg(msg), x.falsy));
+	test(!val, create(val, false, '==', msg, x.falsy));
 };
 
 x.true = (val, msg) => {
-	test(val === true, create(val, true, '===', stringMsg(msg), x.true));
+	test(val === true, create(val, true, '===', msg, x.true));
 };
 
 x.false = (val, msg) => {
-	test(val === false, create(val, false, '===', stringMsg(msg), x.false));
+	test(val === false, create(val, false, '===', msg, x.false));
 };
 
 x.is = (val, expected, msg) => {
-	test(val === expected, create(val, expected, '===', stringMsg(msg), x.is));
+	test(val === expected, create(val, expected, '===', msg, x.is));
 };
 
 x.not = (val, expected, msg) => {
-	test(val !== expected, create(val, expected, '!==', stringMsg(msg), x.not));
+	test(val !== expected, create(val, expected, '!==', msg, x.not));
 };
 
 x.deepEqual = (val, expected, msg) => {
-	test(deepEqual(val, expected), create(val, expected, '===', stringMsg(msg), x.deepEqual));
+	test(deepEqual(val, expected), create(val, expected, '===', msg, x.deepEqual));
 };
 
 x.notDeepEqual = (val, expected, msg) => {
-	test(!deepEqual(val, expected), create(val, expected, '!==', stringMsg(msg), x.notDeepEqual));
+	test(!deepEqual(val, expected), create(val, expected, '!==', msg, x.notDeepEqual));
 };
 
 x.throws = (fn, err, msg) => {
@@ -144,15 +143,15 @@ x.notThrows = (fn, msg) => {
 };
 
 x.regex = (contents, regex, msg) => {
-	test(regex.test(contents), create(regex, contents, '===', stringMsg(msg), x.regex));
+	test(regex.test(contents), create(regex, contents, '===', msg, x.regex));
 };
 
 x.notRegex = (contents, regex, msg) => {
-	test(!regex.test(contents), create(regex, contents, '!==', stringMsg(msg), x.notRegex));
+	test(!regex.test(contents), create(regex, contents, '!==', msg, x.notRegex));
 };
 
 x.ifError = (err, msg) => {
-	test(!err, create(err, 'Error', '!==', stringMsg(msg), x.ifError));
+	test(!err, create(err, 'Error', '!==', msg, x.ifError));
 };
 
 x._snapshot = function (tree, optionalMessage, match, snapshotStateGetter) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -15,7 +15,7 @@ const noop = () => {};
 Object.defineProperty(x, 'AssertionError', {value: assert.AssertionError});
 
 function create(val, expected, operator, msg, fn) {
-	if (msg === undefined || typeof msg === 'string'){
+	if (msg === undefined || typeof msg === 'string') {
 		return {
 			actual: val,
 			expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -31,7 +31,7 @@ function test(ok, opts) {
 }
 
 function stringMsg(msg) {
-	return msg instanceof Error ? msg.message : typeof msg === "string" ? msg : !msg ? null : JSON.stringify(msg);
+	return msg instanceof Error ? msg.message : typeof msg === "string" ? msg : msg ? JSON.stringify(msg) : null;
 }
 
 x.pass = msg => {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -30,45 +30,49 @@ function test(ok, opts) {
 	}
 }
 
+function stringMsg(msg) {
+	return msg instanceof Error ? msg.message : typeof msg === "string" ? msg : !msg ? null : JSON.stringify(msg);
+}
+
 x.pass = msg => {
 	test(true, create(true, true, 'pass', msg, x.pass));
 };
 
 x.fail = msg => {
-	msg = msg || 'Test failed via t.fail()';
+	msg = stringMsg(msg) || 'Test failed via t.fail()';
 	test(false, create(false, false, 'fail', msg, x.fail));
 };
 
 x.truthy = (val, msg) => {
-	test(val, create(val, true, '==', msg, x.truthy));
+	test(val, create(val, true, '==', stringMsg(msg), x.truthy));
 };
 
 x.falsy = (val, msg) => {
-	test(!val, create(val, false, '==', msg, x.falsy));
+	test(!val, create(val, false, '==', stringMsg(msg), x.falsy));
 };
 
 x.true = (val, msg) => {
-	test(val === true, create(val, true, '===', msg, x.true));
+	test(val === true, create(val, true, '===', stringMsg(msg), x.true));
 };
 
 x.false = (val, msg) => {
-	test(val === false, create(val, false, '===', msg, x.false));
+	test(val === false, create(val, false, '===', stringMsg(msg), x.false));
 };
 
 x.is = (val, expected, msg) => {
-	test(val === expected, create(val, expected, '===', msg, x.is));
+	test(val === expected, create(val, expected, '===', stringMsg(msg), x.is));
 };
 
 x.not = (val, expected, msg) => {
-	test(val !== expected, create(val, expected, '!==', msg, x.not));
+	test(val !== expected, create(val, expected, '!==', stringMsg(msg), x.not));
 };
 
 x.deepEqual = (val, expected, msg) => {
-	test(deepEqual(val, expected), create(val, expected, '===', msg, x.deepEqual));
+	test(deepEqual(val, expected), create(val, expected, '===', stringMsg(msg), x.deepEqual));
 };
 
 x.notDeepEqual = (val, expected, msg) => {
-	test(!deepEqual(val, expected), create(val, expected, '!==', msg, x.notDeepEqual));
+	test(!deepEqual(val, expected), create(val, expected, '!==', stringMsg(msg), x.notDeepEqual));
 };
 
 x.throws = (fn, err, msg) => {
@@ -140,15 +144,15 @@ x.notThrows = (fn, msg) => {
 };
 
 x.regex = (contents, regex, msg) => {
-	test(regex.test(contents), create(regex, contents, '===', msg, x.regex));
+	test(regex.test(contents), create(regex, contents, '===', stringMsg(msg), x.regex));
 };
 
 x.notRegex = (contents, regex, msg) => {
-	test(!regex.test(contents), create(regex, contents, '!==', msg, x.notRegex));
+	test(!regex.test(contents), create(regex, contents, '!==', stringMsg(msg), x.notRegex));
 };
 
 x.ifError = (err, msg) => {
-	test(!err, create(err, 'Error', '!==', msg, x.ifError));
+	test(!err, create(err, 'Error', '!==', stringMsg(msg), x.ifError));
 };
 
 x._snapshot = function (tree, optionalMessage, match, snapshotStateGetter) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -15,16 +15,16 @@ const noop = () => {};
 Object.defineProperty(x, 'AssertionError', {value: assert.AssertionError});
 
 function create(val, expected, operator, msg, fn) {
-	if (msg === undefined || typeof msg === 'string') {
-		return {
-			actual: val,
-			expected,
-			message: msg,
-			operator,
-			stackStartFunction: fn
-		};
+	if (msg !== undefined && typeof msg !== 'string') {
+		throw new TypeError('Assertion message must be a string');
 	}
-	throw new TypeError('assertion message must be a string');
+	return {
+		actual: val,
+		expected,
+		message: msg,
+		operator,
+		stackStartFunction: fn
+	};
 }
 
 function test(ok, opts) {


### PR DESCRIPTION
This PR is intended to [fix #1125 ](https://github.com/avajs/ava/issues/1125). 

1.  The approach taken is to ensure/force assertion message to string.
2. This is handled in a single helper function `stringMsg` and
3. `stringMsg` is invoked only in assertion methods it is needed (in my opinion)

**Note: If msg is an object and non Error instance, the msg object is stringified using JSON.stringify.**


All comments/reviews are welcome.

Cheers!!  

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
