### PR TITLE
Allow extra input params during profiling

### DIFF
--- a/profile.js
+++ b/profile.js
@@ -66,7 +66,7 @@ const cli = meow(`
 	}
 });
 
-if (cli.input.length !== 1) {
+if (cli.input.length === 0) {
 	throw new Error('Specify a test file');
 }
 


### PR DESCRIPTION
Allows extra params to be passed to profile, for example when one needs to specify a different location for dotenv.  you must pass in arg in the form of `dotenv_config_path=path/to/.env`

Should not affect profiling, since only the first `cli.input[0]` is used.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
