### PR TITLE
Add warning to browser recipe

### DIFF
--- a/docs/recipes/browser-testing.md
+++ b/docs/recipes/browser-testing.md
@@ -9,6 +9,10 @@ This recipe works for any library that needs a mocked browser environment.
 
 ## Install browser-env
 
+> **❗️ Important note**
+>
+>`browser-env` adds properties from the `jsdom` window namespace to the Node.js global namespace. This is explicitly [recommended against](https://github.com/tmpvar/jsdom/wiki/Don't-stuff-jsdom-globals-onto-the-Node-global) by `jsdom`. Please read through the linked wiki page and make sure you understand the caveats. If you don't have lots of dependencies that also require a browser environment then [`window`](https://github.com/lukechilds/window#universal-testing-pattern) may be a better solution.
+
 Install [browser-env](https://github.com/lukechilds/browser-env).
 
 > Simulates a global browser environment using jsdom.


### PR DESCRIPTION
Ok so since writing [`browser-env`](https://github.com/lukechilds/browser-env) I have come up with a cleaner solution, [`window`](https://github.com/lukechilds/window).It's been working well for me so far and resolves some of the issues raised in #1092.

However, it requires a [small code change](https://github.com/lukechilds/window#universal-testing-pattern) and is only viable for smaller modules without lots of dependencies that also require a browser environment. For other modules you'll still need `browser-env`. For that reason I think it would be best to continue to recommend `browser-env`, but highlight the issues raised in #1092 and offer `window` as a possible alternative.

Happy to change the wording, just pretty much copied it over from what I've got in the `browser-env` readme.