### PR TITLE
Fail tests that finish with pending assertions

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -111,7 +111,7 @@ class Test {
 		this.finishDueToAttributedError = null;
 		this.finishDueToInactivity = null;
 		this.finishing = false;
-		this.pendingAssertions = [];
+		this.pendingAssertionCount = 0;
 		this.pendingThrowsAssertion = null;
 		this.planCount = null;
 		this.startedAt = 0;
@@ -166,7 +166,10 @@ class Test {
 		}
 
 		this.assertCount++;
-		this.pendingAssertions.push(promise.catch(err => this.saveFirstError(err)));
+		this.pendingAssertionCount++;
+		promise
+			.catch(err => this.saveFirstError(err))
+			.then(() => this.pendingAssertionCount--);
 	}
 
 	addFailedAssertion(error) {
@@ -208,8 +211,12 @@ class Test {
 	}
 
 	verifyAssertions() {
-		if (this.failWithoutAssertions && !this.assertError && !this.calledEnd && this.planCount === null && this.assertCount === 0) {
-			this.saveFirstError(new Error('Test finished without running any assertions'));
+		if (!this.assertError) {
+			if (this.failWithoutAssertions && !this.calledEnd && this.planCount === null && this.assertCount === 0) {
+				this.saveFirstError(new Error('Test finished without running any assertions'));
+			} else if (this.pendingAssertionCount > 0) {
+				this.saveFirstError(new Error('Test finished, but an assertion is still pending'));
+			}
 		}
 	}
 
@@ -375,21 +382,6 @@ class Test {
 		this.verifyPlan();
 		this.verifyAssertions();
 
-		if (this.assertError || this.pendingAssertions.length === 0) {
-			return this.completeFinish();
-		}
-
-		// Finish after potential errors from pending assertions have been consumed.
-		return Promise.all(this.pendingAssertions).then(() => this.completeFinish());
-	}
-
-	finishPromised() {
-		return new Promise(resolve => {
-			resolve(this.finish());
-		});
-	}
-
-	completeFinish() {
 		this.duration = globals.now() - this.startedAt;
 
 		let reason = this.assertError;
@@ -412,6 +404,12 @@ class Test {
 		});
 
 		return passed;
+	}
+
+	finishPromised() {
+		return new Promise(resolve => {
+			resolve(this.finish());
+		});
 	}
 }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -154,7 +154,7 @@ class Test {
 
 	countPassedAssertion() {
 		if (this.finishing) {
-			this.saveFirstError(new Error('Assertion passed, but test has already ended'));
+			this.saveFirstError(new Error('Assertion passed, but test has already finished'));
 		}
 
 		this.assertCount++;
@@ -162,7 +162,7 @@ class Test {
 
 	addPendingAssertion(promise) {
 		if (this.finishing) {
-			this.saveFirstError(new Error('Assertion passed, but test has already ended'));
+			this.saveFirstError(new Error('Assertion passed, but test has already finished'));
 		}
 
 		this.assertCount++;
@@ -171,7 +171,7 @@ class Test {
 
 	addFailedAssertion(error) {
 		if (this.finishing) {
-			this.saveFirstError(new Error('Assertion failed, but test has already ended'));
+			this.saveFirstError(new Error('Assertion failed, but test has already finished'));
 		}
 
 		this.assertCount++;

--- a/readme.md
+++ b/readme.md
@@ -964,9 +964,25 @@ test('rejects', async t => {
 });
 ```
 
+When testing a promise you must wait for the assertion to complete:
+
+```js
+test('rejects', async t => {
+	await t.throws(promise);
+});
+```
+
 ### `.notThrows(function|promise, [message])`
 
 Assert that `function` does not throw an error or that `promise` does not reject with an error.
+
+Like the `.throws()` assertion, when testing a promise you must wait for the assertion to complete:
+
+```js
+test('rejects', async t => {
+	await t.notThrows(promise);
+});
+```
 
 ### `.regex(contents, regex, [message])`
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 'use strict';
 const test = require('tap').test;
 const delay = require('delay');
-const isPromise = require('is-promise');
 const formatValue = require('../lib/format-assert-error').formatValue;
 const Test = require('../lib/test');
 
@@ -633,17 +632,6 @@ test('number of assertions doesn\'t match plan when the test exits, but before a
 	t.is(result.reason.assertion, 'plan');
 	t.is(result.reason.operator, '===');
 	t.end();
-});
-
-test('assertions return promises', t => {
-	ava(a => {
-		a.plan(2);
-		t.ok(isPromise(a.throws(Promise.reject(new Error('foo')))));
-		t.ok(isPromise(a.notThrows(Promise.resolve(true))));
-	}).run().then(passed => {
-		t.is(passed, true);
-		t.end();
-	});
 });
 
 test('contextRef', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -591,7 +591,7 @@ test('number of assertions matches t.plan when the test exits, but before all pe
 		result = r;
 	}).run().then(passed => {
 		t.is(passed, false);
-		t.match(result.reason.message, /Assertion passed, but test has already ended/);
+		t.match(result.reason.message, /Assertion passed, but test has already finished/);
 		t.is(result.reason.name, 'Error');
 		t.end();
 	});
@@ -610,7 +610,7 @@ test('number of assertions matches t.plan when the test exits, but before all pe
 		result = r;
 	}).run().then(passed => {
 		t.is(passed, false);
-		t.match(result.reason.message, /Assertion failed, but test has already ended/);
+		t.match(result.reason.message, /Assertion failed, but test has already finished/);
 		t.is(result.reason.name, 'Error');
 		t.end();
 	});


### PR DESCRIPTION
`t.throws()` and `t.notThrows()` can be called with an observable or promise. This commit forces users to wait for the assertion to complete before finishing the test. Usually this means the test has to be written like:

```js
test(async t => {
  await t.throws(Promise.reject(new Error()))
})
```

Or for callback tests:

```js
test.cb(t => {
  t.throws(Promise.reject(new Error())).then(t.end)
})
```

This simplifies internal logic and helps discourage code like in #1327. Anecdotally users are surprised by the previous behavior where a synchronous test worked with an asynchronous assertion (https://github.com/avajs/ava/issues/1327#issuecomment-291122432).

Fixes #1327.