### PR TITLE
Fix formatValue() reference

### DIFF
--- a/lib/enhance-assert.js
+++ b/lib/enhance-assert.js
@@ -1,6 +1,6 @@
 'use strict';
 const dotProp = require('dot-prop');
-const formatValue = require('./format-assert-error');
+const formatValue = require('./format-assert-error').formatValue;
 
 // When adding patterns, don't forget to add to
 // https://github.com/avajs/babel-preset-transform-test-files/blob/master/espower-patterns.json


### PR DESCRIPTION
Fixes #1321.

Turns out we don't have any real integration tests for assertion enhancement. I don't have time to add those right now either, but at least this fixes `master`.

With the sample code from #1321:

```
❯ "$(npm bin)"/ava test.js

  1 failed

  [anonymous]
  /private/var/folders/_6/p8qxp_3n62zg9081tvb0lcc80000gn/T/tmp.okeY2IXLOl/test.js:5

   4:   const x = () => 'foo';
   5:   t.regex(x(), /\d/);
   6: });

  Value must match expression:

    "foo"

  Regular expression:

    /\d/

  x()
  => "foo"
```