### PR TITLE
Speed up flow check

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo && flow check && nyc tap --no-cov --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
+    "test": "xo && flow check test/flow-types && nyc tap --no-cov --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
     "test-win": "tap --no-cov --reporter=classic --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
     "visual": "node test/visual/run-visual-tests.js",
     "prepublish": "npm run make-ts",

--- a/test/flow-types/.flowconfig
+++ b/test/flow-types/.flowconfig
@@ -1,6 +1,5 @@
-[ignore]
-<PROJECT_ROOT>/node_modules/.*
-<PROJECT_ROOT>/.*\.js$
+[include]
+../../*.js.flow$
 
 [options]
 emoji=true

--- a/test/flow-types/regression-1114.js.flow
+++ b/test/flow-types/regression-1114.js.flow
@@ -1,6 +1,6 @@
 /* @flow */
 
-const test = require('../../');
+const test = require('../../index.js.flow');
 
 test('Named test', t => {
 	t.pass('Success');

--- a/test/flow-types/regression-1148.js.flow
+++ b/test/flow-types/regression-1148.js.flow
@@ -1,6 +1,6 @@
 /* @flow */
 
-const test = require('../../');
+const test = require('../../index.js.flow');
 
 test(t => {
 	t.throws(() => { throw new Error(); });


### PR DESCRIPTION
`flow check` is easily taking 30 seconds on my development machine, presumably it's checking too many files. Move the `.flowconfig` into the flow-types test directory and only include the `index.js.flow` file to improve check speed.

I've verified it still catches type errors by reverting the `notThrows` fix from #1230.

@leebyron does my analysis make sense? Given how the `ignore` expressions work I don't think there's any other way of restricting `flow check` to just the three `.js.flow` files we currently have.