### PR TITLE
Don't highlight formatted values with --no-color

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,6 +38,7 @@ exports.run = () => {
 		  --verbose, -v           Enable verbose output
 		  --no-cache              Disable the transpiler cache
 		  --no-power-assert       Disable Power Assert
+		  --color                 Force color output
 		  --no-color              Disable color output
 		  --match, -m             Only run tests with matching title (Can be repeated)
 		  --watch, -w             Re-run tests when tests and source files change

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -75,7 +75,7 @@ exports.run = () => {
 		],
 		default: {
 			cache: conf.cache,
-			color: 'color' in conf ? conf.color : true,
+			color: 'color' in conf ? conf.color : require('supports-color') !== false,
 			concurrency: conf.concurrency,
 			failFast: conf.failFast,
 			init: conf.init,

--- a/lib/format-assert-error.js
+++ b/lib/format-assert-error.js
@@ -5,12 +5,13 @@ const chalk = require('chalk');
 const diff = require('diff');
 const DiffMatchPatch = require('diff-match-patch');
 const indentString = require('indent-string');
+const globals = require('./globals');
 
 function formatValue(value, options) {
 	return prettyFormat(value, Object.assign({
 		callToJSON: false,
 		plugins: [reactTestPlugin],
-		highlight: true
+		highlight: globals.options.color !== false
 	}, options));
 }
 exports.formatValue = formatValue;

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "stack-utils": "^1.0.0",
     "strip-ansi": "^3.0.1",
     "strip-bom-buf": "^1.0.0",
+    "supports-color": "^3.2.3",
     "time-require": "^0.1.2",
     "unique-temp-dir": "^1.0.0",
     "update-notifier": "^2.1.0"

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ $ ava --help
     --verbose, -v           Enable verbose output
     --no-cache              Disable the transpiler cache
     --no-power-assert       Disable Power Assert
+    --color                 Force color output
     --no-color              Disable color output
     --match, -m             Only run tests with matching title (Can be repeated)
     --watch, -w             Re-run tests when tests and source files change

--- a/test/cli.js
+++ b/test/cli.js
@@ -11,6 +11,7 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const uniqueTempDir = require('unique-temp-dir');
 const execa = require('execa');
+const stripAnsi = require('strip-ansi');
 
 const cliPath = path.join(__dirname, '../cli.js');
 
@@ -523,5 +524,21 @@ test('snapshots work', t => {
 			t.ifError(err);
 			t.end();
 		});
+	});
+});
+
+test('--no-color disables formatting colors', t => {
+	execCli(['--no-color', '--verbose', 'formatting-color.js'], {dirname: 'fixture'}, (err, stdout, stderr) => {
+		t.ok(err);
+		t.is(stripAnsi(stderr), stderr);
+		t.end();
+	});
+});
+
+test('--color enables formatting colors', t => {
+	execCli(['--color', '--verbose', 'formatting-color.js'], {dirname: 'fixture'}, (err, stdout, stderr) => {
+		t.ok(err);
+		t.isNot(stripAnsi(stderr), stderr);
+		t.end();
 	});
 });

--- a/test/fixture/formatting-color.js
+++ b/test/fixture/formatting-color.js
@@ -1,0 +1,5 @@
+import test from '../..';
+
+test(t => {
+	t.deepEqual({foo: 1}, {foo: 2});
+});


### PR DESCRIPTION
Fixes #843 (https://github.com/avajs/ava/issues/843#issuecomment-290935567). Values shouldn't be highlighted during formatting if colors are disabled.

Note that this only works when colors are disabled explicitly. @sindresorhus perhaps we should change the default value of the `color` option if we can detect colors are not supported?