### PR TITLE
Update Babel config link to point to "ES2017 support" section in the readme

### DIFF
--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -19,7 +19,7 @@ function validate(conf) {
 	if (!conf || (typeof conf === 'string' && !isValidShortcut)) {
 		let message = colors.error(figures.cross);
 		message += ' Unexpected Babel configuration for AVA. ';
-		message += 'See ' + chalk.underline('https://github.com/avajs/ava#es2015-support') + ' for allowed values.';
+		message += 'See ' + chalk.underline('https://github.com/avajs/ava#es2017-support') + ' for allowed values.';
 
 		throw new Error(message);
 	}

--- a/test/cli.js
+++ b/test/cli.js
@@ -72,7 +72,7 @@ test('disallow invalid babel config shortcuts', t => {
 
 		let expectedOutput = '\n  ';
 		expectedOutput += figures.cross + ' Unexpected Babel configuration for AVA.';
-		expectedOutput += ' See https://github.com/avajs/ava#es2015-support for allowed values.';
+		expectedOutput += ' See https://github.com/avajs/ava#es2017-support for allowed values.';
 		expectedOutput += '\n';
 
 		t.is(stderr, expectedOutput);


### PR DESCRIPTION
The readme has update to [es2017](https://github.com/avajs/ava#es2017-support).

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->