### PR TITLE
Fix flow errors using t.throws and t.notThrows

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -31,7 +31,7 @@ type ErrorValidator =
 	| ((error: any) => boolean);
 
 /**
- * Asertion Types
+ * Assertion Types
  */
 
 type AssertContext = {
@@ -57,11 +57,15 @@ type AssertContext = {
 	notDeepEqual<U>(value: U, expected: U, message?: string): void;
 	// Assert that function throws an error or promise rejects.
 	// @param error Can be a constructor, regex, error message or validation function.
-	throws(value: PromiseLike<mixed>, error?: ErrorValidator, message?: string): Promise<mixed>;
-	throws(value: () => void, error?: ErrorValidator, message?: string): mixed;
+	throws: {
+		(value: PromiseLike<mixed>, error?: ErrorValidator, message?: string): Promise<Error>;
+		(value: () => mixed, error?: ErrorValidator, message?: string): Error;
+	};
 	// Assert that function doesn't throw an error or promise resolves.
-	notThrows<U>(value: PromiseLike<U>, message?: string): Promise<U>;
-	notThrows(value: () => void, message?: string): void;
+	notThrows: {
+		notThrows<U>(value: PromiseLike<U>, message?: string): Promise<U>;
+		notThrows(value: () => mixed, message?: string): void;
+	};
 	// Assert that contents matches regex.
 	regex(contents: string, regex: RegExp, message?: string): void;
 	// Assert that contents does not match regex.


### PR DESCRIPTION
Instead of double-defining each of these, define them once while using overloading.

Also took some liberties to improve the definition. Specifically, ava doesn't care what values these throwing functions return, but doesn't produce a return value.

Fixes #1148

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
