### PR TITLE
Fix get-port usage

### DIFF
--- a/api.js
+++ b/api.js
@@ -198,7 +198,7 @@ class Api extends EventEmitter {
 		}
 
 		return Promise
-			.map(files, getPort)
+			.map(files, () => getPort())
 			.map(port => {
 				const forkExecArgv = execArgv.slice();
 				let flagName = isInspect ? '--inspect' : '--debug';


### PR DESCRIPTION
It's risky to pass a function to a map() operation, and indeed since
get-port@3.1.0 the getPort() function takes a first argument.
