### PR TITLE
Fix string diff colours

### DIFF
--- a/lib/format-assert-error.js
+++ b/lib/format-assert-error.js
@@ -1,5 +1,6 @@
 'use strict';
 const indentString = require('indent-string');
+const stripAnsi = require('strip-ansi');
 const chalk = require('chalk');
 const diff = require('diff');
 
@@ -45,7 +46,7 @@ module.exports = err => {
 	}
 
 	if (err.actualType === 'string' && err.expectedType === 'string') {
-		const patch = diff.diffChars(err.actual, err.expected);
+		const patch = diff.diffChars(stripAnsi(err.actual), stripAnsi(err.expected));
 		const msg = patch
 			.map(part => {
 				if (part.added) {
@@ -56,7 +57,7 @@ module.exports = err => {
 					return chalk.bgRed.black(part.value);
 				}
 
-				return part.value;
+				return chalk.red(part.value);
 			})
 			.join('');
 

--- a/test/format-assert-error.js
+++ b/test/format-assert-error.js
@@ -72,7 +72,7 @@ test('diff strings', t => {
 
 	t.is(format(err), [
 		'Difference:\n',
-		`ab${chalk.bgRed.black('c')}${chalk.bgGreen.black('d')}\n`
+		`${chalk.red('ab')}${chalk.bgRed.black('c')}${chalk.bgGreen.black('d')}\n`
 	].join('\n'));
 	t.end();
 });


### PR DESCRIPTION
Make sure all string diff output is red by default.

Resolves https://github.com/avajs/ava/issues/1286