### PR TITLE
Add TypeScript definition for the snapshot assertion

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -72,6 +72,10 @@ export interface AssertContext {
 	 */
 	regex(contents: string, regex: RegExp, message?: string): void;
 	/**
+	 * Assert that contents matches a snapshot.
+	 */
+	snapshot(contents: any): void;
+	/**
 	 * Assert that contents does not match regex.
 	 */
 	notRegex(contents: string, regex: RegExp, message?: string): void;

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -74,7 +74,7 @@ export interface AssertContext {
 	/**
 	 * Assert that contents matches a snapshot.
 	 */
-	snapshot(contents: any): void;
+	snapshot(contents: any, message?: string): void;
 	/**
 	 * Assert that contents does not match regex.
 	 */


### PR DESCRIPTION
The snapshot method was missing in the typescript type-definition file. 