### PR TITLE
Clarify directories used by API

### DIFF
--- a/api.js
+++ b/api.js
@@ -49,12 +49,7 @@ class Api extends EventEmitter {
 		super();
 		autoBind(this);
 
-		this.options = Object.assign({
-			cwd: process.cwd(),
-			resolveTestsFrom: process.cwd(),
-			match: []
-		}, options);
-
+		this.options = Object.assign({match: []}, options);
 		this.options.require = resolveModules(this.options.require);
 	}
 	_runFile(file, runStatus, execArgv) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,7 +24,7 @@ exports.run = () => {
 	const conf = pkgConf.sync('ava');
 
 	const filepath = pkgConf.filepath(conf);
-	const pkgDir = filepath === null ? process.cwd() : path.dirname(filepath);
+	const projectDir = filepath === null ? process.cwd() : path.dirname(filepath);
 
 	const cli = meow(`
 		Usage
@@ -116,8 +116,8 @@ exports.run = () => {
 		explicitTitles: cli.flags.watch,
 		match: arrify(cli.flags.match),
 		babelConfig: babelConfig.validate(conf.babel),
-		resolveTestsFrom: cli.input.length === 0 ? pkgDir : process.cwd(),
-		pkgDir,
+		resolveTestsFrom: cli.input.length === 0 ? projectDir : process.cwd(),
+		projectDir,
 		timeout: cli.flags.timeout,
 		concurrency: cli.flags.concurrency ? parseInt(cli.flags.concurrency, 10) : 0,
 		updateSnapshots: cli.flags.updateSnapshots,
@@ -129,9 +129,9 @@ exports.run = () => {
 	if (cli.flags.tap && !cli.flags.watch) {
 		reporter = new TapReporter();
 	} else if (cli.flags.verbose || isCi) {
-		reporter = new VerboseReporter({color: cli.flags.color, basePath: pkgDir});
+		reporter = new VerboseReporter({color: cli.flags.color, basePath: projectDir});
 	} else {
-		reporter = new MiniReporter({color: cli.flags.color, watching: cli.flags.watch, basePath: pkgDir});
+		reporter = new MiniReporter({color: cli.flags.color, watching: cli.flags.watch, basePath: projectDir});
 	}
 
 	reporter.api = api;

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -39,7 +39,7 @@ module.exports = (file, opts, execArgv) => {
 	const args = [JSON.stringify(opts), opts.color ? '--color' : '--no-color'];
 
 	const ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), args, {
-		cwd: opts.pkgDir,
+		cwd: opts.projectDir,
 		silent: true,
 		env,
 		execArgv: execArgv || process.execArgv


### PR DESCRIPTION
* Rename pkgDir to projectDir: this better communicates it's the
directory of the user's project.

* Remove unused cwd option from API.

* Remove default for resolveTestsFrom. It's confusing to see
process.cwd() in the code even though it's never actually used.

* Ensure API test properly creates the API instances.

