### PR TITLE
Set absolute output path in Webpack config used for precompiling

### DIFF
--- a/docs/recipes/precompiling-with-webpack.md
+++ b/docs/recipes/precompiling-with-webpack.md
@@ -7,13 +7,14 @@ The AVA [readme](https://github.com/avajs/ava#transpiling-imported-modules) ment
 ###### webpack.config.js
 
 ```js
+const path = require('path');
 const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
 	entry: ['src/tests.js'],
 	target: 'node',
 	output: {
-		path: '_build',
+		path: path.join(__dirname, '_build'),
 		filename: 'tests.js'
 	},
 	externals: [nodeExternals()],


### PR DESCRIPTION
Using `output.path: '_build'` (tested in Webpack v2.5.1) will lead to:
```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "_build" is not an absolute path!
```
