### PR TITLE
Refactor assertions

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -63,7 +63,7 @@ type AssertContext = {
 	};
 	// Assert that function doesn't throw an error or promise resolves.
 	notThrows: {
-		<U>(value: PromiseLike<U>, message?: string): Promise<U>;
+		(value: PromiseLike<mixed>, message?: string): Promise<void>;
 		(value: () => mixed, message?: string): void;
 	};
 	// Assert that contents matches regex.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,158 +1,327 @@
 'use strict';
-const assert = require('core-assert');
+const coreAssert = require('core-assert');
 const deepEqual = require('lodash.isequal');
 const observableToPromise = require('observable-to-promise');
 const indentString = require('indent-string');
 const isObservable = require('is-observable');
 const isPromise = require('is-promise');
 const jestSnapshot = require('jest-snapshot');
+const enhanceAssert = require('./enhance-assert');
 const snapshotState = require('./snapshot-state');
 
-const x = module.exports;
-const noop = () => {};
+class AssertionError extends Error {
+	constructor(opts) {
+		super(opts.message || '');
+		this.name = 'AssertionError';
 
-Object.defineProperty(x, 'AssertionError', {value: assert.AssertionError});
+		this.actual = opts.actual;
+		this.assertion = opts.assertion;
+		this.expected = opts.expected;
+		this.hasActual = 'actual' in opts;
+		this.hasExpected = 'expected' in opts;
+		this.operator = opts.operator;
 
-function create(val, expected, operator, msg, fn) {
-	return {
-		actual: val,
-		expected,
-		message: msg || ' ',
-		operator,
-		stackStartFunction: fn
-	};
-}
+		// Reserved for power-assert statements
+		this.statements = null;
 
-function test(ok, opts) {
-	if (!ok) {
-		const err = new assert.AssertionError(opts);
-		err.showOutput = ['fail', 'throws', 'notThrows'].indexOf(err.operator) === -1;
-		throw err;
-	}
-}
-
-x.pass = msg => {
-	test(true, create(true, true, 'pass', msg, x.pass));
-};
-
-x.fail = msg => {
-	msg = msg || 'Test failed via t.fail()';
-	test(false, create(false, false, 'fail', msg, x.fail));
-};
-
-x.truthy = (val, msg) => {
-	test(val, create(val, true, '==', msg, x.truthy));
-};
-
-x.falsy = (val, msg) => {
-	test(!val, create(val, false, '==', msg, x.falsy));
-};
-
-x.true = (val, msg) => {
-	test(val === true, create(val, true, '===', msg, x.true));
-};
-
-x.false = (val, msg) => {
-	test(val === false, create(val, false, '===', msg, x.false));
-};
-
-x.is = (val, expected, msg) => {
-	test(val === expected, create(val, expected, '===', msg, x.is));
-};
-
-x.not = (val, expected, msg) => {
-	test(val !== expected, create(val, expected, '!==', msg, x.not));
-};
-
-x.deepEqual = (val, expected, msg) => {
-	test(deepEqual(val, expected), create(val, expected, '===', msg, x.deepEqual));
-};
-
-x.notDeepEqual = (val, expected, msg) => {
-	test(!deepEqual(val, expected), create(val, expected, '!==', msg, x.notDeepEqual));
-};
-
-x.throws = (fn, err, msg) => {
-	if (isObservable(fn)) {
-		fn = observableToPromise(fn);
-	}
-
-	if (isPromise(fn)) {
-		return fn
-			.then(() => {
-				x.throws(noop, err, msg);
-			}, fnErr => {
-				return x.throws(() => {
-					throw fnErr;
-				}, err, msg);
-			});
-	}
-
-	if (typeof fn !== 'function') {
-		throw new TypeError('t.throws must be called with a function, Promise, or Observable');
-	}
-
-	try {
-		if (typeof err === 'string') {
-			const errMsg = err;
-			err = err => err.message === errMsg;
+		if (opts.stack) {
+			this.stack = opts.stack;
+		} else {
+			Error.captureStackTrace(this, opts.stackStartFunction);
 		}
+	}
+}
+exports.AssertionError = AssertionError;
 
-		let result;
+function wrapAssertions(callbacks) {
+	const pass = callbacks.pass;
+	const pending = callbacks.pending;
+	const fail = callbacks.fail;
 
-		assert.throws(() => {
-			try {
-				fn();
-			} catch (err) {
-				result = err;
-				throw err;
+	const noop = () => {};
+	const makeNoop = () => noop;
+	const makeRethrow = reason => () => {
+		throw reason;
+	};
+
+	const assertions = {
+		pass() {
+			pass(this);
+		},
+
+		fail(message) {
+			fail(this, new AssertionError({
+				assertion: 'fail',
+				message: message || 'Test failed via t.fail()',
+				stackStartFunction: assertions.fail
+			}));
+		},
+
+		is(actual, expected, message) {
+			if (actual === expected) {
+				pass(this);
+			} else {
+				fail(this, new AssertionError({
+					actual,
+					assertion: 'is',
+					expected,
+					message,
+					operator: '===',
+					stackStartFunction: assertions.is
+				}));
 			}
-		}, err, msg);
+		},
 
-		return result;
-	} catch (err) {
-		test(false, create(err.actual, err.expected, 'throws', err.message, x.throws));
-	}
-};
+		not(actual, expected, message) {
+			if (actual === expected) {
+				fail(this, new AssertionError({
+					actual,
+					assertion: 'not',
+					expected,
+					message,
+					operator: '!==',
+					stackStartFunction: assertions.not
+				}));
+			} else {
+				pass(this);
+			}
+		},
 
-x.notThrows = (fn, msg) => {
-	if (isObservable(fn)) {
-		fn = observableToPromise(fn);
-	}
+		deepEqual(actual, expected, message) {
+			if (deepEqual(actual, expected)) {
+				pass(this);
+			} else {
+				fail(this, new AssertionError({
+					actual,
+					assertion: 'deepEqual',
+					expected,
+					message,
+					stackStartFunction: assertions.deepEqual
+				}));
+			}
+		},
 
-	if (isPromise(fn)) {
-		return fn
-			.catch(err => {
-				x.notThrows(() => {
-					throw err;
-				}, msg);
-			});
-	}
+		notDeepEqual(actual, expected, message) {
+			if (deepEqual(actual, expected)) {
+				fail(this, new AssertionError({
+					actual,
+					assertion: 'notDeepEqual',
+					expected,
+					message,
+					stackStartFunction: assertions.notDeepEqual
+				}));
+			} else {
+				pass(this);
+			}
+		},
 
-	if (typeof fn !== 'function') {
-		throw new TypeError('t.notThrows must be called with a function, Promise, or Observable');
-	}
+		throws(fn, err, message) {
+			let promise;
+			if (isPromise(fn)) {
+				promise = fn;
+			} else if (isObservable(fn)) {
+				promise = observableToPromise(fn);
+			} else if (typeof fn !== 'function') {
+				throw new TypeError('t.throws must be called with a function, Promise, or Observable');
+			}
 
-	try {
-		assert.doesNotThrow(fn, msg);
-	} catch (err) {
-		test(false, create(err.actual, err.expected, 'notThrows', err.message, x.notThrows));
-	}
-};
+			let coreAssertThrowsErrorArg;
+			if (typeof err === 'string') {
+				const expectedMessage = err;
+				coreAssertThrowsErrorArg = error => error.message === expectedMessage;
+			} else {
+				// Assume it's a constructor function or regular expression
+				coreAssertThrowsErrorArg = err;
+			}
 
-x.regex = (contents, regex, msg) => {
-	test(regex.test(contents), create(regex, contents, '===', msg, x.regex));
-};
+			const test = fn => {
+				try {
+					let retval;
+					coreAssert.throws(() => {
+						try {
+							fn();
+						} catch (err) {
+							retval = err;
+							throw err;
+						}
+					}, coreAssertThrowsErrorArg);
+					return retval;
+				} catch (err) {
+					throw new AssertionError({
+						assertion: 'throws',
+						message,
+						stackStartFunction: assertions.throws
+					});
+				}
+			};
 
-x.notRegex = (contents, regex, msg) => {
-	test(!regex.test(contents), create(regex, contents, '!==', msg, x.notRegex));
-};
+			if (promise) {
+				const result = promise.then(makeNoop, makeRethrow).then(test);
+				pending(this, result);
+				return result;
+			}
 
-x.ifError = (err, msg) => {
-	test(!err, create(err, 'Error', '!==', msg, x.ifError));
-};
+			try {
+				const retval = test(fn);
+				pass(this);
+				return retval;
+			} catch (err) {
+				fail(this, err);
+			}
+		},
 
-x._snapshot = function (tree, optionalMessage, match, snapshotStateGetter) {
+		notThrows(fn, message) {
+			let promise;
+			if (isPromise(fn)) {
+				promise = fn;
+			} else if (isObservable(fn)) {
+				promise = observableToPromise(fn);
+			} else if (typeof fn !== 'function') {
+				throw new TypeError('t.notThrows must be called with a function, Promise, or Observable');
+			}
+
+			const test = fn => {
+				try {
+					coreAssert.doesNotThrow(fn);
+				} catch (err) {
+					throw new AssertionError({
+						actual: err.actual,
+						assertion: 'notThrows',
+						message,
+						stackStartFunction: assertions.notThrows
+					});
+				}
+			};
+
+			if (promise) {
+				const result = promise
+					.then(
+						noop,
+						reason => test(makeRethrow(reason)));
+				pending(this, result);
+				return result;
+			}
+
+			try {
+				test(fn);
+				pass(this);
+			} catch (err) {
+				fail(this, err);
+			}
+		},
+
+		ifError(actual, message) {
+			if (actual) {
+				fail(this, new AssertionError({
+					actual,
+					assertion: 'ifError',
+					message,
+					stackStartFunction: assertions.ifError
+				}));
+			} else {
+				pass(this);
+			}
+		},
+
+		snapshot(actual, optionalMessage) {
+			const result = snapshot(this, actual, optionalMessage);
+			if (result.pass) {
+				pass(this);
+			} else {
+				fail(this, new AssertionError({
+					actual,
+					assertion: 'snapshot',
+					expected: result.expected,
+					message: result.message,
+					stackStartFunction: assertions.snapshot
+				}));
+			}
+		}
+	};
+
+	const enhancedAssertions = enhanceAssert(pass, fail, {
+		truthy(actual, message) {
+			if (!actual) {
+				throw new AssertionError({
+					actual,
+					assertion: 'truthy',
+					expected: true,
+					message,
+					operator: '==',
+					stackStartFunction: enhancedAssertions.truthy
+				});
+			}
+		},
+
+		falsy(actual, message) {
+			if (actual) {
+				throw new AssertionError({
+					actual,
+					assertion: 'falsy',
+					expected: false,
+					message,
+					operator: '==',
+					stackStartFunction: enhancedAssertions.falsy
+				});
+			}
+		},
+
+		true(actual, message) {
+			if (actual !== true) {
+				throw new AssertionError({
+					actual,
+					assertion: 'true',
+					expected: true,
+					message,
+					operator: '===',
+					stackStartFunction: enhancedAssertions.true
+				});
+			}
+		},
+
+		false(actual, message) {
+			if (actual !== false) {
+				throw new AssertionError({
+					actual,
+					assertion: 'false',
+					expected: false,
+					message,
+					operator: '===',
+					stackStartFunction: enhancedAssertions.false
+				});
+			}
+		},
+
+		regex(actual, expected, message) {
+			if (!expected.test(actual)) {
+				throw new AssertionError({
+					actual,
+					assertion: 'regex',
+					expected,
+					message,
+					stackStartFunction: enhancedAssertions.regex
+				});
+			}
+		},
+
+		notRegex(actual, expected, message) {
+			if (expected.test(actual)) {
+				throw new AssertionError({
+					actual,
+					assertion: 'notRegex',
+					expected,
+					message,
+					stackStartFunction: enhancedAssertions.notRegex
+				});
+			}
+		}
+	});
+
+	return Object.assign(assertions, enhancedAssertions);
+}
+exports.wrapAssertions = wrapAssertions;
+
+function snapshot(executionContext, tree, optionalMessage, match, snapshotStateGetter) {
 	// Set defaults - this allows tests to mock deps easily
 	const toMatchSnapshot = match || jestSnapshot.toMatchSnapshot;
 	const getState = snapshotStateGetter || snapshotState.get;
@@ -161,7 +330,7 @@ x._snapshot = function (tree, optionalMessage, match, snapshotStateGetter) {
 
 	const context = {
 		dontThrow() {},
-		currentTestName: this.title,
+		currentTestName: executionContext.title,
 		snapshotState: state
 	};
 
@@ -191,9 +360,10 @@ x._snapshot = function (tree, optionalMessage, match, snapshotStateGetter) {
 		}
 	}
 
-	test(result.pass, create(tree, expected, 'snapshot', message, x.snapshot));
-};
-
-x.snapshot = function (tree, optionalMessage) {
-	x._snapshot.call(this, tree, optionalMessage);
-};
+	return {
+		pass: result.pass,
+		expected,
+		message
+	};
+}
+exports.snapshot = snapshot;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -122,7 +122,11 @@ function wrapAssertions(callbacks) {
 			} else if (isObservable(fn)) {
 				promise = observableToPromise(fn);
 			} else if (typeof fn !== 'function') {
-				throw new TypeError('t.throws must be called with a function, Promise, or Observable');
+				fail(this, new AssertionError({
+					actual: fn,
+					message: '`t.throws()` must be called with a function, Promise, or Observable'
+				}));
+				return;
 			}
 
 			let coreAssertThrowsErrorArg;
@@ -177,7 +181,11 @@ function wrapAssertions(callbacks) {
 			} else if (isObservable(fn)) {
 				promise = observableToPromise(fn);
 			} else if (typeof fn !== 'function') {
-				throw new TypeError('t.notThrows must be called with a function, Promise, or Observable');
+				fail(this, new AssertionError({
+					actual: fn,
+					message: '`t.notThrows()` must be called with a function, Promise, or Observable'
+				}));
+				return;
 			}
 
 			const test = fn => {

--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -13,33 +13,6 @@ const PATTERNS = [
 	't.notRegex(contents, regex, [message])'
 ];
 
-const NON_ENHANCED_PATTERNS = [
-	't.pass([message])',
-	't.fail([message])',
-	't.throws(fn, [message])',
-	't.notThrows(fn, [message])',
-	't.ifError(error, [message])',
-	't.snapshot(contents, [message])',
-	't.is(value, expected, [message])',
-	't.not(value, expected, [message])',
-	't.deepEqual(value, expected, [message])',
-	't.notDeepEqual(value, expected, [message])'
-];
-
-const enhanceAssert = opts => {
-	const empower = require('empower-core');
-	const enhanced = empower(opts.assert, {
-		destructive: false,
-		onError: opts.onError,
-		onSuccess: opts.onSuccess,
-		patterns: PATTERNS,
-		wrapOnlyPatterns: NON_ENHANCED_PATTERNS,
-		bindReceiver: false
-	});
-
-	return enhanced;
-};
-
 const isRangeMatch = (a, b) => {
 	return (a[0] === b[0] && a[1] === b[1]) ||
 		(a[0] > b[0] && a[0] < b[1]) ||
@@ -55,22 +28,33 @@ const computeStatement = (tokens, range) => {
 
 const getNode = (ast, path) => dotProp.get(ast, path.replace(/\//g, '.'));
 
-const formatter = () => {
-	return context => {
-		const ast = JSON.parse(context.source.ast);
-		const tokens = JSON.parse(context.source.tokens);
-		const args = context.args[0].events;
+const formatter = context => {
+	const ast = JSON.parse(context.source.ast);
+	const tokens = JSON.parse(context.source.tokens);
+	const args = context.args[0].events;
 
-		return args
-			.map(arg => {
-				const range = getNode(ast, arg.espath).range;
-				return [computeStatement(tokens, range), arg.value];
-			})
-			.reverse();
-	};
+	return args
+		.map(arg => {
+			const range = getNode(ast, arg.espath).range;
+			return [computeStatement(tokens, range), arg.value];
+		})
+		.reverse();
 };
 
+const enhanceAssert = (pass, fail, assertions) => {
+	const empower = require('empower-core');
+	return empower(assertions, {
+		destructive: true,
+		onError(event) {
+			const error = event.error;
+			error.statements = formatter(event.powerAssertContext);
+			fail(this, error);
+		},
+		onSuccess() {
+			pass(this);
+		},
+		patterns: PATTERNS,
+		bindReceiver: false
+	});
+};
 module.exports = enhanceAssert;
-module.exports.PATTERNS = PATTERNS;
-module.exports.NON_ENHANCED_PATTERNS = NON_ENHANCED_PATTERNS;
-module.exports.formatter = formatter;

--- a/lib/format-assert-error.js
+++ b/lib/format-assert-error.js
@@ -66,10 +66,16 @@ module.exports = err => {
 		return `Difference:\n\n${msg}\n`;
 	}
 
-	return [
-		'Actual:\n',
-		`${indentString(err.actual, 2)}\n`,
-		'Expected:\n',
-		`${indentString(err.expected, 2)}\n`
-	].join('\n');
+	if (typeof err.actual === 'string' && typeof err.expected === 'string') {
+		return `Actual:
+
+${indentString(err.actual, 2)}
+
+Expected:
+
+${indentString(err.expected, 2)}
+`;
+	}
+
+	return null;
 };

--- a/lib/format-assert-error.js
+++ b/lib/format-assert-error.js
@@ -34,47 +34,55 @@ module.exports = error => {
 			.join('\n\n') + '\n';
 	}
 
-	if (error.actual && error.expected) {
-		if (error.actual.type === error.expected.type) {
-			const type = error.actual.type;
-			if (type === 'array' || type === 'object') {
-				const patch = diff.createPatch('string', error.actual.formatted, error.expected.formatted);
-				const msg = patch
-					.split('\n')
-					.slice(4)
-					.map(cleanUp)
-					.filter(Boolean)
-					.join('\n')
-					.trimRight();
+	if (error.actual && error.expected && error.actual.type === error.expected.type) {
+		const type = error.actual.type;
+		if (type === 'array' || type === 'object') {
+			const patch = diff.createPatch('string', error.actual.formatted, error.expected.formatted);
+			const msg = patch
+				.split('\n')
+				.slice(4)
+				.map(cleanUp)
+				.filter(Boolean)
+				.join('\n')
+				.trimRight();
 
-				return `Difference:\n\n${msg}\n`;
-			}
-
-			if (type === 'string') {
-				const diffMatchPatch = new DiffMatchPatch();
-				const patch = diffMatchPatch.diff_main(stripAnsi(error.actual.formatted), stripAnsi(error.expected.formatted));
-				const msg = patch
-					.map(part => {
-						if (part[0] === 1) {
-							return chalk.bgGreen.black(part[1]);
-						}
-
-						if (part[0] === -1) {
-							return chalk.bgRed.black(part[1]);
-						}
-
-						return chalk.red(part[1]);
-					})
-					.join('')
-					.trimRight();
-
-				return `Difference:\n\n${msg}\n`;
-			}
+			return `Difference:\n\n${msg}\n`;
 		}
 
-		return `Actual:\n\n${indentString(error.actual.formatted, 2).trimRight()}\n\n` +
-			`Expected:\n\n${indentString(error.expected.formatted, 2).trimRight()}\n`;
+		if (type === 'string') {
+			const diffMatchPatch = new DiffMatchPatch();
+			const patch = diffMatchPatch.diff_main(stripAnsi(error.actual.formatted), stripAnsi(error.expected.formatted));
+			const msg = patch
+				.map(part => {
+					if (part[0] === 1) {
+						return chalk.bgGreen.black(part[1]);
+					}
+
+					if (part[0] === -1) {
+						return chalk.bgRed.black(part[1]);
+					}
+
+					return chalk.red(part[1]);
+				})
+				.join('')
+				.trimRight();
+
+			return `Difference:\n\n${msg}\n`;
+		}
 	}
 
-	return null;
+	let retval = null;
+	if (error.actual) {
+		retval = `Actual:\n\n${indentString(error.actual.formatted, 2).trimRight()}\n`;
+	}
+	if (error.expected) {
+		if (retval) {
+			retval += '\n';
+		} else {
+			retval = '';
+		}
+		retval += `Expected:\n\n${indentString(error.expected.formatted, 2).trimRight()}\n`;
+	}
+
+	return retval;
 };

--- a/lib/format-assert-error.js
+++ b/lib/format-assert-error.js
@@ -25,56 +25,55 @@ const cleanUp = line => {
 	return ` ${line}`;
 };
 
-module.exports = err => {
-	if (err.statements) {
-		const statements = JSON.parse(err.statements);
+module.exports = error => {
+	if (error.statements) {
+		const statements = JSON.parse(error.statements);
 
 		return statements
 			.map(statement => `${statement[0]}\n${chalk.grey('=>')} ${statement[1]}`)
 			.join('\n\n') + '\n';
 	}
 
-	if ((err.actualType === 'object' || err.actualType === 'array') && err.actualType === err.expectedType) {
-		const patch = diff.createPatch('string', err.actual, err.expected);
-		const msg = patch
-			.split('\n')
-			.slice(4)
-			.map(cleanUp)
-			.filter(Boolean)
-			.join('\n');
+	if (error.actual && error.expected) {
+		if (error.actual.type === error.expected.type) {
+			const type = error.actual.type;
+			if (type === 'array' || type === 'object') {
+				const patch = diff.createPatch('string', error.actual.formatted, error.expected.formatted);
+				const msg = patch
+					.split('\n')
+					.slice(4)
+					.map(cleanUp)
+					.filter(Boolean)
+					.join('\n')
+					.trimRight();
 
-		return `Difference:\n\n${msg}`;
-	}
+				return `Difference:\n\n${msg}\n`;
+			}
 
-	if (err.actualType === 'string' && err.expectedType === 'string') {
-		const diffMatchPatch = new DiffMatchPatch();
-		const patch = diffMatchPatch.diff_main(stripAnsi(err.actual), stripAnsi(err.expected));
-		const msg = patch
-			.map(part => {
-				if (part[0] === 1) {
-					return chalk.bgGreen.black(part[1]);
-				}
+			if (type === 'string') {
+				const diffMatchPatch = new DiffMatchPatch();
+				const patch = diffMatchPatch.diff_main(stripAnsi(error.actual.formatted), stripAnsi(error.expected.formatted));
+				const msg = patch
+					.map(part => {
+						if (part[0] === 1) {
+							return chalk.bgGreen.black(part[1]);
+						}
 
-				if (part[0] === -1) {
-					return chalk.bgRed.black(part[1]);
-				}
+						if (part[0] === -1) {
+							return chalk.bgRed.black(part[1]);
+						}
 
-				return chalk.red(part[1]);
-			})
-			.join('');
+						return chalk.red(part[1]);
+					})
+					.join('')
+					.trimRight();
 
-		return `Difference:\n\n${msg}\n`;
-	}
+				return `Difference:\n\n${msg}\n`;
+			}
+		}
 
-	if (typeof err.actual === 'string' && typeof err.expected === 'string') {
-		return `Actual:
-
-${indentString(err.actual, 2)}
-
-Expected:
-
-${indentString(err.expected, 2)}
-`;
+		return `Actual:\n\n${indentString(error.actual.formatted, 2).trimRight()}\n\n` +
+			`Expected:\n\n${indentString(error.expected.formatted, 2).trimRight()}\n`;
 	}
 
 	return null;

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -191,9 +191,11 @@ class MiniReporter {
 					}
 				}
 
-				const formatted = formatAssertError(test.error);
-				if (formatted) {
-					status += '\n' + indentString(formatted, 2);
+				if (test.error.avaAssertionError) {
+					const formatted = formatAssertError(test.error);
+					if (formatted) {
+						status += '\n' + indentString(formatted, 2);
+					}
 				}
 
 				if (test.error.message) {

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -179,10 +179,9 @@ class MiniReporter {
 					return;
 				}
 
-				const title = test.error ? test.title : 'Unhandled Error';
 				const beforeSpacing = index === 0 ? '\n\n' : '\n\n\n\n';
 
-				status += beforeSpacing + '  ' + colors.title(title) + '\n';
+				status += beforeSpacing + '  ' + colors.title(test.title) + '\n';
 				if (test.error.source) {
 					status += '  ' + colors.errorSource(test.error.source.file + ':' + test.error.source.line) + '\n';
 

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -192,12 +192,12 @@ class MiniReporter {
 					}
 				}
 
-				if (test.error.showOutput) {
-					status += '\n' + indentString(formatAssertError(test.error), 2);
+				const formatted = formatAssertError(test.error);
+				if (formatted) {
+					status += '\n' + indentString(formatted, 2);
 				}
 
-				// `.trim()` is needed, because default `err.message` is ' ' (see lib/assert.js)
-				if (test.error.message.trim()) {
+				if (test.error.message) {
 					status += '\n' + indentString(test.error.message, 2) + '\n';
 				}
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -11,25 +11,29 @@ function getSourceFromStack(stack) {
 }
 
 function dumpError(error, includeMessage) {
-	const obj = {};
+	const obj = Object.assign({}, error.object);
 	if (error.name) {
 		obj.name = error.name;
 	}
 	if (includeMessage && error.message) {
 		obj.message = error.message;
 	}
-	if (error.assertion) {
-		obj.assertion = error.assertion;
+
+	if (error.avaAssertionError) {
+		if (error.assertion) {
+			obj.assertion = error.assertion;
+		}
+		if (error.operator) {
+			obj.operator = error.operator;
+		}
+		if (error.actual) {
+			obj.actual = stripAnsi(error.actual.formatted);
+		}
+		if (error.expected) {
+			obj.expected = stripAnsi(error.expected.formatted);
+		}
 	}
-	if (error.operator) {
-		obj.operator = error.operator;
-	}
-	if (typeof error.actual === 'string') { // Be sure to print empty strings, which are falsy
-		obj.actual = stripAnsi(error.actual);
-	}
-	if (typeof error.expected === 'string') { // Be sure to print empty strings, which are falsy
-		obj.expected = stripAnsi(error.expected);
-	}
+
 	if (error.stack) {
 		obj.at = getSourceFromStack(error.stack);
 	}

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -18,6 +18,9 @@ function dumpError(error, includeMessage) {
 	if (includeMessage && error.message) {
 		obj.message = error.message;
 	}
+	if (error.assertion) {
+		obj.assertion = error.assertion;
+	}
 	if (error.operator) {
 		obj.operator = error.operator;
 	}

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -111,12 +111,12 @@ class VerboseReporter {
 					}
 				}
 
-				if (test.error.showOutput) {
-					output += '\n' + indentString(formatAssertError(test.error), 2);
+				const formatted = formatAssertError(test.error);
+				if (formatted) {
+					output += '\n' + indentString(formatted, 2);
 				}
 
-				// `.trim()` is needed, because default `err.message` is ' ' (see lib/assert.js)
-				if (test.error.message.trim()) {
+				if (test.error.message) {
 					output += '\n' + indentString(test.error.message, 2) + '\n';
 				}
 

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -111,9 +111,11 @@ class VerboseReporter {
 					}
 				}
 
-				const formatted = formatAssertError(test.error);
-				if (formatted) {
-					output += '\n' + indentString(formatted, 2);
+				if (test.error.avaAssertionError) {
+					const formatted = formatAssertError(test.error);
+					if (formatted) {
+						output += '\n' + indentString(formatted, 2);
+					}
 				}
 
 				if (test.error.message) {

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -1,7 +1,6 @@
 'use strict';
 const EventEmitter = require('events');
 const chalk = require('chalk');
-const isObj = require('is-obj');
 const flatten = require('arr-flatten');
 const figures = require('figures');
 const autoBind = require('auto-bind');
@@ -15,16 +14,6 @@ function sum(arr, key) {
 	});
 
 	return result;
-}
-
-function normalizeError(err) {
-	if (!isObj(err) || typeof err.message !== 'string') {
-		err = {
-			message: String(err)
-		};
-	}
-
-	return err;
 }
 
 class RunStatus extends EventEmitter {
@@ -68,7 +57,6 @@ class RunStatus extends EventEmitter {
 		this.rejectionCount += data.rejections.length;
 
 		data.rejections.forEach(err => {
-			err = normalizeError(err);
 			err.type = 'rejection';
 			err.file = data.file;
 			this.emit('error', err, this);
@@ -77,7 +65,7 @@ class RunStatus extends EventEmitter {
 	}
 	handleExceptions(data) {
 		this.exceptionCount++;
-		const err = normalizeError(data.exception);
+		const err = data.exception;
 		err.type = 'exception';
 		err.file = data.file;
 		this.emit('error', err, this);

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -87,10 +87,6 @@ class RunStatus extends EventEmitter {
 		test.title = this.prefixTitle(test.file) + test.title;
 
 		if (test.error) {
-			if (test.error.name !== 'AssertionError') {
-				test.error.message = `Error: ${test.error.message}`;
-			}
-
 			this.errors.push(test);
 		}
 

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -4,6 +4,7 @@ const cleanYamlObject = require('clean-yaml-object');
 const StackUtils = require('stack-utils');
 const prettyFormat = require('@ava/pretty-format');
 const reactTestPlugin = require('@ava/pretty-format/plugins/ReactTestComponent');
+const assert = require('./assert');
 const beautifyStack = require('./beautify-stack');
 const extractStack = require('./extract-stack');
 
@@ -13,6 +14,11 @@ function serializeValue(value) {
 		plugins: [reactTestPlugin],
 		highlight: true
 	});
+}
+
+const assertionsWithoutOutput = new Set(['fail', 'throws', 'notThrows']);
+function isAvaAssertionError(source) {
+	return source instanceof assert.AssertionError && !assertionsWithoutOutput.has(source.assertion);
 }
 
 function filter(propertyName, isRoot, source, target) {
@@ -31,8 +37,8 @@ function filter(propertyName, isRoot, source, target) {
 	}
 
 	if (propertyName === 'statements') {
-		if (source.showOutput) {
-			target.statements = JSON.stringify(source[propertyName].map(statement => {
+		if (isAvaAssertionError(source) && source.statements) {
+			target.statements = JSON.stringify(source.statements.map(statement => {
 				const path = statement[0];
 				const value = serializeValue(statement[1]);
 
@@ -44,7 +50,7 @@ function filter(propertyName, isRoot, source, target) {
 	}
 
 	if (propertyName === 'actual' || propertyName === 'expected') {
-		if (source.showOutput) {
+		if (isAvaAssertionError(source)) {
 			const value = source[propertyName];
 			target[propertyName + 'Type'] = typeof value;
 			target[propertyName] = serializeValue(value);

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -16,80 +16,97 @@ function serializeValue(value) {
 	});
 }
 
-const assertionsWithoutOutput = new Set(['fail', 'throws', 'notThrows']);
 function isAvaAssertionError(source) {
-	return source instanceof assert.AssertionError && !assertionsWithoutOutput.has(source.assertion);
+	return source instanceof assert.AssertionError;
 }
 
-function filter(propertyName, isRoot, source, target) {
-	if (!isRoot) {
-		return true;
+function filter(propertyName, isRoot) {
+	return !isRoot || (propertyName !== 'message' && propertyName !== 'name' && propertyName !== 'stack');
+}
+
+const stackUtils = new StackUtils();
+function buildSource(stack) {
+	if (!stack) {
+		return null;
 	}
 
-	if ((propertyName === 'name' || propertyName === 'stack') &&
-		typeof source[propertyName] !== 'string') {
-		return false;
+	const firstStackLine = extractStack(stack).split('\n')[0];
+	const source = stackUtils.parseLine(firstStackLine);
+	if (!source) {
+		return null;
 	}
 
-	if (propertyName === 'stack') {
-		target.stack = beautifyStack(source.stack);
-		return false;
+	// Assume the CWD is the project directory. This holds since this function
+	// is only called in test workers, which are created with their working
+	// directory set to the project directory.
+	const projectDir = process.cwd();
+
+	const file = path.resolve(projectDir, source.file.trim());
+	const rel = path.relative(projectDir, file);
+
+	const isWithinProject = rel.split(path.sep)[0] !== '..';
+	const isDependency = isWithinProject && path.dirname(rel).split(path.sep).indexOf('node_modules') > -1;
+
+	return {
+		isDependency,
+		isWithinProject,
+		file,
+		line: source.line
+	};
+}
+
+module.exports = error => {
+	const stack = typeof error.stack === 'string' ?
+		beautifyStack(error.stack) :
+		null;
+	const source = buildSource(stack);
+	const retval = {
+		avaAssertionError: isAvaAssertionError(error),
+		source
+	};
+	if (stack) {
+		retval.stack = stack;
 	}
 
-	if (propertyName === 'statements') {
-		if (isAvaAssertionError(source) && source.statements) {
-			target.statements = JSON.stringify(source.statements.map(statement => {
+	if (retval.avaAssertionError) {
+		retval.message = error.message;
+		retval.name = error.name;
+
+		if (error.assertion) {
+			retval.assertion = error.assertion;
+		}
+		if (error.operator) {
+			retval.operator = error.operator;
+		}
+		if (error.hasActual) {
+			retval.actual = {
+				type: typeof error.actual,
+				formatted: serializeValue(error.actual)
+			};
+		}
+		if (error.hasExpected) {
+			retval.expected = {
+				type: typeof error.expected,
+				formatted: serializeValue(error.expected)
+			};
+		}
+		if (error.statements) {
+			retval.statements = JSON.stringify(error.statements.map(statement => {
 				const path = statement[0];
 				const value = serializeValue(statement[1]);
 
 				return [path, value];
 			}));
 		}
-
-		return false;
-	}
-
-	if (propertyName === 'actual' || propertyName === 'expected') {
-		if (isAvaAssertionError(source)) {
-			const value = source[propertyName];
-			target[propertyName + 'Type'] = typeof value;
-			target[propertyName] = serializeValue(value);
+	} else {
+		retval.object = cleanYamlObject(error, filter); // Cleanly copy non-standard properties
+		if (typeof error.message === 'string') {
+			retval.message = error.message;
 		}
-
-		return false;
-	}
-
-	return true;
-}
-
-const stackUtils = new StackUtils();
-
-module.exports = error => {
-	const err = cleanYamlObject(error, filter);
-
-	if (err.stack) {
-		const firstStackLine = extractStack(err.stack).split('\n')[0];
-		const source = stackUtils.parseLine(firstStackLine);
-		if (source) {
-			// Assume the CWD is the project directory. This holds since this function
-			// is only called in test workers, which are created with their working
-			// directory set to the project directory.
-			const projectDir = process.cwd();
-
-			const file = path.resolve(projectDir, source.file.trim());
-			const rel = path.relative(projectDir, file);
-
-			const isWithinProject = rel.split(path.sep)[0] !== '..';
-			const isDependency = isWithinProject && path.dirname(rel).split(path.sep).indexOf('node_modules') > -1;
-
-			err.source = {
-				isDependency,
-				isWithinProject,
-				file,
-				line: source.line
-			};
+		if (typeof error.name === 'string') {
+			retval.name = error.name;
 		}
 	}
 
-	return err;
+	return retval;
 };

--- a/lib/test-worker.js
+++ b/lib/test-worker.js
@@ -1,5 +1,6 @@
 'use strict';
 /* eslint-disable import/order */
+const isObj = require('is-obj');
 const process = require('./process-adapter');
 
 const opts = process.opts;
@@ -91,7 +92,13 @@ process.on('ava-teardown', () => {
 	}
 
 	rejections = rejections.map(rejection => {
-		return serializeError(rejection.reason);
+		let reason = rejection.reason;
+		if (!isObj(reason) || typeof reason.message !== 'string') {
+			reason = {
+				message: String(reason)
+			};
+		}
+		return serializeError(reason);
 	});
 
 	send('unhandledRejections', {rejections});

--- a/lib/test-worker.js
+++ b/lib/test-worker.js
@@ -45,6 +45,7 @@ process.on('uncaughtException', exception => {
 		// Avoid using serializeError
 		const err = new Error('Failed to serialize uncaught exception');
 		serialized = {
+			avaAssertionError: false,
 			name: err.name,
 			message: err.message,
 			stack: err.stack

--- a/lib/test.js
+++ b/lib/test.js
@@ -10,25 +10,14 @@ const isPromise = require('is-promise');
 const isObservable = require('is-observable');
 const plur = require('plur');
 const assert = require('./assert');
-const enhanceAssert = require('./enhance-assert');
 const globals = require('./globals');
 const throwsHelper = require('./throws-helper');
-
-const formatter = enhanceAssert.formatter();
 
 class SkipApi {
 	constructor(test) {
 		this._test = test;
 	}
 }
-
-function skipFn() {
-	return this._test._assert(null);
-}
-
-Object.keys(assert).forEach(el => {
-	SkipApi.prototype[el] = skipFn;
-});
 
 class ExecutionContext {
 	constructor(test) {
@@ -64,47 +53,31 @@ class ExecutionContext {
 		contextRef.context = context;
 	}
 }
-
-function onAssertionEvent(event) {
-	if (event.assertionThrew) {
-		if (event.powerAssertContext) {
-			event.error.statements = formatter(event.powerAssertContext);
-			event.error.message = event.originalMessage || '';
-		}
-		this._test._setAssertError(event.error);
-		this._test._assert(null);
-		return null;
-	}
-
-	let ret = event.returnValue;
-
-	if (isObservable(ret)) {
-		ret = observableToPromise(ret);
-	}
-
-	if (isPromise(ret)) {
-		const promise = ret.then(null, err => {
-			err.originalMessage = event.originalMessage;
-			throw err;
-		});
-
-		this._test._assert(promise);
-
-		return promise;
-	}
-
-	this._test._assert(null);
-
-	return ret;
-}
-
-Object.assign(ExecutionContext.prototype, enhanceAssert({
-	assert,
-	onSuccess: onAssertionEvent,
-	onError: onAssertionEvent
-}));
-
 Object.defineProperty(ExecutionContext.prototype, 'context', {enumerable: true});
+
+{
+	const assertions = assert.wrapAssertions({
+		pass(executionContext) {
+			executionContext._test._assertionPassed();
+		},
+
+		pending(executionContext, promise) {
+			executionContext._test._assertionPending(promise);
+		},
+
+		fail(executionContext, error) {
+			executionContext._test._assertionFailed(error);
+		}
+	});
+	Object.assign(ExecutionContext.prototype, assertions);
+
+	function skipFn() {
+		this._test._assertionPassed();
+	}
+	Object.keys(assertions).forEach(el => {
+		SkipApi.prototype[el] = skipFn;
+	});
+}
 
 class Test {
 	constructor(title, fn, contextRef, report) {
@@ -120,7 +93,8 @@ class Test {
 
 		this.title = title || fnName(fn) || '[anonymous]';
 		this.fn = isGeneratorFn(fn) ? co.wrap(fn) : fn;
-		this.assertions = [];
+		this.pendingAssertions = [];
+		this.assertCount = 0;
 		this.planCount = null;
 		this.duration = null;
 		this.assertError = undefined;
@@ -142,15 +116,17 @@ class Test {
 			this.title = '[anonymous]';
 		}
 	}
-	get assertCount() {
-		return this.assertions.length;
+	_assertionPassed() {
+		this.assertCount++;
 	}
-	_assert(promise) {
-		if (isPromise(promise)) {
-			this.sync = false;
-		}
-
-		this.assertions.push(promise);
+	_assertionPending(promise) {
+		this.sync = false;
+		this.assertCount++;
+		this.pendingAssertions.push(promise);
+	}
+	_assertionFailed(error) {
+		this._setAssertError(error);
+		this.assertCount++;
 	}
 	_setAssertError(err) {
 		throwsHelper(err);
@@ -310,15 +286,15 @@ class Test {
 		this.exit();
 	}
 	_checkPlanCount() {
-		if (this.assertError === undefined && this.planCount !== null && this.planCount !== this.assertions.length) {
+		if (this.assertError === undefined && this.planCount !== null && this.planCount !== this.assertCount) {
 			this._setAssertError(new assert.AssertionError({
-				actual: this.assertions.length,
+				actual: this.assertCount,
+				assertion: 'plan',
 				expected: this.planCount,
-				message: `Planned for ${this.planCount} ${plur('assertion', this.planCount)}, but got ${this.assertions.length}.`,
-				operator: 'plan'
+				message: `Planned for ${this.planCount} ${plur('assertion', this.planCount)}, but got ${this.assertCount}.`,
+				operator: '===',
+				stack: this.planStack
 			}));
-
-			this.assertError.stack = this.planStack;
 		}
 	}
 	exit() {
@@ -337,7 +313,7 @@ class Test {
 			return result;
 		}
 
-		Promise.all(this.assertions)
+		Promise.all(this.pendingAssertions)
 			.catch(err => {
 				this._setAssertError(err);
 			})

--- a/lib/test.js
+++ b/lib/test.js
@@ -30,7 +30,7 @@ Object.keys(assert).forEach(el => {
 	SkipApi.prototype[el] = skipFn;
 });
 
-class PublicApi {
+class ExecutionContext {
 	constructor(test) {
 		this._test = test;
 		this.skip = new SkipApi(test);
@@ -98,13 +98,13 @@ function onAssertionEvent(event) {
 	return ret;
 }
 
-Object.assign(PublicApi.prototype, enhanceAssert({
+Object.assign(ExecutionContext.prototype, enhanceAssert({
 	assert,
 	onSuccess: onAssertionEvent,
 	onError: onAssertionEvent
 }));
 
-Object.defineProperty(PublicApi.prototype, 'context', {enumerable: true});
+Object.defineProperty(ExecutionContext.prototype, 'context', {enumerable: true});
 
 class Test {
 	constructor(title, fn, contextRef, report) {
@@ -176,7 +176,7 @@ class Test {
 		let ret;
 
 		try {
-			ret = this.fn(this._publicApi());
+			ret = this.fn(this._createExecutionContext());
 		} catch (err) {
 			this.threwSync = true;
 
@@ -355,8 +355,8 @@ class Test {
 
 		return this.promise().promise;
 	}
-	_publicApi() {
-		return new PublicApi(this);
+	_createExecutionContext() {
+		return new ExecutionContext(this);
 	}
 }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -43,6 +43,12 @@ class PublicApi {
 		Error.stackTraceLimit = limitBefore;
 		this._test.plan(ct, obj.stack);
 	}
+	get end() {
+		return this._test.end;
+	}
+	get title() {
+		return this._test.title;
+	}
 	get context() {
 		const contextRef = this._test.contextRef;
 		return contextRef && contextRef.context;
@@ -97,19 +103,6 @@ Object.assign(PublicApi.prototype, enhanceAssert({
 	onSuccess: onAssertionEvent,
 	onError: onAssertionEvent
 }));
-
-// Getters
-[
-	'title',
-	'end'
-]
-	.forEach(name => {
-		Object.defineProperty(PublicApi.prototype, name, {
-			get() {
-				return this._test[name];
-			}
-		});
-	});
 
 Object.defineProperty(PublicApi.prototype, 'context', {enumerable: true});
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -100,7 +100,6 @@ Object.assign(PublicApi.prototype, enhanceAssert({
 
 // Getters
 [
-	'assertCount',
 	'title',
 	'end'
 ]

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,5 +1,4 @@
 'use strict';
-const inspect = require('util').inspect;
 const isGeneratorFn = require('is-generator-fn');
 const maxTimeout = require('max-timeout');
 const Promise = require('bluebird');
@@ -129,8 +128,6 @@ class Test {
 		this.assertCount++;
 	}
 	_setAssertError(err) {
-		throwsHelper(err);
-
 		if (this.assertError !== undefined) {
 			return;
 		}
@@ -155,16 +152,17 @@ class Test {
 			ret = this.fn(this._createExecutionContext());
 		} catch (err) {
 			this.threwSync = true;
+			throwsHelper(err);
 
-			if (err instanceof Error) {
-				this._setAssertError(err);
-			} else {
-				this._setAssertError(new assert.AssertionError({
+			let error = err;
+			if (!(err instanceof assert.AssertionError)) {
+				error = new assert.AssertionError({
 					actual: err,
-					message: `Non-error thrown with value: ${inspect(err, {depth: null})}`,
-					operator: 'catch'
-				}));
+					message: `Error thrown in test`,
+					stack: err instanceof Error && err.stack
+				});
 			}
+			this._setAssertError(error);
 		}
 
 		return ret;
@@ -214,11 +212,13 @@ class Test {
 			return Promise.resolve(ret).then(
 				() => this.exit(),
 				err => {
-					if (!(err instanceof Error)) {
+					throwsHelper(err);
+
+					if (!(err instanceof assert.AssertionError)) {
 						err = new assert.AssertionError({
 							actual: err,
-							message: `Promise rejected with: ${inspect(err, {depth: null})}`,
-							operator: 'promise'
+							message: 'Rejected promise returned by test',
+							stack: err instanceof Error && err.stack
 						});
 					}
 
@@ -263,11 +263,10 @@ class Test {
 	}
 	_end(err) {
 		if (err) {
-			if (!(err instanceof Error)) {
+			if (!(err instanceof assert.AssertionError)) {
 				err = new assert.AssertionError({
 					actual: err,
-					message: 'Callback called with an error: ' + inspect(err, {depth: null}),
-					operator: 'callback'
+					message: 'Callback called with an error'
 				});
 			}
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -122,7 +122,9 @@ class Test {
 			title = null;
 		}
 
-		assert.is(typeof fn, 'function', 'You must provide a callback');
+		if (typeof fn !== 'function') {
+			throw new Error('You must provide a callback');
+		}
 
 		this.title = title || fnName(fn) || '[anonymous]';
 		this.fn = isGeneratorFn(fn) ? co.wrap(fn) : fn;

--- a/test/assert.js
+++ b/test/assert.js
@@ -3,9 +3,19 @@ const test = require('tap').test;
 const sinon = require('sinon');
 const assert = require('../lib/assert');
 
+const assertions = assert.wrapAssertions({
+	pass() {},
+
+	pending() {},
+
+	fail(_, error) {
+		throw error;
+	}
+});
+
 test('.pass()', t => {
 	t.doesNotThrow(() => {
-		assert.pass();
+		assertions.pass();
 	});
 
 	t.end();
@@ -13,7 +23,7 @@ test('.pass()', t => {
 
 test('.fail()', t => {
 	t.throws(() => {
-		assert.fail();
+		assertions.fail();
 	});
 
 	t.end();
@@ -21,13 +31,13 @@ test('.fail()', t => {
 
 test('.truthy()', t => {
 	t.throws(() => {
-		assert.truthy(0);
-		assert.truthy(false);
+		assertions.truthy(0);
+		assertions.truthy(false);
 	});
 
 	t.doesNotThrow(() => {
-		assert.truthy(1);
-		assert.truthy(true);
+		assertions.truthy(1);
+		assertions.truthy(true);
 	});
 
 	t.end();
@@ -35,13 +45,13 @@ test('.truthy()', t => {
 
 test('.falsy()', t => {
 	t.throws(() => {
-		assert.falsy(1);
-		assert.falsy(true);
+		assertions.falsy(1);
+		assertions.falsy(true);
 	});
 
 	t.doesNotThrow(() => {
-		assert.falsy(0);
-		assert.falsy(false);
+		assertions.falsy(0);
+		assertions.falsy(false);
 	});
 
 	t.end();
@@ -49,23 +59,23 @@ test('.falsy()', t => {
 
 test('.true()', t => {
 	t.throws(() => {
-		assert.true(1);
+		assertions.true(1);
 	});
 
 	t.throws(() => {
-		assert.true(0);
+		assertions.true(0);
 	});
 
 	t.throws(() => {
-		assert.true(false);
+		assertions.true(false);
 	});
 
 	t.throws(() => {
-		assert.true('foo');
+		assertions.true('foo');
 	});
 
 	t.doesNotThrow(() => {
-		assert.true(true);
+		assertions.true(true);
 	});
 
 	t.end();
@@ -73,23 +83,23 @@ test('.true()', t => {
 
 test('.false()', t => {
 	t.throws(() => {
-		assert.false(0);
+		assertions.false(0);
 	});
 
 	t.throws(() => {
-		assert.false(1);
+		assertions.false(1);
 	});
 
 	t.throws(() => {
-		assert.false(true);
+		assertions.false(true);
 	});
 
 	t.throws(() => {
-		assert.false('foo');
+		assertions.false('foo');
 	});
 
 	t.doesNotThrow(() => {
-		assert.false(false);
+		assertions.false(false);
 	});
 
 	t.end();
@@ -97,11 +107,11 @@ test('.false()', t => {
 
 test('.is()', t => {
 	t.doesNotThrow(() => {
-		assert.is('foo', 'foo');
+		assertions.is('foo', 'foo');
 	});
 
 	t.throws(() => {
-		assert.is('foo', 'bar');
+		assertions.is('foo', 'bar');
 	});
 
 	t.end();
@@ -109,11 +119,11 @@ test('.is()', t => {
 
 test('.not()', t => {
 	t.doesNotThrow(() => {
-		assert.not('foo', 'bar');
+		assertions.not('foo', 'bar');
 	});
 
 	t.throws(() => {
-		assert.not('foo', 'foo');
+		assertions.not('foo', 'foo');
 	});
 
 	t.end();
@@ -124,11 +134,11 @@ test('.deepEqual()', t => {
 	// used to test deep object equality
 
 	t.throws(() => {
-		assert.deepEqual({a: false}, {a: 0});
+		assertions.deepEqual({a: false}, {a: 0});
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual({
+		assertions.deepEqual({
 			a: 'a',
 			b: 'b'
 		}, {
@@ -138,7 +148,7 @@ test('.deepEqual()', t => {
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual({
+		assertions.deepEqual({
 			a: 'a',
 			b: 'b',
 			c: {
@@ -154,17 +164,17 @@ test('.deepEqual()', t => {
 	});
 
 	t.throws(() => {
-		assert.deepEqual([1, 2, 3], [1, 2, 3, 4]);
+		assertions.deepEqual([1, 2, 3], [1, 2, 3, 4]);
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual([1, 2, 3], [1, 2, 3]);
+		assertions.deepEqual([1, 2, 3], [1, 2, 3]);
 	});
 
 	t.throws(() => {
 		const fnA = a => a;
 		const fnB = a => a;
-		assert.deepEqual(fnA, fnB);
+		assertions.deepEqual(fnA, fnB);
 	});
 
 	t.doesNotThrow(() => {
@@ -176,7 +186,7 @@ test('.deepEqual()', t => {
 		const y2 = {x: x2};
 		x2.y = y2;
 
-		assert.deepEqual(x1, x2);
+		assertions.deepEqual(x1, x2);
 	});
 
 	t.doesNotThrow(() => {
@@ -187,7 +197,7 @@ test('.deepEqual()', t => {
 		const x = new Foo(1);
 		const y = new Foo(1);
 
-		assert.deepEqual(x, y);
+		assertions.deepEqual(x, y);
 	});
 
 	t.throws(() => {
@@ -202,11 +212,11 @@ test('.deepEqual()', t => {
 		const x = new Foo(1);
 		const y = new Bar(1);
 
-		assert.deepEqual(x, y);
+		assertions.deepEqual(x, y);
 	});
 
 	t.throws(() => {
-		assert.deepEqual({
+		assertions.deepEqual({
 			a: 'a',
 			b: 'b',
 			c: {
@@ -222,73 +232,73 @@ test('.deepEqual()', t => {
 	});
 
 	t.throws(() => {
-		assert.deepEqual({}, []);
+		assertions.deepEqual({}, []);
 	});
 
 	t.throws(() => {
-		assert.deepEqual({0: 'a', 1: 'b'}, ['a', 'b']);
+		assertions.deepEqual({0: 'a', 1: 'b'}, ['a', 'b']);
 	});
 
 	t.throws(() => {
-		assert.deepEqual({a: 1}, {a: 1, b: undefined});
+		assertions.deepEqual({a: 1}, {a: 1, b: undefined});
 	});
 
 	t.throws(() => {
-		assert.deepEqual(new Date('1972-08-01'), null);
+		assertions.deepEqual(new Date('1972-08-01'), null);
 	});
 
 	t.throws(() => {
-		assert.deepEqual(new Date('1972-08-01'), undefined);
+		assertions.deepEqual(new Date('1972-08-01'), undefined);
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(new Date('1972-08-01'), new Date('1972-08-01'));
+		assertions.deepEqual(new Date('1972-08-01'), new Date('1972-08-01'));
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual({x: new Date('1972-08-01')}, {x: new Date('1972-08-01')});
+		assertions.deepEqual({x: new Date('1972-08-01')}, {x: new Date('1972-08-01')});
 	});
 
 	t.throws(() => {
-		assert.deepEqual(() => {}, () => {});
+		assertions.deepEqual(() => {}, () => {});
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(undefined, undefined);
-		assert.deepEqual({x: undefined}, {x: undefined});
-		assert.deepEqual({x: [undefined]}, {x: [undefined]});
+		assertions.deepEqual(undefined, undefined);
+		assertions.deepEqual({x: undefined}, {x: undefined});
+		assertions.deepEqual({x: [undefined]}, {x: [undefined]});
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(null, null);
-		assert.deepEqual({x: null}, {x: null});
-		assert.deepEqual({x: [null]}, {x: [null]});
+		assertions.deepEqual(null, null);
+		assertions.deepEqual({x: null}, {x: null});
+		assertions.deepEqual({x: [null]}, {x: [null]});
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(0, 0);
-		assert.deepEqual(1, 1);
-		assert.deepEqual(3.14, 3.14);
+		assertions.deepEqual(0, 0);
+		assertions.deepEqual(1, 1);
+		assertions.deepEqual(3.14, 3.14);
 	});
 
 	t.throws(() => {
-		assert.deepEqual(0, 1);
+		assertions.deepEqual(0, 1);
 	});
 
 	t.throws(() => {
-		assert.deepEqual(1, -1);
+		assertions.deepEqual(1, -1);
 	});
 
 	t.throws(() => {
-		assert.deepEqual(3.14, 2.72);
+		assertions.deepEqual(3.14, 2.72);
 	});
 
 	t.throws(() => {
-		assert.deepEqual({0: 'a', 1: 'b'}, ['a', 'b']);
+		assertions.deepEqual({0: 'a', 1: 'b'}, ['a', 'b']);
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(
+		assertions.deepEqual(
 			[
 				{foo: {z: 100, y: 200, x: 300}},
 				'bar',
@@ -305,7 +315,7 @@ test('.deepEqual()', t => {
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(
+		assertions.deepEqual(
 			{x: {a: 1, b: 2}, y: {c: 3, d: 4}},
 			{y: {d: 4, c: 3}, x: {b: 2, a: 1}}
 		);
@@ -314,29 +324,29 @@ test('.deepEqual()', t => {
 	// Regression test end here
 
 	t.doesNotThrow(() => {
-		assert.deepEqual({a: 'a'}, {a: 'a'});
+		assertions.deepEqual({a: 'a'}, {a: 'a'});
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(['a', 'b'], ['a', 'b']);
+		assertions.deepEqual(['a', 'b'], ['a', 'b']);
 	});
 
 	t.throws(() => {
-		assert.deepEqual({a: 'a'}, {a: 'b'});
+		assertions.deepEqual({a: 'a'}, {a: 'b'});
 	});
 
 	t.throws(() => {
-		assert.deepEqual(['a', 'b'], ['a', 'a']);
+		assertions.deepEqual(['a', 'b'], ['a', 'a']);
 	});
 
 	t.throws(() => {
-		assert.deepEqual([['a', 'b'], 'c'], [['a', 'b'], 'd']);
+		assertions.deepEqual([['a', 'b'], 'c'], [['a', 'b'], 'd']);
 	});
 
 	t.throws(() => {
 		const circular = ['a', 'b'];
 		circular.push(circular);
-		assert.deepEqual([circular, 'c'], [circular, 'd']);
+		assertions.deepEqual([circular, 'c'], [circular, 'd']);
 	});
 
 	t.end();
@@ -344,19 +354,19 @@ test('.deepEqual()', t => {
 
 test('.notDeepEqual()', t => {
 	t.doesNotThrow(() => {
-		assert.notDeepEqual({a: 'a'}, {a: 'b'});
+		assertions.notDeepEqual({a: 'a'}, {a: 'b'});
 	});
 
 	t.doesNotThrow(() => {
-		assert.notDeepEqual(['a', 'b'], ['c', 'd']);
+		assertions.notDeepEqual(['a', 'b'], ['c', 'd']);
 	});
 
 	t.throws(() => {
-		assert.notDeepEqual({a: 'a'}, {a: 'a'});
+		assertions.notDeepEqual({a: 'a'}, {a: 'a'});
 	});
 
 	t.throws(() => {
-		assert.notDeepEqual(['a', 'b'], ['a', 'b']);
+		assertions.notDeepEqual(['a', 'b'], ['a', 'b']);
 	});
 
 	t.end();
@@ -364,11 +374,11 @@ test('.notDeepEqual()', t => {
 
 test('.throws()', t => {
 	t.throws(() => {
-		assert.throws(() => {});
+		assertions.throws(() => {});
 	});
 
 	t.doesNotThrow(() => {
-		assert.throws(() => {
+		assertions.throws(() => {
 			throw new Error('foo');
 		});
 	});
@@ -378,7 +388,7 @@ test('.throws()', t => {
 
 test('.throws() returns the thrown error', t => {
 	const expected = new Error();
-	const actual = assert.throws(() => {
+	const actual = assertions.throws(() => {
 		throw expected;
 	});
 
@@ -390,7 +400,7 @@ test('.throws() returns the thrown error', t => {
 test('.throws() returns the rejection reason of promise', t => {
 	const expected = new Error();
 
-	return assert.throws(Promise.reject(expected)).then(actual => {
+	return assertions.throws(Promise.reject(expected)).then(actual => {
 		t.is(actual, expected);
 		t.end();
 	});
@@ -400,7 +410,7 @@ test('.throws should throw if passed a bad value', t => {
 	t.plan(1);
 
 	t.throws(() => {
-		assert.throws('not a function');
+		assertions.throws('not a function');
 	}, {
 		name: 'TypeError',
 		message: /t\.throws must be called with a function, Promise, or Observable/
@@ -411,7 +421,7 @@ test('.notThrows should throw if passed a bad value', t => {
 	t.plan(1);
 
 	t.throws(() => {
-		assert.notThrows('not a function');
+		assertions.notThrows('not a function');
 	}, {
 		name: 'TypeError',
 		message: /t\.notThrows must be called with a function, Promise, or Observable/
@@ -420,11 +430,11 @@ test('.notThrows should throw if passed a bad value', t => {
 
 test('.notThrows()', t => {
 	t.doesNotThrow(() => {
-		assert.notThrows(() => {});
+		assertions.notThrows(() => {});
 	});
 
 	t.throws(() => {
-		assert.notThrows(() => {
+		assertions.notThrows(() => {
 			throw new Error('foo');
 		});
 	});
@@ -432,13 +442,19 @@ test('.notThrows()', t => {
 	t.end();
 });
 
+test('.notThrows() returns undefined for a fulfilled promise', t => {
+	return assertions.notThrows(Promise.resolve(Symbol(''))).then(actual => {
+		t.is(actual, undefined);
+	});
+});
+
 test('.regex()', t => {
 	t.doesNotThrow(() => {
-		assert.regex('abc', /^abc$/);
+		assertions.regex('abc', /^abc$/);
 	});
 
 	t.throws(() => {
-		assert.regex('foo', /^abc$/);
+		assertions.regex('foo', /^abc$/);
 	});
 
 	t.end();
@@ -446,11 +462,11 @@ test('.regex()', t => {
 
 test('.notRegex()', t => {
 	t.doesNotThrow(() => {
-		assert.notRegex('abc', /def/);
+		assertions.notRegex('abc', /def/);
 	});
 
 	t.throws(() => {
-		assert.notRegex('abc', /abc/);
+		assertions.notRegex('abc', /abc/);
 	});
 
 	t.end();
@@ -458,11 +474,11 @@ test('.notRegex()', t => {
 
 test('.ifError()', t => {
 	t.throws(() => {
-		assert.ifError(new Error());
+		assertions.ifError(new Error());
 	});
 
 	t.doesNotThrow(() => {
-		assert.ifError(null);
+		assertions.ifError(null);
 	});
 
 	t.end();
@@ -477,11 +493,11 @@ test('.deepEqual() should not mask RangeError from underlying assert', t => {
 	const b = new Circular();
 
 	t.throws(() => {
-		assert.notDeepEqual(a, b);
+		assertions.notDeepEqual(a, b);
 	});
 
 	t.doesNotThrow(() => {
-		assert.deepEqual(a, b);
+		assertions.deepEqual(a, b);
 	});
 
 	t.end();
@@ -493,12 +509,14 @@ test('snapshot makes a snapshot using a library and global options', t => {
 	const stateGetter = sinon.stub().returns(state);
 	const matchStub = sinon.stub().returns({pass: true});
 
-	assert.title = 'Test name';
+	const test = {
+		title: 'Test name'
+	};
 
 	t.plan(4);
 
 	t.doesNotThrow(() => {
-		assert._snapshot('tree', undefined, matchStub, stateGetter);
+		assert.snapshot(test, 'tree', undefined, matchStub, stateGetter);
 	});
 
 	t.ok(stateGetter.called);
@@ -509,9 +527,6 @@ test('snapshot makes a snapshot using a library and global options', t => {
 	});
 
 	t.ok(saveSpy.calledOnce);
-
-	delete assert.title;
-
 	t.end();
 });
 
@@ -521,7 +536,9 @@ test('snapshot handles jsx tree', t => {
 	const stateGetter = sinon.stub().returns(state);
 	const matchStub = sinon.stub().returns({pass: true});
 
-	assert.title = 'Test name';
+	const test = {
+		title: 'Test name'
+	};
 
 	t.plan(5);
 
@@ -534,7 +551,7 @@ test('snapshot handles jsx tree', t => {
 
 		Object.defineProperty(tree, '$$typeof', {value: Symbol.for('react.test.json')});
 
-		assert._snapshot(tree, undefined, matchStub, stateGetter);
+		assert.snapshot(test, tree, undefined, matchStub, stateGetter);
 	});
 
 	t.ok(stateGetter.called);
@@ -554,8 +571,5 @@ test('snapshot handles jsx tree', t => {
 	});
 
 	t.ok(saveSpy.calledOnce);
-
-	delete assert.title;
-
 	t.end();
 });

--- a/test/assert.js
+++ b/test/assert.js
@@ -412,8 +412,8 @@ test('.throws should throw if passed a bad value', t => {
 	t.throws(() => {
 		assertions.throws('not a function');
 	}, {
-		name: 'TypeError',
-		message: /t\.throws must be called with a function, Promise, or Observable/
+		name: 'AssertionError',
+		message: /`t\.throws\(\)` must be called with a function, Promise, or Observable/
 	});
 });
 
@@ -423,8 +423,8 @@ test('.notThrows should throw if passed a bad value', t => {
 	t.throws(() => {
 		assertions.notThrows('not a function');
 	}, {
-		name: 'TypeError',
-		message: /t\.notThrows must be called with a function, Promise, or Observable/
+		name: 'AssertionError',
+		message: /`t\.notThrows\(\)` must be called with a function, Promise, or Observable/
 	});
 });
 

--- a/test/format-assert-error.js
+++ b/test/format-assert-error.js
@@ -26,10 +26,14 @@ test('render statements', t => {
 
 test('diff objects', t => {
 	const err = {
-		actual: prettyFormat({a: 1}),
-		expected: prettyFormat({a: 2}),
-		actualType: 'object',
-		expectedType: 'object'
+		actual: {
+			type: 'object',
+			formatted: prettyFormat({a: 1})
+		},
+		expected: {
+			type: 'object',
+			formatted: prettyFormat({a: 2})
+		}
 	};
 
 	t.is(format(err), [
@@ -38,17 +42,21 @@ test('diff objects', t => {
 		`${chalk.red('-')}   a: 1,`,
 		`${chalk.green('+')}   a: 2,`,
 		'  }',
-		' '
+		''
 	].join('\n'));
 	t.end();
 });
 
 test('diff arrays', t => {
 	const err = {
-		actual: prettyFormat([1]),
-		expected: prettyFormat([2]),
-		actualType: 'array',
-		expectedType: 'array'
+		actual: {
+			type: 'array',
+			formatted: prettyFormat([1])
+		},
+		expected: {
+			type: 'array',
+			formatted: prettyFormat([2])
+		}
 	};
 
 	t.is(format(err), [
@@ -57,17 +65,21 @@ test('diff arrays', t => {
 		`${chalk.red('-')}   1,`,
 		`${chalk.green('+')}   2,`,
 		'  ]',
-		' '
+		''
 	].join('\n'));
 	t.end();
 });
 
 test('diff strings', t => {
 	const err = {
-		actual: 'abc',
-		expected: 'abd',
-		actualType: 'string',
-		expectedType: 'string'
+		actual: {
+			type: 'string',
+			formatted: 'abc'
+		},
+		expected: {
+			type: 'string',
+			formatted: 'abd'
+		}
 	};
 
 	t.is(format(err), [
@@ -79,17 +91,21 @@ test('diff strings', t => {
 
 test('diff different types', t => {
 	const err = {
-		actual: prettyFormat([1, 2, 3]),
-		expected: prettyFormat({a: 1, b: 2, c: 3}),
-		actualType: 'array',
-		expectedType: 'object'
+		actual: {
+			type: 'array',
+			formatted: prettyFormat([1, 2, 3])
+		},
+		expected: {
+			type: 'object',
+			formatted: prettyFormat({a: 1, b: 2, c: 3})
+		}
 	};
 
 	t.is(format(err), [
 		'Actual:\n',
-		`${indentString(err.actual, 2)}\n`,
+		`${indentString(err.actual.formatted, 2)}\n`,
 		'Expected:\n',
-		`${indentString(err.expected, 2)}\n`
+		`${indentString(err.expected.formatted, 2)}\n`
 	].join('\n'));
 	t.end();
 });

--- a/test/format-assert-error.js
+++ b/test/format-assert-error.js
@@ -89,7 +89,7 @@ test('diff strings', t => {
 	t.end();
 });
 
-test('diff different types', t => {
+test('print different types', t => {
 	const err = {
 		actual: {
 			type: 'array',
@@ -104,6 +104,36 @@ test('diff different types', t => {
 	t.is(format(err), [
 		'Actual:\n',
 		`${indentString(err.actual.formatted, 2)}\n`,
+		'Expected:\n',
+		`${indentString(err.expected.formatted, 2)}\n`
+	].join('\n'));
+	t.end();
+});
+
+test('print actual even if no expected', t => {
+	const err = {
+		actual: {
+			type: 'array',
+			formatted: prettyFormat([1, 2, 3])
+		}
+	};
+
+	t.is(format(err), [
+		'Actual:\n',
+		`${indentString(err.actual.formatted, 2)}\n`
+	].join('\n'));
+	t.end();
+});
+
+test('print expected even if no actual', t => {
+	const err = {
+		expected: {
+			type: 'array',
+			formatted: prettyFormat([1, 2, 3])
+		}
+	};
+
+	t.is(format(err), [
 		'Expected:\n',
 		`${indentString(err.expected.formatted, 2)}\n`
 	].join('\n'));

--- a/test/promise.js
+++ b/test/promise.js
@@ -293,8 +293,8 @@ test('reject', t => {
 		});
 	}).run().then(result => {
 		t.is(result.passed, false);
-		t.is(result.reason.name, 'Error');
-		t.is(result.reason.message, 'unicorn');
+		t.is(result.reason.actual.name, 'Error');
+		t.is(result.reason.actual.message, 'unicorn');
 		t.end();
 	});
 });
@@ -303,7 +303,8 @@ test('reject with non-Error', t => {
 	ava(() => Promise.reject('failure')).run().then(result => {
 		t.is(result.passed, false);
 		t.is(result.reason.name, 'AssertionError');
-		t.is(result.reason.message, 'Promise rejected with: \'failure\'');
+		t.is(result.reason.message, 'Rejected promise returned by test');
+		t.is(result.reason.actual, 'failure');
 		t.end();
 	});
 });

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -363,7 +363,6 @@ test('results with errors', t => {
 	err1.stack = beautifyStack(err1.stack);
 	const err1Path = tempWrite.sync('a();');
 	err1.source = source(err1Path);
-	err1.showOutput = true;
 	err1.actual = JSON.stringify('abc');
 	err1.actualType = 'string';
 	err1.expected = JSON.stringify('abd');
@@ -373,7 +372,6 @@ test('results with errors', t => {
 	err2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b();');
 	err2.source = source(err2Path);
-	err2.showOutput = true;
 	err2.actual = JSON.stringify([1]);
 	err2.actualType = 'array';
 	err2.expected = JSON.stringify([2]);
@@ -425,7 +423,6 @@ test('results with errors', t => {
 test('results with errors and disabled code excerpts', t => {
 	const err1 = new Error('failure one');
 	err1.stack = beautifyStack(err1.stack);
-	err1.showOutput = true;
 	err1.actual = JSON.stringify('abc');
 	err1.actualType = 'string';
 	err1.expected = JSON.stringify('abd');
@@ -435,7 +432,6 @@ test('results with errors and disabled code excerpts', t => {
 	err2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b();');
 	err2.source = source(err2Path);
-	err2.showOutput = true;
 	err2.actual = JSON.stringify([1]);
 	err2.actualType = 'array';
 	err2.expected = JSON.stringify([2]);
@@ -486,7 +482,6 @@ test('results with errors and broken code excerpts', t => {
 	err1.stack = beautifyStack(err1.stack);
 	const err1Path = tempWrite.sync('a();');
 	err1.source = source(err1Path, 10);
-	err1.showOutput = true;
 	err1.actual = JSON.stringify('abc');
 	err1.actualType = 'string';
 	err1.expected = JSON.stringify('abd');
@@ -496,7 +491,6 @@ test('results with errors and broken code excerpts', t => {
 	err2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b();');
 	err2.source = source(err2Path);
-	err2.showOutput = true;
 	err2.actual = JSON.stringify([1]);
 	err2.actualType = 'array';
 	err2.expected = JSON.stringify([2]);
@@ -525,69 +519,6 @@ test('results with errors and broken code excerpts', t => {
 		'  ' + chalk.grey(`${err1.source.file}:${err1.source.line}`),
 		'',
 		indentString(formatAssertError(err1), 2).split('\n'),
-		/failure one/,
-		'',
-		stackLineRegex,
-		compareLineOutput.SKIP_UNTIL_EMPTY_LINE,
-		'',
-		'',
-		'',
-		'  ' + chalk.bold.white('failed two'),
-		'  ' + chalk.grey(`${err2.source.file}:${err2.source.line}`),
-		'',
-		indentString(codeExcerpt(err2.source), 2).split('\n'),
-		'',
-		indentString(formatAssertError(err2), 2).split('\n'),
-		/failure two/
-	]));
-	t.end();
-});
-
-test('results with errors and disabled assert output', t => {
-	const err1 = new Error('failure one');
-	err1.stack = beautifyStack(err1.stack);
-	const err1Path = tempWrite.sync('a();');
-	err1.source = source(err1Path);
-	err1.showOutput = false;
-	err1.actual = JSON.stringify('abc');
-	err1.actualType = 'string';
-	err1.expected = JSON.stringify('abd');
-	err1.expectedType = 'string';
-
-	const err2 = new Error('failure two');
-	err2.stack = 'error message\nTest.fn (test.js:1:1)\n';
-	const err2Path = tempWrite.sync('b();');
-	err2.source = source(err2Path);
-	err2.showOutput = true;
-	err2.actual = JSON.stringify([1]);
-	err2.actualType = 'array';
-	err2.expected = JSON.stringify([2]);
-	err2.expectedType = 'array';
-
-	const reporter = miniReporter({color: true});
-	reporter.failCount = 1;
-
-	const runStatus = {
-		errors: [{
-			title: 'failed one',
-			error: err1
-		}, {
-			title: 'failed two',
-			error: err2
-		}]
-	};
-
-	const output = reporter.finish(runStatus);
-
-	compareLineOutput(t, output, flatten([
-		'',
-		'  ' + chalk.red('1 failed'),
-		'',
-		'  ' + chalk.bold.white('failed one'),
-		'  ' + chalk.grey(`${err1.source.file}:${err1.source.line}`),
-		'',
-		indentString(codeExcerpt(err1.source), 2).split('\n'),
-		'',
 		/failure one/,
 		'',
 		stackLineRegex,

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -363,19 +363,29 @@ test('results with errors', t => {
 	err1.stack = beautifyStack(err1.stack);
 	const err1Path = tempWrite.sync('a();');
 	err1.source = source(err1Path);
-	err1.actual = JSON.stringify('abc');
-	err1.actualType = 'string';
-	err1.expected = JSON.stringify('abd');
-	err1.expectedType = 'string';
+	err1.avaAssertionError = true;
+	err1.actual = {
+		type: 'string',
+		formatted: JSON.stringify('abc')
+	};
+	err1.expected = {
+		type: 'string',
+		formatted: JSON.stringify('abd')
+	};
 
 	const err2 = new Error('failure two');
 	err2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b();');
 	err2.source = source(err2Path);
-	err2.actual = JSON.stringify([1]);
-	err2.actualType = 'array';
-	err2.expected = JSON.stringify([2]);
-	err2.expectedType = 'array';
+	err2.avaAssertionError = true;
+	err2.actual = {
+		type: 'array',
+		formatted: JSON.stringify([1])
+	};
+	err2.expected = {
+		type: 'array',
+		formatted: JSON.stringify([2])
+	};
 
 	const reporter = miniReporter();
 	reporter.failCount = 1;
@@ -423,19 +433,29 @@ test('results with errors', t => {
 test('results with errors and disabled code excerpts', t => {
 	const err1 = new Error('failure one');
 	err1.stack = beautifyStack(err1.stack);
-	err1.actual = JSON.stringify('abc');
-	err1.actualType = 'string';
-	err1.expected = JSON.stringify('abd');
-	err1.expectedType = 'string';
+	err1.avaAssertionError = true;
+	err1.actual = {
+		type: 'string',
+		formatted: JSON.stringify('abc')
+	};
+	err1.expected = {
+		type: 'string',
+		formatted: JSON.stringify('abd')
+	};
 
 	const err2 = new Error('failure two');
 	err2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b();');
 	err2.source = source(err2Path);
-	err2.actual = JSON.stringify([1]);
-	err2.actualType = 'array';
-	err2.expected = JSON.stringify([2]);
-	err2.expectedType = 'array';
+	err2.avaAssertionError = true;
+	err2.actual = {
+		type: 'array',
+		formatted: JSON.stringify([1])
+	};
+	err2.expected = {
+		type: 'array',
+		formatted: JSON.stringify([2])
+	};
 
 	const reporter = miniReporter({color: true});
 	reporter.failCount = 1;
@@ -482,19 +502,29 @@ test('results with errors and broken code excerpts', t => {
 	err1.stack = beautifyStack(err1.stack);
 	const err1Path = tempWrite.sync('a();');
 	err1.source = source(err1Path, 10);
-	err1.actual = JSON.stringify('abc');
-	err1.actualType = 'string';
-	err1.expected = JSON.stringify('abd');
-	err1.expectedType = 'string';
+	err1.avaAssertionError = true;
+	err1.actual = {
+		type: 'string',
+		formatted: JSON.stringify('abc')
+	};
+	err1.expected = {
+		type: 'string',
+		formatted: JSON.stringify('abd')
+	};
 
 	const err2 = new Error('failure two');
 	err2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b();');
 	err2.source = source(err2Path);
-	err2.actual = JSON.stringify([1]);
-	err2.actualType = 'array';
-	err2.expected = JSON.stringify([2]);
-	err2.expectedType = 'array';
+	err2.avaAssertionError = true;
+	err2.actual = {
+		type: 'array',
+		formatted: JSON.stringify([1])
+	};
+	err2.expected = {
+		type: 'array',
+		formatted: JSON.stringify([2])
+	};
 
 	const reporter = miniReporter({color: true});
 	reporter.failCount = 1;

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -36,10 +36,11 @@ test('failing test', t => {
 		error: {
 			name: 'AssertionError',
 			message: 'false == true',
+			avaAssertionError: true,
 			assertion: 'true',
 			operator: '==',
-			expected: 'true',
-			actual: 'false',
+			expected: {formatted: 'true'},
+			actual: {formatted: 'false'},
 			stack: ['', 'Test.fn (test.js:1:2)'].join('\n')
 		}
 	});
@@ -66,14 +67,16 @@ test('multiline strings in YAML block', t => {
 	const actualOutput = reporter.test({
 		title: 'multiline',
 		error: {
-			actual: 'hello\nworld'
+			object: {
+				foo: 'hello\nworld'
+			}
 		}
 	});
 
 	const expectedOutput = `# multiline
 not ok 1 - multiline
   ---
-    actual: |-
+    foo: |-
       hello
       world
   ...`;
@@ -88,8 +91,9 @@ test('strips ANSI from actual and expected values', t => {
 	const actualOutput = reporter.test({
 		title: 'strip ansi',
 		error: {
-			actual: '\u001b[31mhello\u001b[39m',
-			expected: '\u001b[32mworld\u001b[39m'
+			avaAssertionError: true,
+			actual: {formatted: '\u001b[31mhello\u001b[39m'},
+			expected: {formatted: '\u001b[32mworld\u001b[39m'}
 		}
 	});
 

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -36,6 +36,7 @@ test('failing test', t => {
 		error: {
 			name: 'AssertionError',
 			message: 'false == true',
+			assertion: 'true',
 			operator: '==',
 			expected: 'true',
 			actual: 'false',
@@ -48,6 +49,7 @@ not ok 1 - failing
   ---
     name: AssertionError
     message: false == true
+    assertion: 'true'
     operator: ==
     actual: 'false'
     expected: 'true'

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -373,7 +373,6 @@ test('results with errors', t => {
 	error1.stack = beautifyStack(error1.stack);
 	const err1Path = tempWrite.sync('a()');
 	error1.source = source(err1Path);
-	error1.showOutput = true;
 	error1.actual = JSON.stringify('abc');
 	error1.actualType = 'string';
 	error1.expected = JSON.stringify('abd');
@@ -383,7 +382,6 @@ test('results with errors', t => {
 	error2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b()');
 	error2.source = source(err2Path);
-	error2.showOutput = true;
 	error2.actual = JSON.stringify([1]);
 	error2.actualType = 'array';
 	error2.expected = JSON.stringify([2]);
@@ -432,7 +430,6 @@ test('results with errors', t => {
 test('results with errors and disabled code excerpts', t => {
 	const error1 = new Error('error one message');
 	error1.stack = beautifyStack(error1.stack);
-	error1.showOutput = true;
 	error1.actual = JSON.stringify('abc');
 	error1.actualType = 'string';
 	error1.expected = JSON.stringify('abd');
@@ -442,7 +439,6 @@ test('results with errors and disabled code excerpts', t => {
 	error2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b()');
 	error2.source = source(err2Path);
-	error2.showOutput = true;
 	error2.actual = JSON.stringify([1]);
 	error2.actualType = 'array';
 	error2.expected = JSON.stringify([2]);
@@ -490,7 +486,6 @@ test('results with errors and disabled code excerpts', t => {
 	error1.stack = beautifyStack(error1.stack);
 	const err1Path = tempWrite.sync('a();');
 	error1.source = source(err1Path, 10);
-	error1.showOutput = true;
 	error1.actual = JSON.stringify('abc');
 	error1.actualType = 'string';
 	error1.expected = JSON.stringify('abd');
@@ -500,7 +495,6 @@ test('results with errors and disabled code excerpts', t => {
 	error2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b()');
 	error2.source = source(err2Path);
-	error2.showOutput = true;
 	error2.actual = JSON.stringify([1]);
 	error2.actualType = 'array';
 	error2.expected = JSON.stringify([2]);
@@ -526,66 +520,6 @@ test('results with errors and disabled code excerpts', t => {
 		'  ' + chalk.grey(`${error1.source.file}:${error1.source.line}`),
 		'',
 		indentString(formatAssertError(error1), 2).split('\n'),
-		/error one message/,
-		'',
-		stackLineRegex,
-		compareLineOutput.SKIP_UNTIL_EMPTY_LINE,
-		'',
-		'',
-		'',
-		'  ' + chalk.bold.white('fail two'),
-		'  ' + chalk.grey(`${error2.source.file}:${error2.source.line}`),
-		'',
-		indentString(codeExcerpt(error2.source), 2).split('\n'),
-		'',
-		indentString(formatAssertError(error2), 2).split('\n'),
-		/error two message/
-	]));
-	t.end();
-});
-
-test('results with errors and disabled assert output', t => {
-	const error1 = new Error('error one message');
-	error1.stack = beautifyStack(error1.stack);
-	const err1Path = tempWrite.sync('a();');
-	error1.source = source(err1Path);
-	error1.showOutput = false;
-	error1.actual = JSON.stringify('abc');
-	error1.actualType = 'string';
-	error1.expected = JSON.stringify('abd');
-	error1.expectedType = 'string';
-
-	const error2 = new Error('error two message');
-	error2.stack = 'error message\nTest.fn (test.js:1:1)\n';
-	const err2Path = tempWrite.sync('b();');
-	error2.source = source(err2Path);
-	error2.showOutput = true;
-	error2.actual = JSON.stringify([1]);
-	error2.actualType = 'array';
-	error2.expected = JSON.stringify([2]);
-	error2.expectedType = 'array';
-
-	const reporter = createReporter({color: true});
-	const runStatus = createRunStatus();
-	runStatus.failCount = 1;
-	runStatus.tests = [{
-		title: 'fail one',
-		error: error1
-	}, {
-		title: 'fail two',
-		error: error2
-	}];
-
-	const output = reporter.finish(runStatus);
-	compareLineOutput(t, output, flatten([
-		'',
-		'  ' + chalk.red('1 test failed') + time,
-		'',
-		'  ' + chalk.bold.white('fail one'),
-		'  ' + chalk.grey(`${error1.source.file}:${error1.source.line}`),
-		'',
-		indentString(codeExcerpt(error1.source), 2).split('\n'),
-		'',
 		/error one message/,
 		'',
 		stackLineRegex,

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -373,19 +373,29 @@ test('results with errors', t => {
 	error1.stack = beautifyStack(error1.stack);
 	const err1Path = tempWrite.sync('a()');
 	error1.source = source(err1Path);
-	error1.actual = JSON.stringify('abc');
-	error1.actualType = 'string';
-	error1.expected = JSON.stringify('abd');
-	error1.expectedType = 'string';
+	error1.avaAssertionError = true;
+	error1.actual = {
+		type: 'string',
+		formatted: JSON.stringify('abc')
+	};
+	error1.expected = {
+		type: 'string',
+		formatted: JSON.stringify('abd')
+	};
 
 	const error2 = new Error('error two message');
 	error2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b()');
 	error2.source = source(err2Path);
-	error2.actual = JSON.stringify([1]);
-	error2.actualType = 'array';
-	error2.expected = JSON.stringify([2]);
-	error2.expectedType = 'array';
+	error2.avaAssertionError = true;
+	error2.actual = {
+		type: 'array',
+		formatted: JSON.stringify([1])
+	};
+	error2.expected = {
+		type: 'array',
+		formatted: JSON.stringify([2])
+	};
 
 	const reporter = createReporter({color: true});
 	const runStatus = createRunStatus();
@@ -430,19 +440,29 @@ test('results with errors', t => {
 test('results with errors and disabled code excerpts', t => {
 	const error1 = new Error('error one message');
 	error1.stack = beautifyStack(error1.stack);
-	error1.actual = JSON.stringify('abc');
-	error1.actualType = 'string';
-	error1.expected = JSON.stringify('abd');
-	error1.expectedType = 'string';
+	error1.avaAssertionError = true;
+	error1.actual = {
+		type: 'string',
+		formatted: JSON.stringify('abc')
+	};
+	error1.expected = {
+		type: 'string',
+		formatted: JSON.stringify('abd')
+	};
 
 	const error2 = new Error('error two message');
 	error2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b()');
 	error2.source = source(err2Path);
-	error2.actual = JSON.stringify([1]);
-	error2.actualType = 'array';
-	error2.expected = JSON.stringify([2]);
-	error2.expectedType = 'array';
+	error2.avaAssertionError = true;
+	error2.actual = {
+		type: 'array',
+		formatted: JSON.stringify([1])
+	};
+	error2.expected = {
+		type: 'array',
+		formatted: JSON.stringify([2])
+	};
 
 	const reporter = createReporter({color: true});
 	const runStatus = createRunStatus();
@@ -486,19 +506,29 @@ test('results with errors and disabled code excerpts', t => {
 	error1.stack = beautifyStack(error1.stack);
 	const err1Path = tempWrite.sync('a();');
 	error1.source = source(err1Path, 10);
-	error1.actual = JSON.stringify('abc');
-	error1.actualType = 'string';
-	error1.expected = JSON.stringify('abd');
-	error1.expectedType = 'string';
+	error1.avaAssertionError = true;
+	error1.actual = {
+		type: 'string',
+		formatted: JSON.stringify('abc')
+	};
+	error1.expected = {
+		type: 'string',
+		formatted: JSON.stringify('abd')
+	};
 
 	const error2 = new Error('error two message');
 	error2.stack = 'error message\nTest.fn (test.js:1:1)\n';
 	const err2Path = tempWrite.sync('b()');
 	error2.source = source(err2Path);
-	error2.actual = JSON.stringify([1]);
-	error2.actualType = 'array';
-	error2.expected = JSON.stringify([2]);
-	error2.expectedType = 'array';
+	error2.avaAssertionError = true;
+	error2.actual = {
+		type: 'array',
+		formatted: JSON.stringify([1])
+	};
+	error2.expected = {
+		type: 'array',
+		formatted: JSON.stringify([2])
+	};
 
 	const reporter = createReporter({color: true});
 	const runStatus = createRunStatus();

--- a/test/run-status.js
+++ b/test/run-status.js
@@ -86,33 +86,3 @@ test('calculate remaining test count', t => {
 	t.is(runStatus.remainingCount, 5);
 	t.end();
 });
-
-test('handle non-object rejections', t => {
-	const runStatus = new RunStatus();
-
-	runStatus.on('error', err => {
-		t.deepEqual(err, {
-			file: 'foo.js',
-			message: '42',
-			type: 'rejection'
-		});
-		t.end();
-	});
-
-	runStatus.handleRejections({file: 'foo.js', rejections: [42]});
-});
-
-test('handle non-object exceptions', t => {
-	const runStatus = new RunStatus();
-
-	runStatus.on('error', err => {
-		t.deepEqual(err, {
-			file: 'bar.js',
-			message: '/ab/g',
-			type: 'exception'
-		});
-		t.end();
-	});
-
-	runStatus.handleExceptions({file: 'bar.js', exception: /ab/g});
-});

--- a/test/test.js
+++ b/test/test.js
@@ -264,7 +264,7 @@ test('handle throws without error', t => {
 
 	t.is(result.passed, false);
 	t.ok(result.reason);
-	t.is(actual, null);
+	t.is(actual, undefined);
 	t.end();
 });
 
@@ -575,9 +575,10 @@ test('number of assertions matches t.plan when the test exits, but before all pr
 		}, 5);
 	}).run().then(result => {
 		t.is(result.passed, false);
-		t.is(result.reason.operator, 'plan');
+		t.is(result.reason.assertion, 'plan');
 		t.is(result.reason.actual, 3);
 		t.is(result.reason.expected, 2);
+		t.is(result.reason.operator, '===');
 		t.end();
 	});
 });
@@ -592,9 +593,10 @@ test('number of assertions doesn\'t match plan when the test exits, but before a
 		}, 5);
 	}).run().then(result => {
 		t.is(result.passed, false);
-		t.is(result.reason.operator, 'plan');
+		t.is(result.reason.assertion, 'plan');
 		t.is(result.reason.actual, 2);
 		t.is(result.reason.expected, 3);
+		t.is(result.reason.operator, '===');
 		t.end();
 	});
 });

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -65,7 +65,7 @@ export interface AssertContext {
 	/**
 	 * Assert that function doesn't throw an error or promise resolves.
 	 */
-	notThrows<U>(value: PromiseLike<U>, message?: string): Promise<U>;
+	notThrows(value: PromiseLike<any>, message?: string): Promise<void>;
 	notThrows(value: () => void, message?: string): void;
 	/**
 	 * Assert that contents matches regex.


### PR DESCRIPTION
See commits. Behavior should be the same, aside from these changes:

* Fixes #1227 
* Fixes #1150 
* Assertions now return `undefined` rather than `null`
* Removes the undocumented `t.assertCount` getter
* All test failures (exception thrown, rejected promise returned, `t.end(error)`) are now wrapped in an assertion error, but we'll still print the actual error
* Do the same for when `t.throws()` / `t.notThrows()` are called with an improper argument. We can now even print the actual argument passed!
* In the TAP reporter, the error YAML block now has varying properties (e.g. do not assume it has `operator` or even `assertion`)
* Test serialization no longer overwrites non-standard error properties