### PR TITLE
Use `diff-match-patch` for text diffs

### DIFF
--- a/lib/format-assert-error.js
+++ b/lib/format-assert-error.js
@@ -2,6 +2,7 @@
 const indentString = require('indent-string');
 const chalk = require('chalk');
 const diff = require('diff');
+const DiffMatchPatch = require('diff-match-patch');
 
 const cleanUp = line => {
 	if (line[0] === '+') {
@@ -45,18 +46,19 @@ module.exports = err => {
 	}
 
 	if (err.actualType === 'string' && err.expectedType === 'string') {
-		const patch = diff.diffChars(err.actual, err.expected);
+		const diffMatchPatch = new DiffMatchPatch();
+		const patch = diffMatchPatch.diff_main(err.actual, err.expected);
 		const msg = patch
 			.map(part => {
-				if (part.added) {
-					return chalk.bgGreen.black(part.value);
+				if (part[0] === 1) {
+					return chalk.bgGreen.black(part[1]);
 				}
 
-				if (part.removed) {
-					return chalk.bgRed.black(part.value);
+				if (part[0] === -1) {
+					return chalk.bgRed.black(part[1]);
 				}
 
-				return part.value;
+				return part[1];
 			})
 			.join('');
 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "currently-unhandled": "^0.4.1",
     "debug": "^2.2.0",
     "diff": "^3.0.1",
+    "diff-match-patch": "^1.0.0",
     "dot-prop": "^4.1.0",
     "empower-core": "^0.6.1",
     "equal-length": "^1.0.0",


### PR DESCRIPTION
Resolves https://github.com/avajs/ava/issues/1280

`diff` is really slow for large strings. This just swaps out the `diff` npm package for `diff-match-patch` which is waaaay quicker. Down from ~20mins to ~1.5s in the linked issue.