### PR TITLE
Fix Babel require hook test for Node.js 7.6.0

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -129,13 +129,13 @@ test('improper use of t.throws from within an async callback will be reported to
 	});
 });
 
-test('babel require hook only applies to the test file', t => {
+test('babel require hook only does not apply to source files', t => {
 	t.plan(3);
 
 	execCli('fixture/babel-hook.js', (err, stdout, stderr) => {
 		t.ok(err);
 		t.is(err.code, 1);
-		t.match(stderr, /Unexpected token/);
+		t.match(stderr, /Unexpected (token|reserved word)/);
 		t.end();
 	});
 });

--- a/test/fixture/babel-hook-imported.js
+++ b/test/fixture/babel-hook-imported.js
@@ -1,1 +1,1 @@
-module.export = async () => {};
+export default () => {};


### PR DESCRIPTION
Node.js 7.6.0 supports async / await so the test doesn't throw an exception. Use the unsupported module syntax instead.
