### PR TITLE
Allow new assertions while waiting for pending ones

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -109,7 +109,7 @@ class Test {
 		this.endCallbackFinisher = null;
 		this.finishDueToAttributedError = null;
 		this.finishDueToInactivity = null;
-		this.finishing = false;
+		this.finished = false;
 		this.pendingAssertions = [];
 		this.pendingThrowsAssertion = null;
 		this.planCount = null;
@@ -152,7 +152,7 @@ class Test {
 	}
 
 	countPassedAssertion() {
-		if (this.finishing) {
+		if (this.finished) {
 			this.saveFirstError(new Error('Assertion passed, but test has already ended'));
 		}
 
@@ -160,7 +160,7 @@ class Test {
 	}
 
 	addPendingAssertion(promise) {
-		if (this.finishing) {
+		if (this.finished) {
 			this.saveFirstError(new Error('Assertion passed, but test has already ended'));
 		}
 
@@ -169,7 +169,7 @@ class Test {
 	}
 
 	addFailedAssertion(error) {
-		if (this.finishing) {
+		if (this.finished) {
 			this.saveFirstError(new Error('Assertion failed, but test has already ended'));
 		}
 
@@ -365,21 +365,19 @@ class Test {
 	}
 
 	finish() {
-		this.finishing = true;
-
 		if (!this.assertError && this.pendingThrowsAssertion) {
 			return this.waitForPendingThrowsAssertion();
 		}
-
-		this.verifyPlan();
-		this.verifyAssertions();
 
 		if (this.assertError || this.pendingAssertions.length === 0) {
 			return this.completeFinish();
 		}
 
-		// Finish after potential errors from pending assertions have been consumed.
-		return Promise.all(this.pendingAssertions).then(() => this.completeFinish());
+		// Retry finishing after potential errors from pending assertions have been consumed.
+		const consumedErrors = Promise.all(this.pendingAssertions);
+		// Note that more assertions may be added in the meantime.
+		this.pendingAssertions = [];
+		return consumedErrors.then(() => this.finish());
 	}
 
 	finishPromised() {
@@ -389,6 +387,10 @@ class Test {
 	}
 
 	completeFinish() {
+		this.verifyPlan();
+		this.verifyAssertions();
+
+		this.finished = true;
 		this.duration = globals.now() - this.startedAt;
 
 		let reason = this.assertError;

--- a/test/test.js
+++ b/test/test.js
@@ -667,6 +667,28 @@ test('no crash when adding assertions after the test has ended', t => {
 	}).run();
 });
 
+test('can add more pending assertions while waiting for earlier assertions to complete', t => {
+	return ava(a => {
+		a.plan(4);
+
+		a.notThrows(new Promise(resolve => {
+			setImmediate(() => {
+				resolve();
+
+				a.pass();
+				a.throws(new Promise(resolve => {
+					setImmediate(() => {
+						a.pass();
+						resolve();
+					});
+				}));
+			});
+		}));
+	}).run().then(passed => {
+		t.is(passed, false);
+	});
+});
+
 test('contextRef', t => {
 	new Test({
 		contextRef: {context: {foo: 'bar'}},


### PR DESCRIPTION
Whilst not a great way to write tests, users may end up adding more
assertions from inside a promise chain that's passed to the `t.throws()`
or `t.notThrows()` assertions. These should be counted for the plan, and
not fail the test as being extraneous.

Fixes #1327.
