### PR TITLE
Simplify failure output - fixes #1072

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -203,7 +203,7 @@ class MiniReporter {
 					status += '\n' + indentString(test.error.message, 2) + '\n';
 				}
 
-				if (test.error.stack) {
+				if (test.error.stack && test.error.source.file !== test.file) {
 					status += '\n' + indentString(colors.errorStack(extractStack(test.error.stack)), 2);
 				}
 			});

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -203,8 +203,11 @@ class MiniReporter {
 					status += '\n' + indentString(test.error.message, 2) + '\n';
 				}
 
-				if (test.error.stack && test.error.source.file !== test.file) {
-					status += '\n' + indentString(colors.errorStack(extractStack(test.error.stack)), 2);
+				if (test.error.stack) {
+					const extracted = extractStack(test.error.stack);
+					if (extracted.includes('\n')) {
+						status += '\n' + indentString(colors.errorStack(extracted), 2);
+					}
 				}
 			});
 		}

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -122,7 +122,10 @@ class VerboseReporter {
 				}
 
 				if (test.error.stack) {
-					output += '\n' + indentString(colors.errorStack(extractStack(test.error.stack)), 2);
+					const extracted = extractStack(test.error.stack);
+					if (extracted.includes('\n')) {
+						output += '\n' + indentString(colors.errorStack(extracted), 2);
+					}
 				}
 			});
 		}

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -406,9 +406,7 @@ test('results with errors', t => {
 		indentString(codeExcerpt(err2Path, err2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(err2), 2).split('\n'),
-		/failure two/,
-		'',
-		stackLineRegex
+		/failure two/
 	]));
 	t.end();
 });
@@ -467,9 +465,7 @@ test('results with errors and disabled code excerpts', t => {
 		indentString(codeExcerpt(err2Path, err2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(err2), 2).split('\n'),
-		/failure two/,
-		'',
-		stackLineRegex
+		/failure two/
 	]));
 	t.end();
 });
@@ -531,9 +527,7 @@ test('results with errors and broken code excerpts', t => {
 		indentString(codeExcerpt(err2Path, err2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(err2), 2).split('\n'),
-		/failure two/,
-		'',
-		stackLineRegex
+		/failure two/
 	]));
 	t.end();
 });
@@ -596,9 +590,7 @@ test('results with errors and disabled assert output', t => {
 		indentString(codeExcerpt(err2Path, err2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(err2), 2).split('\n'),
-		/failure two/,
-		'',
-		stackLineRegex
+		/failure two/
 	]));
 	t.end();
 });

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -413,9 +413,7 @@ test('results with errors', t => {
 		indentString(codeExcerpt(err2Path, error2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(error2), 2).split('\n'),
-		/error two message/,
-		'',
-		stackLineRegex
+		/error two message/
 	]));
 	t.end();
 });
@@ -471,9 +469,7 @@ test('results with errors and disabled code excerpts', t => {
 		indentString(codeExcerpt(err2Path, error2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(error2), 2).split('\n'),
-		/error two message/,
-		'',
-		stackLineRegex
+		/error two message/
 	]));
 	t.end();
 });
@@ -532,9 +528,7 @@ test('results with errors and disabled code excerpts', t => {
 		indentString(codeExcerpt(err2Path, error2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(error2), 2).split('\n'),
-		/error two message/,
-		'',
-		stackLineRegex
+		/error two message/
 	]));
 	t.end();
 });
@@ -594,9 +588,7 @@ test('results with errors and disabled assert output', t => {
 		indentString(codeExcerpt(err2Path, error2.source.line), 2).split('\n'),
 		'',
 		indentString(formatAssertError(error2), 2).split('\n'),
-		/error two message/,
-		'',
-		stackLineRegex
+		/error two message/
 	]));
 	t.end();
 });


### PR DESCRIPTION
The idea is to check when the `test.error.source.file` is NOT the same of the `test.file` within the `forEach` of the errors.

I saw that when I throw an error from another module the `test.file` refers to the module's file and not the file that is running the test.

In this case for example if I make this check, I'm able to hide the stack trace.
```sh
  1 failed

  lol.js:2

   1: const testing = () => { 
   2:   throw new Error('lol')
   3: }                       

  Error: lol

  testing (lol.js:2:8)
  Test.t [as fn] (test.js:5:2)
```

Waiting for your feedback to move forward!