### PR TITLE
More CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ matrix:
 cache:
   directories:
     - $HOME/.npm
-    - node_modules
 before_install:
   - npm install --global npm@^5.0.3
   - npm --version
   - if [[ ${FRESH_DEPS} == "true" ]]; then rm package-lock.json; fi
+install:
+  - if [[ ${FRESH_DEPS} == "true" ]]; then npm install --prefer-online; else npm install --prefer-offline; fi
 after_success: ./node_modules/.bin/codecov --file=./coverage/lcov.info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 build: off
 cache:
-  - node_modules
   - '%APPDATA%\npm-cache'
 clone_depth: 1
 skip_branch_with_pr: true
@@ -29,6 +28,7 @@ install:
   - git config core.symlinks true
   - git reset --hard
   - ps: if ($env:configuration -eq "FreshDeps") { Remove-Item package-lock.json }
-  - npm install
+  - if %configuration% == FreshDeps (npm install --prefer-online)
+  - if %configuration% == LockedDeps (npm install --prefer-online)
 test_script:
   - npm run test-win

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo && flow check test/flow-types && tsc -p test/ts-types && nyc tap --no-cov --timeout=150 --jobs=4 test/*.js test/reporters/*.js",
+    "test": "xo && flow check test/flow-types && tsc -p test/ts-types && nyc tap --no-cov --timeout=300 --jobs=4 test/*.js test/reporters/*.js",
     "test-win": "tap --no-cov --reporter=classic --timeout=300 --jobs=4 test/*.js test/reporters/*.js",
     "visual": "node test/visual/run-visual-tests.js",
     "prepublish": "npm run make-ts",


### PR DESCRIPTION
I forgot to bump the test timeout for Travis, so we were still seeing lots of failures. Caching the `node_modules` folder keeps tripping up npm installs, so instead rely on npm's tarball caching and `--prefer-offline` / `--prefer-online` flags.