### PR TITLE
Removed --source, -S CLI flag. Fixes #937

### DIFF
--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -67,11 +67,11 @@ In AVA there's a distinction between *source files* and *test files*. As you can
 
 By default AVA watches for changes to the test files, `package.json`, and any other `.js` files. It'll ignore files in [certain directories](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) as provided by the [`ignore-by-default`] package.
 
-You can configure patterns for the source files in the [`ava` section of your `package.json`] file, using the `source` key. This is the recommended way, though you could also use the [`--source` CLI flag].
+You can configure patterns for the source files in the [`ava` section of your `package.json`] file, using the `source` key.
 
 You can specify patterns to match files in the folders that would otherwise be ignored, e.g. use `node_modules/some-dependency/*.js` to specify all `.js` files in `node_modules/some-dependency` as a source, even though normally all files in `node_modules` are ignored. Note that you need to specify an exact directory; `{bower_components,node_modules}/**/*.js` won't work.
 
-If your tests write to disk they may trigger the watcher to rerun your tests. If this occurs you will need to use the `--source` flag.
+If your tests write to disk they may trigger the watcher to rerun your tests. Configure patterns for the source files to avoid this.
 
 ## Dependency tracking
 
@@ -113,7 +113,6 @@ Watch mode is relatively new and there might be some rough edges. Please [report
 [`chokidar`]: https://github.com/paulmillr/chokidar
 [Install Troubleshooting]: https://github.com/paulmillr/chokidar#install-troubleshooting
 [`ignore-by-default`]: https://github.com/novemberborn/ignore-by-default
-[`--source` CLI flag]: https://github.com/avajs/ava#cli
 [`.only` modifier]: https://github.com/avajs/ava#running-specific-tests
 [`ava` section of your `package.json`]: https://github.com/avajs/ava#configuration
 [added them in your `package.json`]: https://github.com/avajs/ava#configuration

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -40,7 +40,6 @@ exports.run = () => {
 		  --no-power-assert       Disable Power Assert
 		  --match, -m             Only run tests with matching title (Can be repeated)
 		  --watch, -w             Re-run tests when tests and source files change
-		  --source, -S            Pattern to match source files so tests can be re-run (Can be repeated)
 		  --timeout, -T           Set global timeout
 		  --concurrency, -c       Maximum number of test files running at the same time (EXPERIMENTAL)
 		  --update-snapshots, -u  Update snapshots
@@ -59,7 +58,6 @@ exports.run = () => {
 		string: [
 			'_',
 			'match',
-			'source',
 			'timeout',
 			'concurrency'
 		],
@@ -79,7 +77,6 @@ exports.run = () => {
 			s: 'serial',
 			m: 'match',
 			w: 'watch',
-			S: 'source',
 			T: 'timeout',
 			c: 'concurrency',
 			u: 'update-snapshots'
@@ -152,7 +149,7 @@ exports.run = () => {
 
 	if (cli.flags.watch) {
 		try {
-			const watcher = new Watcher(logger, api, files, arrify(cli.flags.source));
+			const watcher = new Watcher(logger, api, files, arrify(conf.source));
 			watcher.observeStdin(process.stdin);
 		} catch (err) {
 			if (err.name === 'AvaError') {

--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,6 @@ $ ava --help
     --no-power-assert       Disable Power Assert
     --match, -m             Only run tests with matching title (Can be repeated)
     --watch, -w             Re-run tests when tests and source files change
-    --source, -S            Pattern to match source files so tests can be re-run (Can be repeated)
     --timeout, -T           Set global timeout
     --concurrency, -c       Maximum number of test files running at the same time (EXPERIMENTAL)
     --update-snapshots, -u  Update snapshots

--- a/test/cli.js
+++ b/test/cli.js
@@ -238,7 +238,7 @@ test('watcher reruns test files when they changed', t => {
 test('watcher reruns test files when source dependencies change', t => {
 	let killed = false;
 
-	const child = execCli(['--verbose', '--watch', '--source=source.js', 'test-*.js'], {dirname: 'fixture/watcher/with-dependencies'}, err => {
+	const child = execCli(['--verbose', '--watch', 'test-*.js'], {dirname: 'fixture/watcher/with-dependencies'}, err => {
 		t.ok(killed);
 		t.ifError(err);
 		t.end();


### PR DESCRIPTION
Removed every reference within `lib/cli.js`.  Replaced the reference for the `Watcher` constructor with `conf.source`.

I don't know if I need to write some tests or there are other references to remove, I tried to check what seemed more relevant.
