### PR TITLE
Fail hard when `--concurrency` is used without a value

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -118,6 +118,10 @@ exports.run = () => {
 		throw new Error(colors.error(figures.cross) + ' Watch mode is not available in CI, as it prevents AVA from terminating.');
 	}
 
+	if (hasFlag('--concurrency') || hasFlag('-c')) {
+		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided the maximum number of test files to run with.');
+	}
+
 	if (hasFlag('--require') || hasFlag('-r')) {
 		throw new Error(colors.error(figures.cross) + ' The --require and -r flags are deprecated. Requirements should be configured in package.json - see documentation.');
 	}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -118,8 +118,8 @@ exports.run = () => {
 		throw new Error(colors.error(figures.cross) + ' Watch mode is not available in CI, as it prevents AVA from terminating.');
 	}
 
-	if (hasFlag('--concurrency') || hasFlag('-c')) {
-		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided the maximum number of test files to run with.');
+	if (cli.flags.concurrency === '') {
+		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided the maximum number of test files to run at once.');
 	}
 
 	if (hasFlag('--require') || hasFlag('-r')) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -364,11 +364,22 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 	});
 });
 
-test('bails when config does not contain `--concurrency` and `-c` values', t => {
-	execCli(['test.js'], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
-		t.is(err.code, 1);
-		t.match(stderr, 'The --concurrency and -c flags must be provided the maximum number of test files to run with.');
-		t.end();
+['--concurrency', '-c'].forEach(concurrencyFlag => {
+	test(`bails when ${concurrencyFlag} provided without value`, t => {
+		execCli([concurrencyFlag, 'test.js'], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+			t.is(err.code, 1);
+			t.match(stderr, 'The --concurrency and -c flags must be provided the maximum number of test files to run at once.');
+			t.end();
+		});
+	});
+});
+
+['--concurrency', '-c'].forEach(concurrencyFlag => {
+	test(`works when ${concurrencyFlag} provided with value`, t => {
+		execCli([`${concurrencyFlag}=1`, 'test.js'], {dirname: 'fixture/concurrency'}, err => {
+			t.ifError(err);
+			t.end();
+		});
 	});
 });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -364,6 +364,14 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 	});
 });
 
+test('bails when config does not contain `--concurrency` and `-c` values', t => {
+	execCli(['test.js'], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+		t.is(err.code, 1);
+		t.match(stderr, 'The --concurrency and -c flags must be provided the maximum number of test files to run with.');
+		t.end();
+	});
+});
+
 test('--match works', t => {
 	execCli(['-m=foo', '-m=bar', '-m=!baz', '-m=t* a* f*', '-m=!t* a* n* f*', 'fixture/matcher-skip.js'], err => {
 		t.ifError(err);

--- a/test/cli.js
+++ b/test/cli.js
@@ -366,7 +366,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 
 ['--concurrency', '-c'].forEach(concurrencyFlag => {
 	test(`bails when ${concurrencyFlag} provided without value`, t => {
-		execCli([concurrencyFlag, 'test.js'], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+		execCli(['test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
 			t.match(stderr, 'The --concurrency and -c flags must be provided the maximum number of test files to run at once.');
 			t.end();

--- a/test/fixture/concurrency/test.js
+++ b/test/fixture/concurrency/test.js
@@ -1,0 +1,5 @@
+import test from '../../../';
+
+test('works', t => {
+	t.pass();
+});


### PR DESCRIPTION
Fixes #1367 