### PR TITLE
Don't call toJSON() when formatting values

### DIFF
--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -8,6 +8,7 @@ const extractStack = require('./extract-stack');
 
 function serializeValue(value) {
 	return prettyFormat(value, {
+		callToJSON: false,
 		plugins: [reactTestPlugin],
 		highlight: true
 	});

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "@ava/babel-preset-stage-4": "^1.0.0",
     "@ava/babel-preset-transform-test-files": "^2.0.0",
-    "@ava/pretty-format": "^1.0.0",
+    "@ava/pretty-format": "^1.1.0",
     "arr-flatten": "^1.0.1",
     "array-union": "^1.0.1",
     "array-uniq": "^1.0.2",

--- a/readme.md
+++ b/readme.md
@@ -914,11 +914,15 @@ Assert that `value` is not equal to `expected`.
 
 ### `.deepEqual(value, expected, [message])`
 
-Assert that `value` is deep equal to `expected`.
+Assert that `value` is deep equal to `expected`. This is based on [Lodash' `isEqual()`](https://lodash.com/docs/4.17.4#isEqual):
+
+> Performs a deep comparison between two values to determine if they are equivalent.
+>
+> *Note*: This method supports comparing arrays, array buffers, booleans, date objects, error objects, maps, numbers, `Object` objects, regexes, sets, strings, symbols, and typed arrays. `Object` objects are compared by their own, not inherited, enumerable properties. Functions and DOM nodes are compared by strict equality, i.e. `===`.
 
 ### `.notDeepEqual(value, expected, [message])`
 
-Assert that `value` is not deep equal to `expected`.
+Assert that `value` is not deep equal to `expected`. The inverse of `.deepEqual()`.
 
 ### `.throws(function|promise, [error, [message]])`
 

--- a/test/serialize-error.js
+++ b/test/serialize-error.js
@@ -8,6 +8,7 @@ const serialize = require('../lib/serialize-error');
 
 function serializeValue(value) {
 	return prettyFormat(value, {
+		callToJSON: false,
 		plugins: [reactTestPlugin],
 		highlight: true
 	});
@@ -91,5 +92,31 @@ test('skip actual and expected if output is off', t => {
 	t.notOk(serializedErr.expected);
 	t.notOk(serializedErr.actualType);
 	t.notOk(serializedErr.expectedType);
+	t.end();
+});
+
+test('does not call toJSON() when serializing actual and expected', t => {
+	const err = Object.assign(new Error(), {
+		showOutput: true,
+		actual: {
+			foo: 'bar',
+			toJSON() {
+				return {
+					foo: 'BAR'
+				};
+			}
+		},
+		expected: {
+			foo: 'thud',
+			toJSON() {
+				return {
+					foo: 'BAR'
+				};
+			}
+		}
+	});
+
+	const serializedErr = serialize(err);
+	t.notSame(serializedErr.actual, serializedErr.expected);
 	t.end();
 });


### PR DESCRIPTION
Fixes #1233. Our assertions don't call toJSON(), so we shouldn't use it either when displaying actual and expected values.

Also:

* Bump `@ava/pretty-format` to include bug fixes
* Document that `deepEqual()` uses `lodash.isequal`