### PR TITLE
Ensure TAP reporter test does not write to stderr

### DIFF
--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -209,12 +209,12 @@ test('write should call console.log', t => {
 
 test('stdout and stderr should call process.stderr.write', t => {
 	const reporter = new TapReporter();
-	const spy = sinon.spy(process.stderr, 'write');
+	const stub = sinon.stub(process.stderr, 'write');
 
 	reporter.stdout('result');
 	reporter.stderr('result');
 
-	t.is(spy.callCount, 2);
 	process.stderr.write.restore();
+	t.is(stub.callCount, 2);
 	t.end();
 });


### PR DESCRIPTION
Stub process.stderr.write(), rather than just spying on it. Otherwise 'resultresult' gets written to the stderr while the tests run.
