### PR TITLE
Fix `nodeExternals` in the precompiling-with-webpack recipe

### DIFF
--- a/docs/recipes/precompiling-with-webpack.md
+++ b/docs/recipes/precompiling-with-webpack.md
@@ -10,19 +10,19 @@ The AVA [readme](https://github.com/avajs/ava#transpiling-imported-modules) ment
 const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
-	entry: ['src/tests.js'],
-	target: 'node',
-	output: {
-		path: '_build',
-		filename: 'tests.js'
-	},
-	externals: nodeExternals,
-	module: {
-		rules: [{
-				test: /\.(js|jsx)$/,
-				use: 'babel-loader'
-		}]
-	}
+  entry: ['src/tests.js'],
+  target: 'node',
+  output: {
+    path: '_build',
+    filename: 'tests.js'
+  },
+  externals: [nodeExternals()],
+  module: {
+    rules: [{
+      test: /\.(js|jsx)$/,
+      use: 'babel-loader'
+    }]
+  }
 };
 ```
 

--- a/docs/recipes/precompiling-with-webpack.md
+++ b/docs/recipes/precompiling-with-webpack.md
@@ -19,8 +19,8 @@ module.exports = {
 	externals: [nodeExternals()],
 	module: {
 		rules: [{
-			test: /\.(js|jsx)$/,
-			use: 'babel-loader'
+				test: /\.(js|jsx)$/,
+				use: 'babel-loader'
 		}]
 	}
 };

--- a/docs/recipes/precompiling-with-webpack.md
+++ b/docs/recipes/precompiling-with-webpack.md
@@ -10,19 +10,19 @@ The AVA [readme](https://github.com/avajs/ava#transpiling-imported-modules) ment
 const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
-  entry: ['src/tests.js'],
-  target: 'node',
-  output: {
-    path: '_build',
-    filename: 'tests.js'
-  },
-  externals: [nodeExternals()],
-  module: {
-    rules: [{
-      test: /\.(js|jsx)$/,
-      use: 'babel-loader'
-    }]
-  }
+	entry: ['src/tests.js'],
+	target: 'node',
+	output: {
+		path: '_build',
+		filename: 'tests.js'
+	},
+	externals: [nodeExternals()],
+	module: {
+		rules: [{
+			test: /\.(js|jsx)$/,
+			use: 'babel-loader'
+		}]
+	}
 };
 ```
 


### PR DESCRIPTION
Fixed `nodeExternals` in `webpack.config.js` because the provided example did not work. `externals` have to be an array and `nodeExternals` is a function that must be called and not referenced.