### PR TITLE
Separate config keys from CLI flags

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,7 +21,7 @@ const babelConfigHelper = require('./babel-config');
 Promise.longStackTraces();
 
 exports.run = () => {
-	const conf = pkgConf.sync('ava');
+	let conf = pkgConf.sync('ava');
 
 	const filepath = pkgConf.filepath(conf);
 	const projectDir = filepath === null ? process.cwd() : path.dirname(filepath);
@@ -72,7 +72,21 @@ exports.run = () => {
 			'update-snapshots',
 			'color'
 		],
-		default: Object.assign({color: true}, conf),
+		default: {
+			init: conf.init,
+			failFast: conf.failFast,
+			serial: conf.serial,
+			cache: conf.cache,
+			powerAssert: conf.powerAssert,
+			tap: conf.tap,
+			verbose: conf.verbose,
+			watch: conf.watch,
+			match: conf.match,
+			timeout: conf.timeout,
+			concurrency: conf.concurrency,
+			updateSnapshots: conf.updateSnapshots,
+			color: true || conf.color
+		},
 		alias: {
 			t: 'tap',
 			v: 'verbose',
@@ -107,31 +121,34 @@ exports.run = () => {
 		throw new Error(colors.error(figures.cross) + ' The --require and -r flags are deprecated. Requirements should be configured in package.json - see documentation.');
 	}
 
+	// copy resultant cli.flags into conf for use with Api and elsewhere
+	conf = Object.assign(conf, cli.flags);
+
 	const api = new Api({
-		failFast: cli.flags.failFast,
-		serial: cli.flags.serial,
+		failFast: conf.failFast,
+		serial: conf.serial,
 		require: arrify(conf.require),
-		cacheEnabled: cli.flags.cache !== false,
-		powerAssert: cli.flags.powerAssert !== false,
-		explicitTitles: cli.flags.watch,
-		match: arrify(cli.flags.match),
+		cacheEnabled: conf.cache !== false,
+		powerAssert: conf.powerAssert !== false,
+		explicitTitles: conf.watch,
+		match: arrify(conf.match),
 		babelConfig: babelConfigHelper.validate(conf.babel),
 		resolveTestsFrom: cli.input.length === 0 ? projectDir : process.cwd(),
 		projectDir,
-		timeout: cli.flags.timeout,
-		concurrency: cli.flags.concurrency ? parseInt(cli.flags.concurrency, 10) : 0,
-		updateSnapshots: cli.flags.updateSnapshots,
-		color: cli.flags.color
+		timeout: conf.timeout,
+		concurrency: conf.concurrency ? parseInt(conf.concurrency, 10) : 0,
+		updateSnapshots: conf.updateSnapshots,
+		color: conf.color
 	});
 
 	let reporter;
 
-	if (cli.flags.tap && !cli.flags.watch) {
+	if (conf.tap && !conf.watch) {
 		reporter = new TapReporter();
-	} else if (cli.flags.verbose || isCi) {
-		reporter = new VerboseReporter({color: cli.flags.color});
+	} else if (conf.verbose || isCi) {
+		reporter = new VerboseReporter({color: conf.color});
 	} else {
-		reporter = new MiniReporter({color: cli.flags.color, watching: cli.flags.watch});
+		reporter = new MiniReporter({color: conf.color, watching: conf.watch});
 	}
 
 	reporter.api = api;
@@ -150,7 +167,7 @@ exports.run = () => {
 
 	const files = cli.input.length ? cli.input : arrify(conf.files);
 
-	if (cli.flags.watch) {
+	if (conf.watch) {
 		try {
 			const watcher = new Watcher(logger, api, files, arrify(conf.source));
 			watcher.observeStdin(process.stdin);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,7 +21,7 @@ const babelConfigHelper = require('./babel-config');
 Promise.longStackTraces();
 
 exports.run = () => {
-	let conf = pkgConf.sync('ava');
+	const conf = pkgConf.sync('ava');
 
 	const filepath = pkgConf.filepath(conf);
 	const projectDir = filepath === null ? process.cwd() : path.dirname(filepath);
@@ -73,19 +73,19 @@ exports.run = () => {
 			'color'
 		],
 		default: {
-			init: conf.init,
-			failFast: conf.failFast,
-			serial: conf.serial,
 			cache: conf.cache,
-			powerAssert: conf.powerAssert,
-			tap: conf.tap,
-			verbose: conf.verbose,
-			watch: conf.watch,
-			match: conf.match,
-			timeout: conf.timeout,
+			color: 'color' in conf ? conf.color : true,
 			concurrency: conf.concurrency,
+			failFast: conf.failFast,
+			init: conf.init,
+			match: conf.match,
+			powerAssert: conf.powerAssert,
+			serial: conf.serial,
+			tap: conf.tap,
+			timeout: conf.timeout,
 			updateSnapshots: conf.updateSnapshots,
-			color: true || conf.color
+			verbose: conf.verbose,
+			watch: conf.watch
 		},
 		alias: {
 			t: 'tap',
@@ -122,7 +122,7 @@ exports.run = () => {
 	}
 
 	// copy resultant cli.flags into conf for use with Api and elsewhere
-	conf = Object.assign(conf, cli.flags);
+	Object.assign(conf, cli.flags);
 
 	const api = new Api({
 		failFast: conf.failFast,


### PR DESCRIPTION
Fixes #1046 

This separates out package config keys from CLI flags by picking up defaults from `conf` and passing them to `meow` as defaults. Furthermore, the resultant `cli.flags` is copied back `conf` so that it can be used elsewhere (instead of `cli.flags`).

@novemberborn The changes have been made as per our discussion about the same. Let me know if something doesn't seems like fitting in right!