### PR TITLE
Make `t.is()` use `Object.is()`

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -59,31 +59,29 @@ function wrapAssertions(callbacks) {
 		},
 
 		is(actual, expected, message) {
-			if (actual === expected) {
+			if (Object.is(actual, expected)) {
 				pass(this);
 			} else {
 				const diff = formatAssertError.formatDiff(actual, expected);
 				const values = diff ? [diff] : [
 					formatAssertError.formatWithLabel('Actual:', actual),
-					formatAssertError.formatWithLabel('Must be strictly equal to:', expected)
+					formatAssertError.formatWithLabel('Must be strictly equal (using Object.is) to:', expected)
 				];
 
 				fail(this, new AssertionError({
 					assertion: 'is',
 					message,
-					operator: '===',
 					values
 				}));
 			}
 		},
 
 		not(actual, expected, message) {
-			if (actual === expected) {
+			if (Object.is(actual, expected)) {
 				fail(this, new AssertionError({
 					assertion: 'not',
 					message,
-					operator: '!==',
-					values: [formatAssertError.formatWithLabel('Value is strictly equal:', actual)]
+					values: [formatAssertError.formatWithLabel('Value is strictly equal (using Object.is):', actual)]
 				}));
 			} else {
 				pass(this);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -65,7 +65,7 @@ function wrapAssertions(callbacks) {
 				const diff = formatAssertError.formatDiff(actual, expected);
 				const values = diff ? [diff] : [
 					formatAssertError.formatWithLabel('Actual:', actual),
-					formatAssertError.formatWithLabel('Must be strictly equal (using Object.is) to:', expected)
+					formatAssertError.formatWithLabel('Must be the same as:', expected)
 				];
 
 				fail(this, new AssertionError({
@@ -81,7 +81,7 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'not',
 					message,
-					values: [formatAssertError.formatWithLabel('Value is strictly equal (using Object.is):', actual)]
+					values: [formatAssertError.formatWithLabel('Value is the same as:', actual)]
 				}));
 			} else {
 				pass(this);

--- a/readme.md
+++ b/readme.md
@@ -632,8 +632,8 @@ function macro(t, input, expected) {
 	t.is(eval(input), expected);
 }
 
-test('2 + 2 === 4', macro, '2 + 2', 4);
-test('2 * 3 === 6', macro, '2 * 3', 6);
+test('Object.is(2 + 2, 4)', macro, '2 + 2', 4);
+test('Object.is(2 * 3, 6)', macro, '2 * 3', 6);
 ```
 
 You can build the test title programmatically by attaching a `title` function to the macro:
@@ -643,7 +643,7 @@ function macro(t, input, expected) {
 	t.is(eval(input), expected);
 }
 
-macro.title = (providedTitle, input, expected) => `${providedTitle} ${input} === ${expected}`.trim();
+macro.title = (providedTitle, input, expected) => `${providedTitle} Object.is(${input}, ${expected})`.trim();
 
 test(macro, '2 + 2', 4);
 test(macro, '2 * 3', 6);
@@ -914,15 +914,15 @@ Assert that `value` is `false`.
 
 ### `.is(value, expected, [message])`
 
-Assert that `value` is equal to `expected`.
+Assert that `value` is equal to `expected` (using `Object.is()` for equality testing).
 
 ### `.not(value, expected, [message])`
 
-Assert that `value` is not equal to `expected`.
+Assert that `value` is not equal to `expected` (using `Object.is()` for equality testing).
 
 ### `.deepEqual(value, expected, [message])`
 
-Assert that `value` is deep equal to `expected`. This is based on [Lodash' `isEqual()`](https://lodash.com/docs/4.17.4#isEqual):
+Assert that `value` is deeply equal to `expected`. This is based on [Lodash's `isEqual()`](https://lodash.com/docs/4.17.4#isEqual):
 
 > Performs a deep comparison between two values to determine if they are equivalent.
 >
@@ -930,7 +930,7 @@ Assert that `value` is deep equal to `expected`. This is based on [Lodash' `isEq
 
 ### `.notDeepEqual(value, expected, [message])`
 
-Assert that `value` is not deep equal to `expected`. The inverse of `.deepEqual()`.
+Assert that `value` is not deeply equal to `expected`. The inverse of `.deepEqual()`.
 
 ### `.throws(function|promise, [error, [message]])`
 

--- a/readme.md
+++ b/readme.md
@@ -914,11 +914,11 @@ Assert that `value` is `false`.
 
 ### `.is(value, expected, [message])`
 
-Assert that `value` is the same as `expected`. This is based on using [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).
+Assert that `value` is the same as `expected`. This is based on [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).
 
 ### `.not(value, expected, [message])`
 
-Assert that `value` is not the same as `expected`. This is based on using [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).
+Assert that `value` is not the same as `expected`. This is based on [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).
 
 ### `.deepEqual(value, expected, [message])`
 

--- a/readme.md
+++ b/readme.md
@@ -914,11 +914,11 @@ Assert that `value` is `false`.
 
 ### `.is(value, expected, [message])`
 
-Assert that `value` is equal to `expected` (using `Object.is()` for equality testing).
+Assert that `value` is the same as `expected`. This is based on using [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).
 
 ### `.not(value, expected, [message])`
 
-Assert that `value` is not equal to `expected` (using `Object.is()` for equality testing).
+Assert that `value` is not the same as `expected`. This is based on using [`Object.is()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).
 
 ### `.deepEqual(value, expected, [message])`
 

--- a/readme.md
+++ b/readme.md
@@ -632,8 +632,8 @@ function macro(t, input, expected) {
 	t.is(eval(input), expected);
 }
 
-test('Object.is(2 + 2, 4)', macro, '2 + 2', 4);
-test('Object.is(2 * 3, 6)', macro, '2 * 3', 6);
+test('2 + 2 = 4', macro, '2 + 2', 4);
+test('2 * 3 = 6', macro, '2 * 3', 6);
 ```
 
 You can build the test title programmatically by attaching a `title` function to the macro:
@@ -643,7 +643,7 @@ function macro(t, input, expected) {
 	t.is(eval(input), expected);
 }
 
-macro.title = (providedTitle, input, expected) => `${providedTitle} Object.is(${input}, ${expected})`.trim();
+macro.title = (providedTitle, input, expected) => `${providedTitle} ${input} = ${expected}`.trim();
 
 test(macro, '2 + 2', 4);
 test(macro, '2 * 3', 6);

--- a/test/assert.js
+++ b/test/assert.js
@@ -103,6 +103,10 @@ test('.is()', t => {
 	});
 
 	passes(t, () => {
+		assertions.is('', '');
+	});
+
+	passes(t, () => {
 		assertions.is(true, true);
 	});
 
@@ -119,6 +123,10 @@ test('.is()', t => {
 	});
 
 	passes(t, () => {
+		assertions.is(1, 1);
+	});
+
+	passes(t, () => {
 		assertions.is(0, 0);
 	});
 
@@ -132,6 +140,73 @@ test('.is()', t => {
 
 	passes(t, () => {
 		assertions.is(0 / 0, NaN);
+	});
+
+	passes(t, () => {
+		const someRef = {foo: 'bar'};
+		assertions.is(someRef, someRef);
+	});
+
+	fails(t, () => {
+		assertions.is(0, -0);
+	});
+
+	fails(t, () => {
+		assertions.is(0, false);
+	});
+
+	fails(t, () => {
+		assertions.is('', false);
+	});
+
+	fails(t, () => {
+		assertions.is('0', 0);
+	});
+
+	fails(t, () => {
+		assertions.is('17', 17);
+	});
+
+	fails(t, () => {
+		assertions.is([1, 2], '1,2');
+	});
+
+	fails(t, () => {
+		// eslint-disable-next-line no-new-wrappers
+		assertions.is(new String('foo'), 'foo');
+	});
+
+	fails(t, () => {
+		assertions.is(null, undefined);
+	});
+
+	fails(t, () => {
+		assertions.is(null, false);
+	});
+
+	fails(t, () => {
+		assertions.is(undefined, false);
+	});
+
+	fails(t, () => {
+		assertions.is({foo: 'bar'}, {foo: 'bar'});
+	});
+
+	fails(t, () => {
+		// eslint-disable-next-line no-new-wrappers
+		assertions.is(new String('foo'), new String('foo'));
+	});
+
+	fails(t, () => {
+		assertions.is(0, null);
+	});
+
+	fails(t, () => {
+		assertions.is(0, NaN);
+	});
+
+	fails(t, () => {
+		assertions.is('foo', NaN);
 	});
 
 	failsWith(t, () => {
@@ -194,6 +269,14 @@ test('.is()', t => {
 test('.not()', t => {
 	passes(t, () => {
 		assertions.not('foo', 'bar');
+	});
+
+	fails(t, () => {
+		assertions.not(NaN, NaN);
+	});
+
+	fails(t, () => {
+		assertions.not(0 / 0, NaN);
 	});
 
 	failsWith(t, () => {

--- a/test/assert.js
+++ b/test/assert.js
@@ -226,7 +226,7 @@ test('.is()', t => {
 		message: '',
 		values: [
 			{label: 'Actual:', formatted: /foo/},
-			{label: 'Must be strictly equal (using Object.is) to:', formatted: /42/}
+			{label: 'Must be the same as:', formatted: /42/}
 		]
 	});
 
@@ -237,7 +237,7 @@ test('.is()', t => {
 		message: 'my message',
 		values: [
 			{label: 'Actual:', formatted: /foo/},
-			{label: 'Must be strictly equal (using Object.is) to:', formatted: /42/}
+			{label: 'Must be the same as:', formatted: /42/}
 		]
 	});
 
@@ -248,7 +248,7 @@ test('.is()', t => {
 		message: 'my message',
 		values: [
 			{label: 'Actual:', formatted: /0/},
-			{label: 'Must be strictly equal (using Object.is) to:', formatted: /0/}
+			{label: 'Must be the same as:', formatted: /-0/}
 		]
 	});
 
@@ -258,8 +258,8 @@ test('.is()', t => {
 		assertion: 'is',
 		message: 'my message',
 		values: [
-			{label: 'Actual:', formatted: /0/},
-			{label: 'Must be strictly equal (using Object.is) to:', formatted: /0/}
+			{label: 'Actual:', formatted: /-0/},
+			{label: 'Must be the same as:', formatted: /0/}
 		]
 	});
 
@@ -284,7 +284,7 @@ test('.not()', t => {
 	}, {
 		assertion: 'not',
 		message: '',
-		values: [{label: 'Value is strictly equal (using Object.is):', formatted: /foo/}]
+		values: [{label: 'Value is the same as:', formatted: /foo/}]
 	});
 
 	failsWith(t, () => {
@@ -292,7 +292,7 @@ test('.not()', t => {
 	}, {
 		assertion: 'not',
 		message: 'my message',
-		values: [{label: 'Value is strictly equal (using Object.is):', formatted: /foo/}]
+		values: [{label: 'Value is the same as:', formatted: /foo/}]
 	});
 
 	t.end();

--- a/test/assert.js
+++ b/test/assert.js
@@ -102,12 +102,43 @@ test('.is()', t => {
 		assertions.is('foo', 'foo');
 	});
 
+	passes(t, () => {
+		assertions.is(true, true);
+	});
+
+	passes(t, () => {
+		assertions.is(false, false);
+	});
+
+	passes(t, () => {
+		assertions.is(null, null);
+	});
+
+	passes(t, () => {
+		assertions.is(undefined, undefined);
+	});
+
+	passes(t, () => {
+		assertions.is(0, 0);
+	});
+
+	passes(t, () => {
+		assertions.is(-0, -0);
+	});
+
+	passes(t, () => {
+		assertions.is(NaN, NaN);
+	});
+
+	passes(t, () => {
+		assertions.is(0 / 0, NaN);
+	});
+
 	failsWith(t, () => {
 		assertions.is('foo', 'bar');
 	}, {
 		assertion: 'is',
 		message: '',
-		operator: '===',
 		values: [
 			{label: 'Difference:', formatted: /foobar/}
 		]
@@ -118,10 +149,9 @@ test('.is()', t => {
 	}, {
 		assertion: 'is',
 		message: '',
-		operator: '===',
 		values: [
 			{label: 'Actual:', formatted: /foo/},
-			{label: 'Must be strictly equal to:', formatted: /42/}
+			{label: 'Must be strictly equal (using Object.is) to:', formatted: /42/}
 		]
 	});
 
@@ -130,10 +160,31 @@ test('.is()', t => {
 	}, {
 		assertion: 'is',
 		message: 'my message',
-		operator: '===',
 		values: [
 			{label: 'Actual:', formatted: /foo/},
-			{label: 'Must be strictly equal to:', formatted: /42/}
+			{label: 'Must be strictly equal (using Object.is) to:', formatted: /42/}
+		]
+	});
+
+	failsWith(t, () => {
+		assertions.is(0, -0, 'my message');
+	}, {
+		assertion: 'is',
+		message: 'my message',
+		values: [
+			{label: 'Actual:', formatted: /0/},
+			{label: 'Must be strictly equal (using Object.is) to:', formatted: /0/}
+		]
+	});
+
+	failsWith(t, () => {
+		assertions.is(-0, 0, 'my message');
+	}, {
+		assertion: 'is',
+		message: 'my message',
+		values: [
+			{label: 'Actual:', formatted: /0/},
+			{label: 'Must be strictly equal (using Object.is) to:', formatted: /0/}
 		]
 	});
 
@@ -150,8 +201,7 @@ test('.not()', t => {
 	}, {
 		assertion: 'not',
 		message: '',
-		operator: '!==',
-		values: [{label: 'Value is strictly equal:', formatted: /foo/}]
+		values: [{label: 'Value is strictly equal (using Object.is):', formatted: /foo/}]
 	});
 
 	failsWith(t, () => {
@@ -159,8 +209,7 @@ test('.not()', t => {
 	}, {
 		assertion: 'not',
 		message: 'my message',
-		operator: '!==',
-		values: [{label: 'Value is strictly equal:', formatted: /foo/}]
+		values: [{label: 'Value is strictly equal (using Object.is):', formatted: /foo/}]
 	});
 
 	t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -379,7 +379,7 @@ test('fails with the first assertError', t => {
 	t.is(result.reason.name, 'AssertionError');
 	t.same(result.reason.values, [
 		{label: 'Actual:', formatted: formatValue(1)},
-		{label: 'Must be strictly equal (using Object.is) to:', formatted: formatValue(2)}
+		{label: 'Must be the same as:', formatted: formatValue(2)}
 	]);
 	t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -379,7 +379,7 @@ test('fails with the first assertError', t => {
 	t.is(result.reason.name, 'AssertionError');
 	t.same(result.reason.values, [
 		{label: 'Actual:', formatted: formatValue(1)},
-		{label: 'Must be strictly equal to:', formatted: formatValue(2)}
+		{label: 'Must be strictly equal (using Object.is) to:', formatted: formatValue(2)}
 	]);
 	t.end();
 });


### PR DESCRIPTION
Refactor `is` assertion to use `Object.is()` rather than `===`.
Also add a few more test cases in for `is` to make it clearer what it is expected to do.

As per discussion in #1339, this will make it more sensible to compare `NaN` against `NaN`.

The good:

- `NaN` now compares to `NaN` in a way that people expect (truthily)

The odd:

- `+0`/`0` and `-0` are now **not** equal. As we discussed in #1339, this actually feels fine - this being a testing framework, it's good to be strict on this math stuff, while sensible on the NaN stuff.

Fixes #1339 

/cc @novemberborn, @sotojuan, @sindresorhus 