### PR TITLE
Only add basePath to error stacktraces with relative source file paths

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -187,7 +187,10 @@ class MiniReporter {
 				if (test.error.source) {
 					status += '  ' + colors.errorSource(test.error.source.file + ':' + test.error.source.line) + '\n';
 
-					const errorPath = path.join(this.options.basePath, test.error.source.file);
+					let errorPath = test.error.source.file;
+					if (!path.isAbsolute(test.error.source.file)) {
+						errorPath = path.join(this.options.basePath, test.error.source.file);
+					}
 					const excerpt = codeExcerpt(errorPath, test.error.source.line, {maxWidth: process.stdout.columns});
 					if (excerpt) {
 						status += '\n' + indentString(excerpt, 2) + '\n';

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -106,7 +106,10 @@ class VerboseReporter {
 				if (test.error.source) {
 					output += '  ' + colors.errorSource(test.error.source.file + ':' + test.error.source.line) + '\n';
 
-					const errorPath = path.join(this.options.basePath, test.error.source.file);
+					let errorPath = test.error.source.file;
+					if (!path.isAbsolute(test.error.source.file)) {
+						errorPath = path.join(this.options.basePath, test.error.source.file);
+					}
 					const excerpt = codeExcerpt(errorPath, test.error.source.line, {maxWidth: process.stdout.columns});
 					if (excerpt) {
 						output += '\n' + indentString(excerpt, 2) + '\n';


### PR DESCRIPTION
Some sourcemap tools can produce absolute paths for source map urls, which will then be reflected in error stacktraces that feature absolute paths for the stack frame source url.

Previously, the basePath (typically `process.cwd()`) was prefixed to all error stacktrace urls, which sometimes works for relative paths[1], but will fail with absolute paths.

This change checks if the stacktrace url is absolute first - if so, it skips prefixing the url with basePath.

This change is more than cosmetic - the mini reporter uses the stacktrace url to invoke the `codeExcerpt` helper, which tries to load the source file from that url. If it's not correct, `codeExcerpt` will throw.

--------

[1] - See #1266. Intermediate build steps between the sourcemap generation and running ava can break relative urls too. This change does not solve that problem - it only fixes the absolute path scenario.