### PR TITLE
Print out warning in verbose & mini reporter when .only() tests are used

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -10,5 +10,5 @@ module.exports = {
 	duration: chalk.gray.dim,
 	errorStack: chalk.gray,
 	stack: chalk.red,
-	failFast: chalk.magenta
+	information: chalk.magenta
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -55,7 +55,7 @@ function exit() {
 
 globals.setImmediate(() => {
 	const hasExclusive = runner.tests.hasExclusive;
-	const numberOfTests = runner.tests.tests.concurrent.length + runner.tests.tests.serial.length;
+	const numberOfTests = runner.tests.testCount;
 
 	if (numberOfTests === 0) {
 		send('no-tests', {avaRequired: true});

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -216,7 +216,11 @@ MiniReporter.prototype.finish = function (runStatus) {
 	}
 
 	if (runStatus.failFastEnabled === true) {
-		status += '\n\n  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped');
+		status += '\n\n  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped');
+	}
+
+	if (runStatus.hasExclusive === true && runStatus.remainingCount > 0) {
+		status += '\n\n  ' + colors.information('The .only() modifier is used in some tests.', runStatus.remainingCount, plur('test', runStatus.remainingCount), plur('was', 'were', runStatus.remainingCount), 'not run.');
 	}
 
 	return status + '\n\n';

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -115,7 +115,11 @@ VerboseReporter.prototype.finish = function (runStatus) {
 	}
 
 	if (runStatus.failFastEnabled === true) {
-		output += '\n\n\n  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped');
+		output += '\n\n\n  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped');
+	}
+
+	if (runStatus.hasExclusive === true && runStatus.remainingCount > 0) {
+		output += '\n\n\n  ' + colors.information('The .only() modifier is used in some tests.', runStatus.remainingCount, plur('test', runStatus.remainingCount), plur('was', 'were', runStatus.remainingCount), 'not run.');
 	}
 
 	return output + '\n';

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -45,6 +45,7 @@ class RunStatus extends EventEmitter {
 		this.failCount = 0;
 		this.fileCount = 0;
 		this.testCount = 0;
+		this.remainingCount = 0;
 		this.previousFailCount = 0;
 		this.knownFailures = [];
 		this.errors = [];
@@ -89,13 +90,8 @@ class RunStatus extends EventEmitter {
 	handleStats(stats) {
 		this.emit('stats', stats, this);
 
-		if (this.hasExclusive && !stats.hasExclusive) {
-			return;
-		}
-
-		if (!this.hasExclusive && stats.hasExclusive) {
+		if (stats.hasExclusive) {
 			this.hasExclusive = true;
-			this.testCount = 0;
 		}
 
 		this.testCount += stats.testCount;
@@ -139,6 +135,7 @@ class RunStatus extends EventEmitter {
 		this.skipCount = sum(this.stats, 'skipCount');
 		this.todoCount = sum(this.stats, 'todoCount');
 		this.failCount = sum(this.stats, 'failCount');
+		this.remainingCount = this.testCount - this.passCount - this.failCount - this.skipCount - this.todoCount - this.knownFailureCount;
 	}
 }
 

--- a/lib/test-collection.js
+++ b/lib/test-collection.js
@@ -10,6 +10,7 @@ class TestCollection extends EventEmitter {
 		super();
 
 		this.hasExclusive = false;
+		this.testCount = 0;
 
 		this.tests = {
 			concurrent: [],
@@ -65,6 +66,8 @@ class TestCollection extends EventEmitter {
 			this.hooks[type + (metadata.always ? 'Always' : '')].push(test);
 			return;
 		}
+
+		this.testCount++;
 
 		// Add `.only()` tests if `.only()` was used previously
 		if (this.hasExclusive && !metadata.exclusive) {

--- a/test/api.js
+++ b/test/api.js
@@ -33,7 +33,7 @@ test('Without Pool: test file with exclusive tests causes non-exclusive tests in
 	return api.run(files)
 		.then(result => {
 			t.ok(result.hasExclusive);
-			t.is(result.testCount, 2);
+			t.is(result.testCount, 5);
 			t.is(result.passCount, 2);
 			t.is(result.failCount, 0);
 		});
@@ -48,7 +48,7 @@ test('Without Pool: test files can be forced to run in exclusive mode', t => {
 		{runOnlyExclusive: true}
 	).then(result => {
 		t.ok(result.hasExclusive);
-		t.is(result.testCount, 0);
+		t.is(result.testCount, 1);
 		t.is(result.passCount, 0);
 		t.is(result.failCount, 0);
 	});

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -424,7 +424,7 @@ test('results when fail-fast is enabled', function (t) {
 	compareLineOutput(t, output, [
 		'',
 		'',
-		'  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped')
+		'  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped')
 	]);
 	t.end();
 });
@@ -589,3 +589,57 @@ test('stderr and stdout should call _update', function (t) {
 	reporter._update.restore();
 	t.end();
 });
+
+test('results when hasExclusive is enabled, but there are no known remaining tests', function (t) {
+	var reporter = miniReporter();
+	var runStatus = {
+		hasExclusive: true
+	};
+
+	var output = reporter.finish(runStatus);
+	t.is(output, '\n\n');
+	t.end();
+});
+
+test('results when hasExclusive is enabled, but there is one remaining tests', function (t) {
+	var reporter = miniReporter();
+
+	var runStatus = {
+		hasExclusive: true,
+		testCount: 2,
+		passCount: 1,
+		remainingCount: 1
+	};
+
+	var actualOutput = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'',
+		'  ' + colors.information('The .only() modifier is used in some tests. 1 test was not run.'),
+		'\n'
+	].join('\n');
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});
+
+test('results when hasExclusive is enabled, but there are multiple remaining tests', function (t) {
+	var reporter = miniReporter();
+
+	var runStatus = {
+		hasExclusive: true,
+		testCount: 3,
+		passCount: 1,
+		remainingCount: 2
+	};
+
+	var actualOutput = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'',
+		'  ' + colors.information('The .only() modifier is used in some tests. 2 tests were not run.'),
+		'\n'
+	].join('\n');
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});
+

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -396,7 +396,7 @@ test('results when fail-fast is enabled', function (t) {
 		'  ' + chalk.red('1 test failed') + time,
 		'',
 		'',
-		'  ' + colors.failFast('`--fail-fast` is on. Any number of tests may have been skipped'),
+		'  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped'),
 		''
 	].join('\n');
 
@@ -464,6 +464,69 @@ test('reporter.stdout and reporter.stderr both use process.stderr.write', functi
 	reporter.stderr('result');
 	t.is(stub.callCount, 2);
 	process.stderr.write.restore();
+	t.end();
+});
+
+test('results when hasExclusive is enabled, but there are no known remaining tests', function (t) {
+	var reporter = verboseReporter();
+	var runStatus = createRunStatus();
+	runStatus.hasExclusive = true;
+	runStatus.passCount = 1;
+
+	var output = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'  ' + chalk.green('1 test passed') + time,
+		''
+	].join('\n');
+
+	t.is(output, expectedOutput);
+	t.end();
+});
+
+test('results when hasExclusive is enabled, but there is one remaining tests', function (t) {
+	var reporter = verboseReporter();
+	var runStatus = createRunStatus();
+	runStatus.hasExclusive = true;
+	runStatus.testCount = 2;
+	runStatus.passCount = 1;
+	runStatus.failCount = 0;
+	runStatus.remainingCount = 1;
+
+	var output = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'  ' + chalk.green('1 test passed') + time,
+		'',
+		'',
+		'  ' + colors.information('The .only() modifier is used in some tests. 1 test was not run.'),
+		''
+	].join('\n');
+
+	t.is(output, expectedOutput);
+	t.end();
+});
+
+test('results when hasExclusive is enabled, but there are multiple remaining tests', function (t) {
+	var reporter = verboseReporter();
+	var runStatus = createRunStatus();
+	runStatus.hasExclusive = true;
+	runStatus.testCount = 3;
+	runStatus.passCount = 1;
+	runStatus.failCount = 0;
+	runStatus.remainingCount = 2;
+
+	var output = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'  ' + chalk.green('1 test passed') + time,
+		'',
+		'',
+		'  ' + colors.information('The .only() modifier is used in some tests. 2 tests were not run.'),
+		''
+	].join('\n');
+
+	t.is(output, expectedOutput);
 	t.end();
 });
 

--- a/test/run-status.js
+++ b/test/run-status.js
@@ -66,3 +66,24 @@ test('successfully initializes without any options provided', t => {
 	t.is(runStatus.base, '');
 	t.end();
 });
+
+test('calculate remaining test count', t => {
+	const runStatus = new RunStatus();
+	runStatus.testCount = 10;
+
+	var results = [{
+		stats: {
+			passCount: 1,
+			failCount: 1,
+			skipCount: 1,
+			todoCount: 1,
+			knownFailureCount: 1
+		}
+	}];
+
+	runStatus.processResults(results);
+
+	t.is(runStatus.remainingCount, 5);
+	t.end();
+});
+


### PR DESCRIPTION
This PR fixes #1135. If all test files have at least one .only test in them, it will print out the following message at the end of the report for both mini and verbose.

> The .only() modifier is used in some tests. All other tests have been skipped.

If there are test files without .only in them, it will print out the following.

> The .only() modifier is used in some tests. At least', remainingTests, 'tests were not run.

remainingTests will then be the number of tests in the test files that don´t have any .only tests.

It currently looks like this:

![mini](https://cloud.githubusercontent.com/assets/3599597/21841330/120c0a6c-d7e2-11e6-9a12-8438a6cb03a2.png)

![verbose](https://cloud.githubusercontent.com/assets/3599597/21841334/16dd08ca-d7e2-11e6-8adb-8e379982396a.png)

Feedback appreciated :)