### PR TITLE
[Bug report] Add tests for observable-support: rxjs, xstream, most

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,9 +177,11 @@
     "inquirer": "^3.0.5",
     "is-array-sorted": "^1.0.0",
     "lolex": "^1.4.0",
+    "most": "^1.2.2",
     "nyc": "^10.0.0",
     "proxyquire": "^1.7.4",
     "rimraf": "^2.5.0",
+    "rxjs": "^5.2.0",
     "signal-exit": "^3.0.0",
     "sinon": "^2.0.0",
     "source-map-fixtures": "^2.1.0",
@@ -187,6 +189,7 @@
     "temp-write": "^3.1.0",
     "touch": "^1.0.0",
     "xo": "^0.18.0",
+    "xstream": "^10.3.0",
     "zen-observable": "^0.5.1"
   },
   "xo": {

--- a/test/observable.js
+++ b/test/observable.js
@@ -136,12 +136,13 @@ Observable.of('zen-observable').subscribe(logger);
  * @param ctor {(x) => Observable}
  */
 function detects(name, ctor) {
-	test(`detects ${name} observables`, t => {
+	test(`ava detects ${name} observable as a return value`, t => {
 		ava(a => {
 			a.plan(1);
-
 			const observable = ctor(1);
-			observable.subscribe(x => a.is(x, 1));
+			observable.subscribe({
+				next: x => a.is(x, 1)
+			});
 			return observable;
 		}).run().then(result => {
 			t.is(result.passed, true);


### PR DESCRIPTION
Ava's [observable support](https://github.com/avajs/ava#observable-support) works well for `xen-observable` and `rxjs`, but doesn't work for `xstream` and `most.js`.

There are two reasons for this.
Firstly, 'xstream' and 'most' observables don't have `.forEach()` method. This could be solved by sindresorhus/observable-to-promise#4.
Secondly, 'xstream' and 'most.js' observables are not detected by `isObservable()` function at [`lib/test.js::onAssertionEvent()`](https://github.com/avajs/ava/blob/157ef25aff0bae7145a6133928d2bdd0da853a78/lib/test.js#L75) and at [`lib/test.js::run()`](https://github.com/avajs/ava/blob/157ef25aff0bae7145a6133928d2bdd0da853a78/lib/test.js#L231).

At the same time `isObservable` detects them successfully in observable-to-promise project (see the tests in [PR#4](https://github.com/sindresorhus/observable-to-promise/pull/4))