### PR TITLE
Fix debugging with Webstorm on Node.js 8

### DIFF
--- a/api.js
+++ b/api.js
@@ -173,7 +173,7 @@ class Api extends EventEmitter {
 
 		// --inspect-brk is used in addition to --inspect to break on first line and wait
 		execArgv.some((arg, index) => {
-			const isDebugArg = arg === '--inspect' || arg === '--inspect-brk' || arg.indexOf('--inspect=') === 0 || arg.indexOf('--inspect-brk=') === 0;
+			const isDebugArg = /^--inspect(-brk)?($|=)/.test(arg);
 			if (isDebugArg) {
 				debugArgIndex = index;
 			}
@@ -184,7 +184,7 @@ class Api extends EventEmitter {
 		const isInspect = debugArgIndex >= 0;
 		if (!isInspect) {
 			execArgv.some((arg, index) => {
-				const isDebugArg = arg === '--debug' || arg === '--debug-brk' || arg.indexOf('--debug-brk=') === 0 || arg.indexOf('--debug=') === 0;
+				const isDebugArg = /^--debug(-brk)?($|=)/.test(arg);
 				if (isDebugArg) {
 					debugArgIndex = index;
 				}

--- a/api.js
+++ b/api.js
@@ -173,7 +173,7 @@ class Api extends EventEmitter {
 
 		// --debug-brk is used in addition to --inspect to break on first line and wait
 		execArgv.some((arg, index) => {
-			const isDebugArg = arg === '--inspect' || arg.indexOf('--inspect=') === 0;
+			const isDebugArg = arg === '--inspect' || arg === '--inspect-brk' || arg.indexOf('--inspect=') === 0 || arg.indexOf('--inspect-brk=') === 0;
 			if (isDebugArg) {
 				debugArgIndex = index;
 			}

--- a/api.js
+++ b/api.js
@@ -171,7 +171,7 @@ class Api extends EventEmitter {
 		const execArgv = this.options.testOnlyExecArgv || process.execArgv;
 		let debugArgIndex = -1;
 
-		// --debug-brk is used in addition to --inspect to break on first line and wait
+		// --inspect-brk is used in addition to --inspect to break on first line and wait
 		execArgv.some((arg, index) => {
 			const isDebugArg = arg === '--inspect' || arg === '--inspect-brk' || arg.indexOf('--inspect=') === 0 || arg.indexOf('--inspect-brk=') === 0;
 			if (isDebugArg) {

--- a/test/api.js
+++ b/test/api.js
@@ -1049,9 +1049,11 @@ generatePassDebugTests(['--debug'], -1);
 generatePassDebugTests(['--inspect=0'], 0);
 generatePassDebugTests(['--inspect'], 0);
 
+// --inspect takes precedence
 generatePassDebugTests(['--inspect=0', '--debug-brk'], 0);
 generatePassDebugTests(['--inspect', '--debug-brk'], 0);
 
+// --inspect takes precedence, though --debug-brk is still passed to the worker
 generatePassDebugTests(['--debug-brk', '--inspect=0'], 1);
 generatePassDebugTests(['--debug-brk', '--inspect'], 1);
 


### PR DESCRIPTION
## Description
On Node 8 Webstorm debug is not working any longer. The reason is, that the `--inspect-brk` is not handled correctly inside of the cli.js file

### Error Message & Stack Trace
```
Starting inspector on 127.0.0.1:53733 failed: address already in use
```
### Fix
Adding --inspect-brk to api.js

## Environment
Node v8.1, latest AVAJS