### PR TITLE
Fix issue with using 'chalk' in tests

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -5,22 +5,14 @@ const childProcess = require('child_process');
 const test = require('tap').test;
 const getStream = require('get-stream');
 const figures = require('figures');
-const chalk = require('chalk');
 const mkdirp = require('mkdirp');
 const touch = require('touch');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const uniqueTempDir = require('unique-temp-dir');
 const execa = require('execa');
-const colors = require('../lib/colors');
 
 const cliPath = path.join(__dirname, '../cli.js');
-
-// For some reason chalk is disabled by default
-chalk.enabled = true;
-for (const key of Object.keys(colors)) {
-	colors[key].enabled = true;
-}
 
 function execCli(args, opts, cb) {
 	let dirname;
@@ -74,12 +66,12 @@ function execCli(args, opts, cb) {
 }
 
 test('disallow invalid babel config shortcuts', t => {
-	execCli(['--color', 'es2015.js'], {dirname: 'fixture/invalid-babel-config'}, (err, stdout, stderr) => {
+	execCli(['es2015.js'], {dirname: 'fixture/invalid-babel-config'}, (err, stdout, stderr) => {
 		t.ok(err);
 
 		let expectedOutput = '\n  ';
-		expectedOutput += colors.error(figures.cross) + ' Unexpected Babel configuration for AVA.';
-		expectedOutput += ' See ' + chalk.underline('https://github.com/avajs/ava#es2015-support') + ' for allowed values.';
+		expectedOutput += figures.cross + ' Unexpected Babel configuration for AVA.';
+		expectedOutput += ' See https://github.com/avajs/ava#es2015-support for allowed values.';
 		expectedOutput += '\n';
 
 		t.is(stderr, expectedOutput);

--- a/test/fixture/chalk-disabled.js
+++ b/test/fixture/chalk-disabled.js
@@ -1,0 +1,6 @@
+import chalk from 'chalk';
+import test from '../../';
+
+test('should not support colors', t => {
+	t.false(chalk.enabled);
+});

--- a/test/fixture/chalk-enabled.js
+++ b/test/fixture/chalk-enabled.js
@@ -1,0 +1,6 @@
+import chalk from 'chalk';
+import test from '../../';
+
+test('should support colors', t => {
+	t.true(chalk.enabled);
+});


### PR DESCRIPTION
This PR fixes a bug where the chalk module reported that the current terminal does not support colors.

'chalk' is using the 'supports-color' module which reads process.stdout.isTTY as soon as it is required. Since our process-adapter is initializing a fake TTY support, we must ensure that 'supports-color' is not executed before our fake TTY support is initialized.

I just re-arranged the `require()` statements. Also added tests for it.

Fixes #1124

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
