### PR TITLE
Only print fail-fast when there are remaining tests

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -215,7 +215,7 @@ MiniReporter.prototype.finish = function (runStatus) {
 		});
 	}
 
-	if (runStatus.failFastEnabled === true) {
+	if (runStatus.failFastEnabled === true && runStatus.remainingCount > 0 && runStatus.failCount > 0) {
 		status += '\n\n  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped');
 	}
 

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -114,7 +114,7 @@ VerboseReporter.prototype.finish = function (runStatus) {
 		});
 	}
 
-	if (runStatus.failFastEnabled === true) {
+	if (runStatus.failFastEnabled === true && runStatus.remainingCount > 0 && runStatus.failCount > 0) {
 		output += '\n\n\n  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped');
 	}
 

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -417,6 +417,8 @@ test('results with unhandled errors', function (t) {
 test('results when fail-fast is enabled', function (t) {
 	var reporter = miniReporter();
 	var runStatus = {
+		remainingCount: 1,
+		failCount: 1,
 		failFastEnabled: true
 	};
 
@@ -426,6 +428,32 @@ test('results when fail-fast is enabled', function (t) {
 		'',
 		'  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped')
 	]);
+	t.end();
+});
+
+test('results without fail-fast if no failing tests', function (t) {
+	var reporter = miniReporter();
+	var runStatus = {
+		remainingCount: 1,
+		failCount: 0,
+		failFastEnabled: true
+	};
+
+	var output = reporter.finish(runStatus);
+	t.is(output, '\n\n');
+	t.end();
+});
+
+test('results without fail-fast if no skipped tests', function (t) {
+	var reporter = miniReporter();
+	var runStatus = {
+		remainingCount: 0,
+		failCount: 1,
+		failFastEnabled: true
+	};
+
+	var output = reporter.finish(runStatus);
+	t.is(output, '\n\n');
 	t.end();
 });
 

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -384,6 +384,7 @@ test('results with errors', function (t) {
 test('results when fail-fast is enabled', function (t) {
 	var reporter = verboseReporter();
 	var runStatus = createRunStatus();
+	runStatus.remainingCount = 1;
 	runStatus.failCount = 1;
 	runStatus.failFastEnabled = true;
 	runStatus.tests = [{
@@ -397,6 +398,46 @@ test('results when fail-fast is enabled', function (t) {
 		'',
 		'',
 		'  ' + colors.information('`--fail-fast` is on. Any number of tests may have been skipped'),
+		''
+	].join('\n');
+
+	t.is(output, expectedOutput);
+	t.end();
+});
+
+test('results without fail-fast if no failing tests', function (t) {
+	var reporter = verboseReporter();
+	var runStatus = createRunStatus();
+	runStatus.remainingCount = 1;
+	runStatus.failCount = 0;
+	runStatus.passCount = 1;
+	runStatus.failFastEnabled = true;
+
+	var output = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'  ' + chalk.green('1 test passed') + time,
+		''
+	].join('\n');
+
+	t.is(output, expectedOutput);
+	t.end();
+});
+
+test('results without fail-fast if no skipped tests', function (t) {
+	var reporter = verboseReporter();
+	var runStatus = createRunStatus();
+	runStatus.remainingCount = 0;
+	runStatus.failCount = 1;
+	runStatus.failFastEnabled = true;
+	runStatus.tests = [{
+		title: 'failed test'
+	}];
+
+	var output = reporter.finish(runStatus);
+	var expectedOutput = [
+		'',
+		'  ' + chalk.red('1 test failed') + time,
 		''
 	].join('\n');
 


### PR DESCRIPTION
This PR tries to fix #1171 by calculating the remaningCount in run-status.js
And then check the value in the reporters, if there are no remaining test it will not print:

> `--fail-fast` is on. Any number of tests may have been skipped
