### PR TITLE
Document helper precompilation caveat (in code at least)

### DIFF
--- a/api.js
+++ b/api.js
@@ -119,6 +119,11 @@ class Api extends EventEmitter {
 	_precompileHelpers() {
 		this._precompiledHelpers = {};
 
+		// Assumes the tests only load helpers from within the `resolveTestsFrom`
+		// directory. Without arguments this is the `projectDir`, else it's
+		// `process.cwd()` which may be nested too deeply. This will be solved
+		// as we implement RFC 001 and move helper compilation into the worker
+		// processes, avoiding the need for precompilation.
 		return new AvaFiles({cwd: this.options.resolveTestsFrom})
 			.findTestHelpers()
 			.map(file => { // eslint-disable-line array-callback-return


### PR DESCRIPTION
The way helpers are precompiled, if you invoke AVA from inside a directory, with file arguments, then only helper files inside that directory are precompiled.

We'll be able to fix it when we move compilation into the workers, and I'm not even convinced it should be considered a bug at this stage. I did want to document the behavior somewhere, but I'm not sure it has to be in user-facing documentation as it's (hopefully) a rather specific edge-case.