### PR TITLE
Add support for explicit callsites in asserts

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -33,18 +33,18 @@ class AssertionError extends Error {
 exports.AssertionError = AssertionError;
 
 class CallSite {
-	constructor() {
+	constructor(caller) {
 		// This is not lazy in node. However, using pure `Error` instances might not be
 		// backwards compatible (nor will it allow us to remove unwanted frames easily).
-		Error.captureStackTrace(this, CallSite);
+		Error.captureStackTrace(this, caller || CallSite);
 	}
 
 	toString() {
 		return '[[CallSite]]';
 	}
 
-	getStack(target = '') {
-		return this.stack.replace('[[CallSite]]', target);
+	getStack(target) {
+		return this.stack.replace('[[CallSite]]', target || '');
 	}
 }
 exports.CallSite = CallSite;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -22,18 +22,32 @@ class AssertionError extends Error {
 		// Reserved for power-assert statements
 		this.statements = [];
 
+		// To keep compatibility with old API, don't know if needed
 		if (opts.stack) {
 			this.stack = opts.stack;
+		} else if (opts.callSite) {
+			this.stack = opts.callSite.getStack(this.toString());
 		}
 	}
 }
 exports.AssertionError = AssertionError;
 
-function getStack() {
-	const obj = {};
-	Error.captureStackTrace(obj, getStack);
-	return obj.stack;
+class CallSite {
+	constructor() {
+		// This is not lazy in node. However, using pure `Error` instances might not be
+		// backwards compatible (nor will it allow us to remove unwanted frames easily).
+		Error.captureStackTrace(this, CallSite);
+	}
+
+	toString() {
+		return '[[CallSite]]';
+	}
+
+	getStack(target = '') {
+		return this.stack.replace('[[CallSite]]', target);
+	}
 }
+exports.CallSite = CallSite;
 
 function wrapAssertions(callbacks) {
 	const pass = callbacks.pass;
@@ -51,14 +65,15 @@ function wrapAssertions(callbacks) {
 			pass(this);
 		},
 
-		fail(message) {
+		fail(message, {callSite} = {}) {
 			fail(this, new AssertionError({
 				assertion: 'fail',
-				message: message || 'Test failed via `t.fail()`'
+				message: message || 'Test failed via `t.fail()`',
+				callSite
 			}));
 		},
 
-		is(actual, expected, message) {
+		is(actual, expected, message, {callSite} = {}) {
 			if (Object.is(actual, expected)) {
 				pass(this);
 			} else {
@@ -71,24 +86,26 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'is',
 					message,
-					values
+					values,
+					callSite
 				}));
 			}
 		},
 
-		not(actual, expected, message) {
+		not(actual, expected, message, {callSite} = {}) {
 			if (Object.is(actual, expected)) {
 				fail(this, new AssertionError({
 					assertion: 'not',
 					message,
-					values: [formatAssertError.formatWithLabel('Value is the same as:', actual)]
+					values: [formatAssertError.formatWithLabel('Value is the same as:', actual)],
+					callSite
 				}));
 			} else {
 				pass(this);
 			}
 		},
 
-		deepEqual(actual, expected, message) {
+		deepEqual(actual, expected, message, {callSite} = {}) {
 			if (deepEqual(actual, expected)) {
 				pass(this);
 			} else {
@@ -101,24 +118,26 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'deepEqual',
 					message,
-					values
+					values,
+					callSite
 				}));
 			}
 		},
 
-		notDeepEqual(actual, expected, message) {
+		notDeepEqual(actual, expected, message, {callSite} = {}) {
 			if (deepEqual(actual, expected)) {
 				fail(this, new AssertionError({
 					assertion: 'notDeepEqual',
 					message,
-					values: [formatAssertError.formatWithLabel('Value is deeply equal:', actual)]
+					values: [formatAssertError.formatWithLabel('Value is deeply equal:', actual)],
+					callSite
 				}));
 			} else {
 				pass(this);
 			}
 		},
 
-		throws(fn, err, message) {
+		throws(fn, err, message, {callSite} = {}) {
 			let promise;
 			if (isPromise(fn)) {
 				promise = fn;
@@ -129,7 +148,8 @@ function wrapAssertions(callbacks) {
 					assertion: 'throws',
 					improperUsage: true,
 					message: '`t.throws()` must be called with a function, Promise, or Observable',
-					values: [formatAssertError.formatWithLabel('Called with:', fn)]
+					values: [formatAssertError.formatWithLabel('Called with:', fn)],
+					callSite
 				}));
 				return;
 			}
@@ -143,7 +163,7 @@ function wrapAssertions(callbacks) {
 				coreAssertThrowsErrorArg = err;
 			}
 
-			const test = (fn, stack) => {
+			const test = (fn, callSite) => {
 				let actual;
 				let threw = false;
 				try {
@@ -165,7 +185,7 @@ function wrapAssertions(callbacks) {
 					throw new AssertionError({
 						assertion: 'throws',
 						message,
-						stack,
+						callSite,
 						values
 					});
 				}
@@ -173,15 +193,18 @@ function wrapAssertions(callbacks) {
 
 			if (promise) {
 				// Record stack before it gets lost in the promise chain.
-				const stack = getStack();
-				const intermediate = promise.then(makeNoop, makeRethrow).then(fn => test(fn, stack));
+				if (!callSite) {
+					callSite = new CallSite();
+				}
+
+				const intermediate = promise.then(makeNoop, makeRethrow).then(fn => test(fn, callSite));
 				pending(this, intermediate);
 				// Don't reject the returned promise, even if the assertion fails.
 				return intermediate.catch(noop);
 			}
 
 			try {
-				const retval = test(fn);
+				const retval = test(fn, callSite);
 				pass(this);
 				return retval;
 			} catch (err) {
@@ -189,7 +212,7 @@ function wrapAssertions(callbacks) {
 			}
 		},
 
-		notThrows(fn, message) {
+		notThrows(fn, message, {callSite} = {}) {
 			let promise;
 			if (isPromise(fn)) {
 				promise = fn;
@@ -200,19 +223,20 @@ function wrapAssertions(callbacks) {
 					assertion: 'notThrows',
 					improperUsage: true,
 					message: '`t.notThrows()` must be called with a function, Promise, or Observable',
-					values: [formatAssertError.formatWithLabel('Called with:', fn)]
+					values: [formatAssertError.formatWithLabel('Called with:', fn)],
+					callSite
 				}));
 				return;
 			}
 
-			const test = (fn, stack) => {
+			const test = (fn, callSite) => {
 				try {
 					coreAssert.doesNotThrow(fn);
 				} catch (err) {
 					throw new AssertionError({
 						assertion: 'notThrows',
 						message,
-						stack,
+						callSite,
 						values: [formatAssertError.formatWithLabel('Threw:', err.actual)]
 					});
 				}
@@ -220,34 +244,37 @@ function wrapAssertions(callbacks) {
 
 			if (promise) {
 				// Record stack before it gets lost in the promise chain.
-				const stack = getStack();
-				const intermediate = promise.then(noop, reason => test(makeRethrow(reason), stack));
+				if (!callSite) {
+					callSite = new CallSite();
+				}
+				const intermediate = promise.then(noop, reason => test(makeRethrow(reason), callSite));
 				pending(this, intermediate);
 				// Don't reject the returned promise, even if the assertion fails.
 				return intermediate.catch(noop);
 			}
 
 			try {
-				test(fn);
+				test(fn, callSite);
 				pass(this);
 			} catch (err) {
 				fail(this, err);
 			}
 		},
 
-		ifError(actual, message) {
+		ifError(actual, message, {callSite} = {}) {
 			if (actual) {
 				fail(this, new AssertionError({
 					assertion: 'ifError',
 					message,
-					values: [formatAssertError.formatWithLabel('Error:', actual)]
+					values: [formatAssertError.formatWithLabel('Error:', actual)],
+					callSite
 				}));
 			} else {
 				pass(this);
 			}
 		},
 
-		snapshot(actual, message) {
+		snapshot(actual, message, {callSite} = {}) {
 			const state = this._test.getSnapshotState();
 			const result = state.match(this.title, actual);
 			if (result.pass) {
@@ -261,62 +288,68 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'snapshot',
 					message: message || 'Did not match snapshot',
-					values: [{label: 'Difference:', formatted: diff}]
+					values: [{label: 'Difference:', formatted: diff}],
+					callSite
 				}));
 			}
 		}
 	};
 
 	const enhancedAssertions = enhanceAssert(pass, fail, {
-		truthy(actual, message) {
+		truthy(actual, message, {callSite} = {}) {
 			if (!actual) {
 				throw new AssertionError({
 					assertion: 'truthy',
 					message,
 					operator: '!!',
-					values: [formatAssertError.formatWithLabel('Value is not truthy:', actual)]
+					values: [formatAssertError.formatWithLabel('Value is not truthy:', actual)],
+					callSite
 				});
 			}
 		},
 
-		falsy(actual, message) {
+		falsy(actual, message, {callSite} = {}) {
 			if (actual) {
 				throw new AssertionError({
 					assertion: 'falsy',
 					message,
 					operator: '!',
-					values: [formatAssertError.formatWithLabel('Value is not falsy:', actual)]
+					values: [formatAssertError.formatWithLabel('Value is not falsy:', actual)],
+					callSite
 				});
 			}
 		},
 
-		true(actual, message) {
+		true(actual, message, {callSite} = {}) {
 			if (actual !== true) {
 				throw new AssertionError({
 					assertion: 'true',
 					message,
-					values: [formatAssertError.formatWithLabel('Value is not `true`:', actual)]
+					values: [formatAssertError.formatWithLabel('Value is not `true`:', actual)],
+					callSite
 				});
 			}
 		},
 
-		false(actual, message) {
+		false(actual, message, {callSite} = {}) {
 			if (actual !== false) {
 				throw new AssertionError({
 					assertion: 'false',
 					message,
-					values: [formatAssertError.formatWithLabel('Value is not `false`:', actual)]
+					values: [formatAssertError.formatWithLabel('Value is not `false`:', actual)],
+					callSite
 				});
 			}
 		},
 
-		regex(string, regex, message) {
+		regex(string, regex, message, {callSite} = {}) {
 			if (typeof string !== 'string') {
 				throw new AssertionError({
 					assertion: 'regex',
 					improperUsage: true,
 					message: '`t.regex()` must be called with a string',
-					values: [formatAssertError.formatWithLabel('Called with:', string)]
+					values: [formatAssertError.formatWithLabel('Called with:', string)],
+					callSite
 				});
 			}
 			if (!(regex instanceof RegExp)) {
@@ -324,7 +357,8 @@ function wrapAssertions(callbacks) {
 					assertion: 'regex',
 					improperUsage: true,
 					message: '`t.regex()` must be called with a regular expression',
-					values: [formatAssertError.formatWithLabel('Called with:', regex)]
+					values: [formatAssertError.formatWithLabel('Called with:', regex)],
+					callSite
 				});
 			}
 
@@ -335,18 +369,20 @@ function wrapAssertions(callbacks) {
 					values: [
 						formatAssertError.formatWithLabel('Value must match expression:', string),
 						formatAssertError.formatWithLabel('Regular expression:', regex)
-					]
+					],
+					callSite
 				});
 			}
 		},
 
-		notRegex(string, regex, message) {
+		notRegex(string, regex, message, {callSite} = {}) {
 			if (typeof string !== 'string') {
 				throw new AssertionError({
 					assertion: 'notRegex',
 					improperUsage: true,
 					message: '`t.notRegex()` must be called with a string',
-					values: [formatAssertError.formatWithLabel('Called with:', string)]
+					values: [formatAssertError.formatWithLabel('Called with:', string)],
+					callSite
 				});
 			}
 			if (!(regex instanceof RegExp)) {
@@ -354,7 +390,8 @@ function wrapAssertions(callbacks) {
 					assertion: 'notRegex',
 					improperUsage: true,
 					message: '`t.notRegex()` must be called with a regular expression',
-					values: [formatAssertError.formatWithLabel('Called with:', regex)]
+					values: [formatAssertError.formatWithLabel('Called with:', regex)],
+					callSite
 				});
 			}
 
@@ -365,7 +402,8 @@ function wrapAssertions(callbacks) {
 					values: [
 						formatAssertError.formatWithLabel('Value must not match expression:', string),
 						formatAssertError.formatWithLabel('Regular expression:', regex)
-					]
+					],
+					callSite
 				});
 			}
 		}

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,7 @@ const adapter = require('./process-adapter');
 const serializeError = require('./serialize-error');
 const globals = require('./globals');
 const Runner = require('./runner');
+const CallSite = require('./assert').CallSite;
 
 const opts = globals.options;
 const runner = new Runner({
@@ -96,6 +97,7 @@ globals.setImmediate(() => {
 });
 
 module.exports = runner.chain;
+module.exports.CallSite = CallSite;
 
 // TypeScript imports the `default` property for
 // an ES2015 default import (`import test from 'ava'`)

--- a/test/assert.js
+++ b/test/assert.js
@@ -1429,3 +1429,13 @@ test('CallSite provides stack proxy functionality', t => {
 	t.true(stackTargetingFoo.split('\n')[1].indexOf('assert.js') > 0);
 	t.end();
 });
+
+test('CallSite accepts custom caller', t => {
+	function doFoo() {
+		return new CallSite(doFoo);
+	}
+
+	const callSite = doFoo();
+	t.true(callSite.getStack().indexOf('doFoo') === -1);
+	t.end();
+});

--- a/test/assert.js
+++ b/test/assert.js
@@ -7,6 +7,7 @@ const formatValue = require('../lib/format-assert-error').formatValue;
 
 let lastFailure = null;
 let lastPassed = false;
+const CallSite = assert.CallSite;
 const assertions = assert.wrapAssertions({
 	pass() {
 		lastPassed = true;
@@ -48,6 +49,12 @@ function failsWith(t, fn, subset) {
 		});
 	} else {
 		t.same(lastFailure.values, []);
+	}
+	if (subset.callSite) {
+		const callSiteStack = subset.callSite.getStack();
+		const fullStack = lastFailure.stack;
+		const actualStack = fullStack.substring(fullStack.length - callSiteStack.length);
+		t.is(actualStack, callSiteStack);
 	}
 }
 
@@ -92,6 +99,23 @@ test('.fail()', t => {
 	}, {
 		assertion: 'fail',
 		message: 'my message'
+	});
+
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.fail(null, {callSite});
+	}, {
+		assertion: 'fail',
+		message: 'Test failed via `t.fail()`',
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.fail('my message', {callSite});
+	}, {
+		assertion: 'fail',
+		message: 'my message',
+		callSite
 	});
 
 	t.end();
@@ -263,6 +287,66 @@ test('.is()', t => {
 		]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.is('foo', 'bar', null, {callSite});
+	}, {
+		assertion: 'is',
+		message: '',
+		values: [
+			{label: 'Difference:', formatted: /foobar/}
+		],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.is('foo', 42, null, {callSite});
+	}, {
+		assertion: 'is',
+		message: '',
+		values: [
+			{label: 'Actual:', formatted: /foo/},
+			{label: 'Must be the same as:', formatted: /42/}
+		],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.is('foo', 42, 'my message', {callSite});
+	}, {
+		assertion: 'is',
+		message: 'my message',
+		values: [
+			{label: 'Actual:', formatted: /foo/},
+			{label: 'Must be the same as:', formatted: /42/}
+		],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.is(0, -0, 'my message', {callSite});
+	}, {
+		assertion: 'is',
+		message: 'my message',
+		values: [
+			{label: 'Actual:', formatted: /0/},
+			{label: 'Must be the same as:', formatted: /-0/}
+		],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.is(-0, 0, 'my message', {callSite});
+	}, {
+		assertion: 'is',
+		message: 'my message',
+		values: [
+			{label: 'Actual:', formatted: /-0/},
+			{label: 'Must be the same as:', formatted: /0/}
+		],
+		callSite
+	});
+
 	t.end();
 });
 
@@ -293,6 +377,25 @@ test('.not()', t => {
 		assertion: 'not',
 		message: 'my message',
 		values: [{label: 'Value is the same as:', formatted: /foo/}]
+	});
+
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.not('foo', 'foo', null, {callSite});
+	}, {
+		assertion: 'not',
+		message: '',
+		values: [{label: 'Value is the same as:', formatted: /foo/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.not('foo', 'foo', 'my message', {callSite});
+	}, {
+		assertion: 'not',
+		message: 'my message',
+		values: [{label: 'Value is the same as:', formatted: /foo/}],
+		callSite
 	});
 
 	t.end();
@@ -548,6 +651,40 @@ test('.deepEqual()', t => {
 		]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.deepEqual('foo', 'bar', null, {callSite});
+	}, {
+		assertion: 'deepEqual',
+		message: '',
+		values: [{label: 'Difference:', formatted: /foobar/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.deepEqual('foo', 42, null, {callSite});
+	}, {
+		assertion: 'deepEqual',
+		message: '',
+		values: [
+			{label: 'Actual:', formatted: /foo/},
+			{label: 'Must be deeply equal to:', formatted: /42/}
+		],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.deepEqual('foo', 42, 'my message', {callSite});
+	}, {
+		assertion: 'deepEqual',
+		message: 'my message',
+		values: [
+			{label: 'Actual:', formatted: /foo/},
+			{label: 'Must be deeply equal to:', formatted: /42/}
+		],
+		callSite
+	});
+
 	t.end();
 });
 
@@ -574,6 +711,25 @@ test('.notDeepEqual()', t => {
 		assertion: 'notDeepEqual',
 		message: 'my message',
 		values: [{label: 'Value is deeply equal:', formatted: formatValue(['a', 'b'])}]
+	});
+
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.notDeepEqual({a: 'a'}, {a: 'a'}, null, {callSite});
+	}, {
+		assertion: 'notDeepEqual',
+		message: '',
+		values: [{label: 'Value is deeply equal:', formatted: formatValue({a: 'a'})}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.notDeepEqual(['a', 'b'], ['a', 'b'], 'my message', {callSite});
+	}, {
+		assertion: 'notDeepEqual',
+		message: 'my message',
+		values: [{label: 'Value is deeply equal:', formatted: formatValue(['a', 'b'])}],
+		callSite
 	});
 
 	t.end();
@@ -605,6 +761,36 @@ test('.throws()', t => {
 		assertion: 'throws',
 		message: '',
 		values: [{label: 'Threw unexpected exception:', formatted: /foo/}]
+	});
+
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.throws(() => {}, null, null, {callSite});
+	}, {
+		assertion: 'throws',
+		message: '',
+		values: [],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.throws(() => {}, Error, 'my message', {callSite});
+	}, {
+		assertion: 'throws',
+		message: 'my message',
+		values: [],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.throws(() => {
+			throw err;
+		}, 'bar', null, {callSite});
+	}, {
+		assertion: 'throws',
+		message: '',
+		values: [{label: 'Threw unexpected exception:', formatted: /foo/}],
+		callSite
 	});
 
 	passes(t, () => {
@@ -645,6 +831,16 @@ test('.throws() fails if passed a bad value', t => {
 		values: [{label: 'Called with:', formatted: /not a function/}]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.throws('not a function', null, null, {callSite});
+	}, {
+		assertion: 'throws',
+		message: '`t.throws()` must be called with a function, Promise, or Observable',
+		values: [{label: 'Called with:', formatted: /not a function/}],
+		callSite
+	});
+
 	t.end();
 });
 
@@ -673,6 +869,29 @@ test('.notThrows()', t => {
 		values: [{label: 'Threw:', formatted: /foo/}]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.notThrows(() => {
+			throw new Error('foo');
+		}, null, {callSite});
+	}, {
+		assertion: 'notThrows',
+		message: '',
+		values: [{label: 'Threw:', formatted: /foo/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.notThrows(() => {
+			throw new Error('foo');
+		}, 'my message', {callSite});
+	}, {
+		assertion: 'notThrows',
+		message: 'my message',
+		values: [{label: 'Threw:', formatted: /foo/}],
+		callSite
+	});
+
 	t.end();
 });
 
@@ -689,6 +908,16 @@ test('.notThrows() fails if passed a bad value', t => {
 		assertion: 'notThrows',
 		message: '`t.notThrows()` must be called with a function, Promise, or Observable',
 		values: [{label: 'Called with:', formatted: /not a function/}]
+	});
+
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.notThrows('not a function', null, {callSite});
+	}, {
+		assertion: 'notThrows',
+		message: '`t.notThrows()` must be called with a function, Promise, or Observable',
+		values: [{label: 'Called with:', formatted: /not a function/}],
+		callSite
 	});
 
 	t.end();
@@ -772,6 +1001,27 @@ test('.truthy()', t => {
 		values: [{label: 'Value is not truthy:', formatted: /false/}]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.truthy(0, null, {callSite});
+	}, {
+		assertion: 'truthy',
+		message: '',
+		operator: '!!',
+		values: [{label: 'Value is not truthy:', formatted: /0/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.truthy(false, 'my message', {callSite});
+	}, {
+		assertion: 'truthy',
+		message: 'my message',
+		operator: '!!',
+		values: [{label: 'Value is not truthy:', formatted: /false/}],
+		callSite
+	});
+
 	passes(t, () => {
 		assertions.truthy(1);
 		assertions.truthy(true);
@@ -797,6 +1047,27 @@ test('.falsy()', t => {
 		message: 'my message',
 		operator: '!',
 		values: [{label: 'Value is not falsy:', formatted: /true/}]
+	});
+
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.falsy(1, null, {callSite});
+	}, {
+		assertion: 'falsy',
+		message: '',
+		operator: '!',
+		values: [{label: 'Value is not falsy:', formatted: /1/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.falsy(true, 'my message', {callSite});
+	}, {
+		assertion: 'falsy',
+		message: 'my message',
+		operator: '!',
+		values: [{label: 'Value is not falsy:', formatted: /true/}],
+		callSite
 	});
 
 	passes(t, () => {
@@ -840,6 +1111,43 @@ test('.true()', t => {
 		values: [{label: 'Value is not `true`:', formatted: /foo/}]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.true(1, null, {callSite});
+	}, {
+		assertion: 'true',
+		message: '',
+		values: [{label: 'Value is not `true`:', formatted: /1/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.true(0, null, {callSite});
+	}, {
+		assertion: 'true',
+		message: '',
+		values: [{label: 'Value is not `true`:', formatted: /0/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.true(false, null, {callSite});
+	}, {
+		assertion: 'true',
+		message: '',
+		values: [{label: 'Value is not `true`:', formatted: /false/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.true('foo', 'my message', {callSite});
+	}, {
+		assertion: 'true',
+		message: 'my message',
+		values: [{label: 'Value is not `true`:', formatted: /foo/}],
+		callSite
+	});
+
 	passes(t, () => {
 		assertions.true(true);
 	});
@@ -880,6 +1188,43 @@ test('.false()', t => {
 		values: [{label: 'Value is not `false`:', formatted: /foo/}]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.false(0, null, {callSite});
+	}, {
+		assertion: 'false',
+		message: '',
+		values: [{label: 'Value is not `false`:', formatted: /0/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.false(1, null, {callSite});
+	}, {
+		assertion: 'false',
+		message: '',
+		values: [{label: 'Value is not `false`:', formatted: /1/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.false(true, null, {callSite});
+	}, {
+		assertion: 'false',
+		message: '',
+		values: [{label: 'Value is not `false`:', formatted: /true/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.false('foo', 'my message', {callSite});
+	}, {
+		assertion: 'false',
+		message: 'my message',
+		values: [{label: 'Value is not `false`:', formatted: /foo/}],
+		callSite
+	});
+
 	passes(t, () => {
 		assertions.false(false);
 	});
@@ -914,6 +1259,31 @@ test('.regex()', t => {
 		]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.regex('foo', /^abc$/, null, {callSite});
+	}, {
+		assertion: 'regex',
+		message: '',
+		values: [
+			{label: 'Value must match expression:', formatted: /foo/},
+			{label: 'Regular expression:', formatted: /\/\^abc\$\//}
+		],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.regex('foo', /^abc$/, 'my message', {callSite});
+	}, {
+		assertion: 'regex',
+		message: 'my message',
+		values: [
+			{label: 'Value must match expression:', formatted: /foo/},
+			{label: 'Regular expression:', formatted: /\/\^abc\$\//}
+		],
+		callSite
+	});
+
 	t.end();
 });
 
@@ -932,6 +1302,25 @@ test('.regex() fails if passed a bad value', t => {
 		assertion: 'regex',
 		message: '`t.regex()` must be called with a regular expression',
 		values: [{label: 'Called with:', formatted: /Object/}]
+	});
+
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.regex(42, /foo/, null, {callSite});
+	}, {
+		assertion: 'regex',
+		message: '`t.regex()` must be called with a string',
+		values: [{label: 'Called with:', formatted: /42/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.regex('42', {}, null, {callSite});
+	}, {
+		assertion: 'regex',
+		message: '`t.regex()` must be called with a regular expression',
+		values: [{label: 'Called with:', formatted: /Object/}],
+		callSite
 	});
 
 	t.end();
@@ -964,6 +1353,31 @@ test('.notRegex()', t => {
 		]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.notRegex('abc', /abc/, null, {callSite});
+	}, {
+		assertion: 'notRegex',
+		message: '',
+		values: [
+			{label: 'Value must not match expression:', formatted: /abc/},
+			{label: 'Regular expression:', formatted: /\/abc\//}
+		],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.notRegex('abc', /abc/, 'my message', {callSite});
+	}, {
+		assertion: 'notRegex',
+		message: 'my message',
+		values: [
+			{label: 'Value must not match expression:', formatted: /abc/},
+			{label: 'Regular expression:', formatted: /\/abc\//}
+		],
+		callSite
+	});
+
 	t.end();
 });
 
@@ -984,5 +1398,34 @@ test('.notRegex() fails if passed a bad value', t => {
 		values: [{label: 'Called with:', formatted: /Object/}]
 	});
 
+	const callSite = new CallSite();
+	failsWith(t, () => {
+		assertions.notRegex(42, /foo/, null, {callSite});
+	}, {
+		assertion: 'notRegex',
+		message: '`t.notRegex()` must be called with a string',
+		values: [{label: 'Called with:', formatted: /42/}],
+		callSite
+	});
+
+	failsWith(t, () => {
+		assertions.notRegex('42', {}, null, {callSite});
+	}, {
+		assertion: 'notRegex',
+		message: '`t.notRegex()` must be called with a regular expression',
+		values: [{label: 'Called with:', formatted: /Object/}],
+		callSite
+	});
+
+	t.end();
+});
+
+test('CallSite provides stack proxy functionality', t => {
+	const callSite = new CallSite();
+	t.true(typeof callSite.getStack === 'function');
+	t.true(typeof callSite.getStack() === 'string');
+	const stackTargetingFoo = callSite.getStack('Foo:');
+	t.true(stackTargetingFoo.indexOf('Foo:') === 0);
+	t.true(stackTargetingFoo.split('\n')[1].indexOf('assert.js') > 0);
 	t.end();
 });


### PR DESCRIPTION
See #1396. I've not been able to test that it works with snapshots, because I don't really understand how the snapshoting works, otherwize there is updated tests for all asserts. It's not been decided whether or not this is a feature ava want's to support, but I figured it's better to have an actual implementation to talk about. I will likely be using this fork in my Fable bindings.

Currently there are two tests failing locally for me, but they were failing in master as well locally.