### PR TITLE
add options argument to cli.run

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,8 +20,13 @@ const babelConfigHelper = require('./babel-config');
 // Bluebird specific
 Promise.longStackTraces();
 
-exports.run = () => {
-	const conf = pkgConf.sync('ava');
+exports.run = (options) => {
+	options = options || {};
+
+	const conf = pkgConf.sync('ava', {
+		defaults: options.defaults,
+		cwd: options.cwd
+	});
 
 	const filepath = pkgConf.filepath(conf);
 	const projectDir = filepath === null ? process.cwd() : path.dirname(filepath);


### PR DESCRIPTION
hey :cat:

use case: when using `ava` as part of a [framework](https://dogstack.js.org) cli, i want to be able to pass in some configuration to the `ava` cli, so `ava` runs as the framework expects.

what do y'all think of a change like this?