### PR TITLE
Point to correct JavaScript file on Windows

### DIFF
--- a/docs/recipes/debugging-with-webstorm.md
+++ b/docs/recipes/debugging-with-webstorm.md
@@ -9,7 +9,7 @@ Starting with version 2016.2, [WebStorm](https://www.jetbrains.com/webstorm/) an
 
 Add a new *Node.js Run/Debug configuration*: select `Edit Configurations...` from the dropdown list on the top right, then click `+` and select *Node.js*.
 
-In the `JavaScript file` field specify the path to AVA in the project's `node_modules` folder: `node_modules/.bin/ava` on macOS and Linux or `node_modules/.bin/ava.cmd` on Windows.
+In the `JavaScript file` field specify the path to AVA in the project's `node_modules` folder: `node_modules/.bin/ava` on macOS and Linux or `node_modules/ava/cli.js` on Windows.
 
 In the `Application parameters` pass the CLI flags you're using and the test files you would like to debug, for example `--verbose test.js`.
 


### PR DESCRIPTION
`node_modules/.bin/ava.cmd` doesn't work on Windows (seen this mistake repeated in too many repos). The correct way is to reference the cli file under the module itself.
