### PR TITLE
Include anonymous functions (whose name node cannot infer) in stack traces

### DIFF
--- a/lib/extract-stack.js
+++ b/lib/extract-stack.js
@@ -1,5 +1,5 @@
 'use strict';
-const stackLineRegex = /^.+ \(.+:[0-9]+:[0-9]+\)$/;
+const stackLineRegex = /^.+( \(.+:[0-9]+:[0-9]+\)|:[0-9]+:[0-9]+)$/;
 
 module.exports = stack => {
 	return stack

--- a/test/cli.js
+++ b/test/cli.js
@@ -105,6 +105,14 @@ test('throwing a named function will report the to the console', t => {
 	});
 });
 
+test('include anonymous functions in error reports', t => {
+	execCli('fixture/error-in-anonymous-function.js', (err, stdout, stderr) => {
+		t.ok(err);
+		t.match(stderr, /test\/fixture\/error-in-anonymous-function\.js:4:8/);
+		t.end();
+	});
+});
+
 test('improper use of t.throws will be reported to the console', t => {
 	execCli('fixture/improper-t-throws.js', (err, stdout, stderr) => {
 		t.ok(err);

--- a/test/extract-stack.js
+++ b/test/extract-stack.js
@@ -34,3 +34,13 @@ test('strip beginning whitespace from stack', t => {
 	t.is(extractStack(stack), 'Test.t (test.js:1:1)');
 	t.end();
 });
+
+test('includes anonymous function lines', t => {
+	const stack = [
+		'error message',
+		'path/to/test.js:1:1'
+	].join('\n');
+
+	t.is(extractStack(stack), 'path/to/test.js:1:1');
+	t.end();
+});

--- a/test/fixture/error-in-anonymous-function.js
+++ b/test/fixture/error-in-anonymous-function.js
@@ -1,0 +1,9 @@
+import test from '../../';
+
+const getAnonymousFn = () => () => {
+	throw Error();
+};
+
+test(t => {
+	getAnonymousFn()();
+});


### PR DESCRIPTION
### Issue

Functions whose name node cannot infer do not get included in stack traces.

I came across this issue when working with curried functions.

### Reproduction 

This error in a code using an anonymous function:

```js
const fn = () => () => doesnotexist
fn()()
```

Produces a stacktrace line without a function name:

```
ReferenceError: doesnotexist is not defined
    at /Users/caden/Code/libs/ava/repro.js:1:86
    at Object.<anonymous> (/Users/caden/Code/libs/ava/repro.js:2:5)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
```

The regex in [extract-stack.js:2](https://github.com/avajs/ava/blob/master/lib/extract-stack.js#L2) expects the function name & brackets to be there:

```js
const stackLineRegex = /^.+ \(.+:[0-9]+:[0-9]+\)$/;
```

So that line gets swallowed. Which means we lose context for our error message. This is a shame.

### Fix

This commit fixes the issue by adding another regex to `extract-stack.js` which will match anonymous functions. 

The regex may be a little broad — I couldn't think of any obvious instances where it would fail but undoubtedly some contrived examples exist.

I have included a unit test and an integration test. A few different areas in the codebase amend stacktraces, so I thought it was best to do so.

### Finally

Thanks for all your great work on Ava!