### PR TITLE
Removed period at end of only()/exclusive output in mini and verbose reporters

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -220,7 +220,7 @@ MiniReporter.prototype.finish = function (runStatus) {
 	}
 
 	if (runStatus.hasExclusive === true && runStatus.remainingCount > 0) {
-		status += '\n\n  ' + colors.information('The .only() modifier is used in some tests.', runStatus.remainingCount, plur('test', runStatus.remainingCount), plur('was', 'were', runStatus.remainingCount), 'not run.');
+		status += '\n\n  ' + colors.information('The .only() modifier is used in some tests.', runStatus.remainingCount, plur('test', runStatus.remainingCount), plur('was', 'were', runStatus.remainingCount), 'not run');
 	}
 
 	return status + '\n\n';

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -119,7 +119,7 @@ VerboseReporter.prototype.finish = function (runStatus) {
 	}
 
 	if (runStatus.hasExclusive === true && runStatus.remainingCount > 0) {
-		output += '\n\n\n  ' + colors.information('The .only() modifier is used in some tests.', runStatus.remainingCount, plur('test', runStatus.remainingCount), plur('was', 'were', runStatus.remainingCount), 'not run.');
+		output += '\n\n\n  ' + colors.information('The .only() modifier is used in some tests.', runStatus.remainingCount, plur('test', runStatus.remainingCount), plur('was', 'were', runStatus.remainingCount), 'not run');
 	}
 
 	return output + '\n';

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -615,7 +615,7 @@ test('results when hasExclusive is enabled, but there is one remaining tests', f
 	var expectedOutput = [
 		'',
 		'',
-		'  ' + colors.information('The .only() modifier is used in some tests. 1 test was not run.'),
+		'  ' + colors.information('The .only() modifier is used in some tests. 1 test was not run'),
 		'\n'
 	].join('\n');
 	t.is(actualOutput, expectedOutput);
@@ -636,7 +636,7 @@ test('results when hasExclusive is enabled, but there are multiple remaining tes
 	var expectedOutput = [
 		'',
 		'',
-		'  ' + colors.information('The .only() modifier is used in some tests. 2 tests were not run.'),
+		'  ' + colors.information('The .only() modifier is used in some tests. 2 tests were not run'),
 		'\n'
 	].join('\n');
 	t.is(actualOutput, expectedOutput);

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -499,7 +499,7 @@ test('results when hasExclusive is enabled, but there is one remaining tests', f
 		'  ' + chalk.green('1 test passed') + time,
 		'',
 		'',
-		'  ' + colors.information('The .only() modifier is used in some tests. 1 test was not run.'),
+		'  ' + colors.information('The .only() modifier is used in some tests. 1 test was not run'),
 		''
 	].join('\n');
 
@@ -522,7 +522,7 @@ test('results when hasExclusive is enabled, but there are multiple remaining tes
 		'  ' + chalk.green('1 test passed') + time,
 		'',
 		'',
-		'  ' + colors.information('The .only() modifier is used in some tests. 2 tests were not run.'),
+		'  ' + colors.information('The .only() modifier is used in some tests. 2 tests were not run'),
 		''
 	].join('\n');
 


### PR DESCRIPTION
@novemberborn tiny PR to fix the period in the end of exclusive / only()  report in mini and verbose reporters.

Requested by @novemberborn after PR #1177 was closed.