### PR TITLE
Fix default helper files glob to cover helper files inside subdirectories

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -88,9 +88,9 @@ const defaultIncludePatterns = () => [
 ];
 
 const defaultHelperPatterns = () => [
-	'**/__tests__/helpers/**/*.js',
+	'**/__tests__/**/helpers/**/*.js',
 	'**/__tests__/**/_*.js',
-	'**/test/helpers/**/*.js',
+	'**/test/**/helpers/**/*.js',
 	'**/test/**/_*.js'
 ];
 


### PR DESCRIPTION
## Description

When we have a `helpers` folder inside a subdirectory (e.g: `test/unit/helpers`), the helper files are not transpiled by Ava.

This PR fixes the glob that finds the defaultHelperFiles to cover subdirectories as well.

## Related

This fixes #1319 