### PR TITLE
Symlink fix

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -187,7 +187,7 @@ class MiniReporter {
 				if (test.error.source) {
 					status += '  ' + colors.errorSource(test.error.source.file + ':' + test.error.source.line) + '\n';
 
-					const errorPath = path.join(this.options.basePath, test.error.source.file);
+					const errorPath = path.resolve(this.options.basePath, test.error.source.file);
 					const excerpt = codeExcerpt(errorPath, test.error.source.line, {maxWidth: process.stdout.columns});
 					if (excerpt) {
 						status += '\n' + indentString(excerpt, 2) + '\n';

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -106,7 +106,7 @@ class VerboseReporter {
 				if (test.error.source) {
 					output += '  ' + colors.errorSource(test.error.source.file + ':' + test.error.source.line) + '\n';
 
-					const errorPath = path.join(this.options.basePath, test.error.source.file);
+					const errorPath = path.resolve(this.options.basePath, test.error.source.file);
 					const excerpt = codeExcerpt(errorPath, test.error.source.line, {maxWidth: process.stdout.columns});
 					if (excerpt) {
 						output += '\n' + indentString(excerpt, 2) + '\n';

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -1,5 +1,6 @@
 'use strict';
 const path = require('path');
+const os = require('os');
 const indentString = require('indent-string');
 const tempWrite = require('temp-write');
 const flatten = require('arr-flatten');
@@ -947,5 +948,45 @@ test('result when no-color flag is set', t => {
 		'\n'
 	].join('\n');
 	t.is(output, expectedOutput);
+	t.end();
+});
+
+test('results with errors when failure is a file under an unrelated path', t => {
+	const err1 = new Error('failure one');
+	err1.stack = beautifyStack(err1.stack);
+	const err1Path = tempWrite.sync('a();');
+	err1.source = {file: err1Path, line: 1};
+	err1.showOutput = true;
+	err1.actual = JSON.stringify('abc');
+	err1.actualType = 'string';
+	err1.expected = JSON.stringify('abd');
+	err1.expectedType = 'string';
+
+	const reporter = miniReporter({basePath: path.join(os.tmpdir(), 'foo')});
+	reporter.failCount = 1;
+
+	const runStatus = {
+		errors: [{
+			title: 'failed one',
+			error: err1
+		}]
+	};
+
+	const output = reporter.finish(runStatus);
+
+	compareLineOutput(t, output, flatten([
+		'',
+		'  ' + chalk.red('1 failed'),
+		'',
+		'  ' + chalk.bold.white('failed one'),
+		'  ' + chalk.grey(`${err1.source.file}:${err1.source.line}`),
+		'',
+		indentString(codeExcerpt(err1Path, err1.source.line), 2).split('\n'),
+		'',
+		indentString(formatAssertError(err1), 2).split('\n'),
+		/failure one/,
+		'',
+		stackLineRegex
+	]));
 	t.end();
 });


### PR DESCRIPTION
Fixes an issue that I found when i had errors under symlinks in my `node_modules` folder; `codeExcerpt` would crash because `path.join` doesn't take absolute paths into consideration. `path.resolve` does.
