### PR TITLE
Ensure watcher rethrows logger errors

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -107,13 +107,15 @@ class Watcher {
 				}
 			}
 
-			this.busy = api.run(specificFiles || files, {runOnlyExclusive}).then(runStatus => {
-				runStatus.previousFailCount = this.sumPreviousFailures(currentVector);
-				logger.finish(runStatus);
+			this.busy = api.run(specificFiles || files, {runOnlyExclusive})
+				.then(runStatus => {
+					runStatus.previousFailCount = this.sumPreviousFailures(currentVector);
+					logger.finish(runStatus);
 
-				const badCounts = runStatus.failCount + runStatus.rejectionCount + runStatus.exceptionCount;
-				this.clearLogOnNextRun = this.clearLogOnNextRun && badCounts === 0;
-			}, rethrowAsync);
+					const badCounts = runStatus.failCount + runStatus.rejectionCount + runStatus.exceptionCount;
+					this.clearLogOnNextRun = this.clearLogOnNextRun && badCounts === 0;
+				})
+				.catch(rethrowAsync);
 		};
 
 		this.testDependencies = [];


### PR DESCRIPTION
The watcher would break if `logger.finish()` threw an exception. Instead rethrow this error (which causes the process to exit).

This surfaced in https://github.com/avajs/ava/issues/1231#issuecomment-278169455.
