### PR TITLE
Add flow type tests

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+<PROJECT_ROOT>/node_modules/.*
+<PROJECT_ROOT>/.*\.js$
+
+[options]
+emoji=true
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError

--- a/index.js.flow
+++ b/index.js.flow
@@ -63,8 +63,8 @@ type AssertContext = {
 	};
 	// Assert that function doesn't throw an error or promise resolves.
 	notThrows: {
-		notThrows<U>(value: PromiseLike<U>, message?: string): Promise<U>;
-		notThrows(value: () => mixed, message?: string): void;
+		<U>(value: PromiseLike<U>, message?: string): Promise<U>;
+		(value: () => mixed, message?: string): void;
 	};
 	// Assert that contents matches regex.
 	regex(contents: string, regex: RegExp, message?: string): void;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo && nyc tap --no-cov --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
+    "test": "xo && flow check && nyc tap --no-cov --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
     "test-win": "tap --no-cov --reporter=classic --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
     "visual": "node test/visual/run-visual-tests.js",
     "prepublish": "npm run make-ts",
@@ -167,6 +167,7 @@
     "coveralls": "^2.11.4",
     "delay": "^1.3.0",
     "execa": "^0.6.0",
+    "flow-bin": "^0.38.0",
     "get-stream": "^3.0.0",
     "git-branch": "^0.3.0",
     "has-ansi": "^2.0.0",

--- a/test/flow-types/regression-1114.js.flow
+++ b/test/flow-types/regression-1114.js.flow
@@ -1,0 +1,53 @@
+/* @flow */
+
+const test = require('../../');
+
+test('Named test', t => {
+	t.pass('Success');
+	// $ExpectError: Unknown method "unknownAssertion"
+	t.unknownAssertion('Whoops');
+	const context = t.context;
+	// $ExpectError: Unknown method "end"
+	t.end();
+});
+
+test(t => {
+	t.pass('Success');
+	// $ExpectError: Unknown method "unknownAssertion"
+	t.unknownAssertion('Whoops');
+	const context = t.context;
+	// $ExpectError: Unknown method "end"
+	t.end();
+});
+
+test.cb(t => {
+	t.pass('Success');
+	t.end();
+});
+
+test.beforeEach(t => {
+	// $ExpectError: Unknown property "context"
+	const context = t.context;
+})
+
+function macro(t, input, expected) {
+	t.is(eval(input), expected);
+}
+macro.title = (title, input, expected) => title || input;
+
+function macro2(t, input, expected) {
+	t.is(eval(input), expected);
+}
+
+test('2 + 2 === 4', macro, '2 + 2', 4);
+test(macro, '2 * 3', 6);
+
+test('2 + 2 === 4', [macro, macro2], '2 + 2', 4);
+test([macro, macro2], '2 * 3', 6);
+
+function macroBadTitle(t, input, expected) {
+	t.is(eval(input), expected);
+}
+macroBadTitle.title = 'Not a function';
+// $ExpectError: Macro "title" is not a function
+test('2 + 2 === 4', macroBadTitle, '2 + 2', 4);

--- a/test/flow-types/regression-1148.js.flow
+++ b/test/flow-types/regression-1148.js.flow
@@ -1,0 +1,19 @@
+/* @flow */
+
+const test = require('../../');
+
+test(t => {
+	t.throws(() => { throw new Error(); });
+	t.throws(Promise.reject(new Error()));
+
+	t.notThrows(() => { return; });
+	t.notThrows(Promise.resolve('Success'));
+
+	const error = t.throws(() => { throw new Error(); });
+	const message: string = error.message;
+
+	const promise = t.throws(Promise.reject(new Error()));
+	promise.then(error => {
+		const message: string = error.message;
+	})
+});


### PR DESCRIPTION
Closes #1224

This adds flow-bin, adds it to the test running script, and adds some regression tests based on prior issues.

In an immediate proof of value (and proof of my own prior sloppiness) it spotted an issue that #1219 sought to fix and did not do so. Fix included along with test.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
