### PR TITLE
Improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: node_js
 node_js:
-  - '8'
-  - '6'
-  - '4'
+  - 8
+  - 6
+  - 4
+env:
+  - FRESH_DEPS=false
+  - FRESH_DEPS=true
+matrix:
+  exclude:
+    - node_js: 6
+      env: FRESH_DEPS=true
+    - node_js: 4
+      env: FRESH_DEPS=true
 cache:
   directories:
     - $HOME/.npm
     - node_modules
 before_install:
-  - 'npm install --global npm'
-before_script:
-  - 'npm prune'
-after_success:
-  - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'
+  - npm install --global npm@^5.0.3
+  - npm --version
+  - if [[ ${FRESH_DEPS} == "true" ]]; then rm package-lock.json; fi
+after_success: ./node_modules/.bin/codecov --file=./coverage/lcov.info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,34 @@
-environment:
-  matrix:
-    - nodejs_version: '8'
-    - nodejs_version: '6'
-    - nodejs_version: '4'
-install:
-  - ps: Install-Product node $env:nodejs_version
-  - set CI=true
-  - set AVA_APPVEYOR=true
-  - git config core.symlinks true
-  - git reset --hard
-  - npm install --global npm
-  - set PATH=%APPDATA%\npm;%PATH%
-  - npm install
-  - npm prune
-matrix:
-  fast_finish: true
 build: off
-clone_depth: 1
 cache:
   - node_modules
   - '%APPDATA%\npm-cache'
-test_script:
-  - node --version
+clone_depth: 1
+skip_branch_with_pr: true
+skip_commits:
+  files:
+    - '**/*.md'
+configuration:
+  - FreshDeps
+  - LockedDeps
+environment:
+  matrix:
+    - nodejs_version: 8
+    - nodejs_version: 6
+    - nodejs_version: 4
+matrix:
+  fast_finish: true
+  exclude:
+    - configuration: FreshDeps
+      nodejs_version: 6
+    - configuration: FreshDeps
+      nodejs_version: 4
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install --global npm@^5.0.3
   - npm --version
+  - git config core.symlinks true
+  - git reset --hard
+  - ps: if ($env:configuration -eq "FreshDeps") { Remove-Item package-lock.json }
+  - npm install
+test_script:
   - npm run test-win

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "test": "xo && flow check test/flow-types && tsc -p test/ts-types && nyc tap --no-cov --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
-    "test-win": "tap --no-cov --reporter=classic --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
+    "test-win": "tap --no-cov --reporter=classic --timeout=300 --jobs=4 test/*.js test/reporters/*.js",
     "visual": "node test/visual/run-visual-tests.js",
     "prepublish": "npm run make-ts",
     "make-ts": "node types/make.js"

--- a/test/babel-config.js
+++ b/test/babel-config.js
@@ -116,13 +116,17 @@ test('caches and uses results', t => {
 			const firstCacheKeys = result.cacheKeys;
 			const stats = files.map(f => fs.statSync(path.join(cacheDir, f)));
 			delete stats[0].atime;
+			delete stats[0].atimeMs;
 			delete stats[1].atime;
+			delete stats[1].atimeMs;
 
 			return babelConfigHelper.build(projectDir, cacheDir, 'default', true)
 				.then(result => {
 					const newStats = files.map(f => fs.statSync(path.join(cacheDir, f)));
 					delete newStats[0].atime;
+					delete newStats[0].atimeMs;
 					delete newStats[1].atime;
+					delete newStats[1].atimeMs;
 
 					t.same(newStats, stats);
 					t.same(result.cacheKeys, firstCacheKeys);

--- a/test/cli.js
+++ b/test/cli.js
@@ -28,10 +28,6 @@ function execCli(args, opts, cb) {
 		env = opts.env || {};
 	}
 
-	if (process.env.AVA_APPVEYOR) {
-		env.AVA_APPVEYOR = 1;
-	}
-
 	let child;
 	let stdout;
 	let stderr;


### PR DESCRIPTION
Highlights:

* Test on latest Node.js without a `package-lock`: this means we're testing the dependencies as seen by the user when they install AVA
* Test on all Node.js versions with a `package-lock`. This includes the latest version, which may be useful in determining whether a failure is due to a dependency or not
* Fix tests for Node.js 8.1.0
* Allow tests to take longer
* More efficient AppVeyor tests