### PR TITLE
Include raw actual and expected objects in AssertionError

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -29,7 +29,7 @@ function formatWithLabel(label, value) {
 }
 
 class AssertionError extends Error {
-	constructor(opts, raw) {
+	constructor(opts) {
 		super(opts.message || '');
 		this.name = 'AssertionError';
 
@@ -42,7 +42,7 @@ class AssertionError extends Error {
 		// Raw expected and actual objects are stored for custom reporters
 		// (such as wallaby.js), that manage worker processes directly and
 		// use the values for custom diff views
-		this.raw = raw;
+		this.raw = opts.raw;
 
 		// Reserved for power-assert statements
 		this.statements = [];
@@ -91,8 +91,9 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'is',
 					message,
+					raw: {actual, expected},
 					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-				}, {actual, expected}));
+				}));
 			}
 		},
 
@@ -101,8 +102,9 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'not',
 					message,
+					raw: {actual, expected},
 					values: [formatWithLabel('Value is the same as:', actual)]
-				}, {actual, expected}));
+				}));
 			} else {
 				pass(this);
 			}
@@ -118,8 +120,9 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'deepEqual',
 					message,
+					raw: {actual, expected},
 					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-				}, {actual, expected}));
+				}));
 			}
 		},
 
@@ -130,8 +133,9 @@ function wrapAssertions(callbacks) {
 				fail(this, new AssertionError({
 					assertion: 'notDeepEqual',
 					message,
+					raw: {actual, expected},
 					values: [formatDescriptorWithLabel('Value is deeply equal:', actualDescriptor)]
-				}, {actual, expected}));
+				}));
 			} else {
 				pass(this);
 			}

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -29,7 +29,7 @@ function formatWithLabel(label, value) {
 }
 
 class AssertionError extends Error {
-	constructor(opts) {
+	constructor(opts, raw) {
 		super(opts.message || '');
 		this.name = 'AssertionError';
 
@@ -38,8 +38,11 @@ class AssertionError extends Error {
 		this.improperUsage = opts.improperUsage || false;
 		this.operator = opts.operator;
 		this.values = opts.values || [];
-		this.actual = opts.actual;
-		this.expected = opts.expected;
+
+		// Raw expected and actual objects are stored for custom reporters
+		// (such as wallaby.js), that manage worker processes directly and
+		// use the values for custom diff views
+		this.raw = raw;
 
 		// Reserved for power-assert statements
 		this.statements = [];
@@ -86,24 +89,20 @@ function wrapAssertions(callbacks) {
 				const actualDescriptor = concordance.describe(actual, concordanceOptions);
 				const expectedDescriptor = concordance.describe(expected, concordanceOptions);
 				fail(this, new AssertionError({
-					actual,
 					assertion: 'is',
-					expected,
 					message,
 					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-				}));
+				}, {actual, expected}));
 			}
 		},
 
 		not(actual, expected, message) {
 			if (Object.is(actual, expected)) {
 				fail(this, new AssertionError({
-					actual,
 					assertion: 'not',
-					expected,
 					message,
 					values: [formatWithLabel('Value is the same as:', actual)]
-				}));
+				}, {actual, expected}));
 			} else {
 				pass(this);
 			}
@@ -117,12 +116,10 @@ function wrapAssertions(callbacks) {
 				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
 				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
 				fail(this, new AssertionError({
-					actual,
 					assertion: 'deepEqual',
-					expected,
 					message,
 					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-				}));
+				}, {actual, expected}));
 			}
 		},
 
@@ -131,12 +128,10 @@ function wrapAssertions(callbacks) {
 			if (result.pass) {
 				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
 				fail(this, new AssertionError({
-					actual,
 					assertion: 'notDeepEqual',
-					expected,
 					message,
 					values: [formatDescriptorWithLabel('Value is deeply equal:', actualDescriptor)]
-				}));
+				}, {actual, expected}));
 			} else {
 				pass(this);
 			}

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -38,6 +38,8 @@ class AssertionError extends Error {
 		this.improperUsage = opts.improperUsage || false;
 		this.operator = opts.operator;
 		this.values = opts.values || [];
+		this.actual = opts.actual;
+		this.expected = opts.expected;
 
 		// Reserved for power-assert statements
 		this.statements = [];
@@ -84,7 +86,9 @@ function wrapAssertions(callbacks) {
 				const actualDescriptor = concordance.describe(actual, concordanceOptions);
 				const expectedDescriptor = concordance.describe(expected, concordanceOptions);
 				fail(this, new AssertionError({
+					actual,
 					assertion: 'is',
+					expected,
 					message,
 					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
 				}));
@@ -94,7 +98,9 @@ function wrapAssertions(callbacks) {
 		not(actual, expected, message) {
 			if (Object.is(actual, expected)) {
 				fail(this, new AssertionError({
+					actual,
 					assertion: 'not',
+					expected,
 					message,
 					values: [formatWithLabel('Value is the same as:', actual)]
 				}));
@@ -111,7 +117,9 @@ function wrapAssertions(callbacks) {
 				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
 				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
 				fail(this, new AssertionError({
+					actual,
 					assertion: 'deepEqual',
+					expected,
 					message,
 					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
 				}));
@@ -123,7 +131,9 @@ function wrapAssertions(callbacks) {
 			if (result.pass) {
 				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
 				fail(this, new AssertionError({
+					actual,
 					assertion: 'notDeepEqual',
+					expected,
 					message,
 					values: [formatDescriptorWithLabel('Value is deeply equal:', actualDescriptor)]
 				}));

--- a/test/assert.js
+++ b/test/assert.js
@@ -39,6 +39,10 @@ function assertFailure(t, subset) {
 	t.is(lastFailure.message, subset.message);
 	t.is(lastFailure.name, 'AssertionError');
 	t.is(lastFailure.operator, subset.operator);
+	if (subset.expected) {
+		t.is(lastFailure.expected, subset.expected);
+		t.is(lastFailure.actual, subset.actual);
+	}
 	if (subset.statements) {
 		t.is(lastFailure.statements.length, subset.statements.length);
 		lastFailure.statements.forEach((s, i) => {
@@ -233,7 +237,9 @@ test('.is()', t => {
 	failsWith(t, () => {
 		assertions.is('foo', 'bar');
 	}, {
+		actual: 'foo',
 		assertion: 'is',
+		expected: 'bar',
 		message: '',
 		values: [
 			{label: 'Difference:', formatted: /- 'foo'\n\+ 'bar'/}
@@ -243,7 +249,9 @@ test('.is()', t => {
 	failsWith(t, () => {
 		assertions.is('foo', 42);
 	}, {
+		actual: 'foo',
 		assertion: 'is',
+		expected: 42,
 		message: '',
 		values: [
 			{label: 'Difference:', formatted: /- 'foo'\n\+ 42/}
@@ -299,7 +307,9 @@ test('.not()', t => {
 	failsWith(t, () => {
 		assertions.not('foo', 'foo');
 	}, {
+		actual: 'foo',
 		assertion: 'not',
+		expected: 'foo',
 		message: '',
 		values: [{label: 'Value is the same as:', formatted: /foo/}]
 	});
@@ -544,7 +554,9 @@ test('.deepEqual()', t => {
 	failsWith(t, () => {
 		assertions.deepEqual('foo', 'bar');
 	}, {
+		actual: 'foo',
 		assertion: 'deepEqual',
+		expected: 'bar',
 		message: '',
 		values: [{label: 'Difference:', formatted: /- 'foo'\n\+ 'bar'/}]
 	});
@@ -552,7 +564,9 @@ test('.deepEqual()', t => {
 	failsWith(t, () => {
 		assertions.deepEqual('foo', 42);
 	}, {
+		actual: 'foo',
 		assertion: 'deepEqual',
+		expected: 42,
 		message: '',
 		values: [{label: 'Difference:', formatted: /- 'foo'\n\+ 42/}]
 	});
@@ -577,10 +591,14 @@ test('.notDeepEqual()', t => {
 		assertions.notDeepEqual(['a', 'b'], ['c', 'd']);
 	});
 
+	const actual = {a: 'a'};
+	const expected = {a: 'a'};
 	failsWith(t, () => {
-		assertions.notDeepEqual({a: 'a'}, {a: 'a'});
+		assertions.notDeepEqual(actual, expected);
 	}, {
+		actual,
 		assertion: 'notDeepEqual',
+		expected,
 		message: '',
 		values: [{label: 'Value is deeply equal:', formatted: /.*\{.*\n.*a: 'a'/}]
 	});

--- a/test/assert.js
+++ b/test/assert.js
@@ -39,9 +39,9 @@ function assertFailure(t, subset) {
 	t.is(lastFailure.message, subset.message);
 	t.is(lastFailure.name, 'AssertionError');
 	t.is(lastFailure.operator, subset.operator);
-	if (subset.expected) {
-		t.is(lastFailure.expected, subset.expected);
-		t.is(lastFailure.actual, subset.actual);
+	if (subset.raw) {
+		t.is(lastFailure.raw.expected, subset.raw.expected);
+		t.is(lastFailure.raw.actual, subset.raw.actual);
 	}
 	if (subset.statements) {
 		t.is(lastFailure.statements.length, subset.statements.length);
@@ -237,10 +237,9 @@ test('.is()', t => {
 	failsWith(t, () => {
 		assertions.is('foo', 'bar');
 	}, {
-		actual: 'foo',
 		assertion: 'is',
-		expected: 'bar',
 		message: '',
+		raw: {actual: 'foo', expected: 'bar'},
 		values: [
 			{label: 'Difference:', formatted: /- 'foo'\n\+ 'bar'/}
 		]
@@ -307,10 +306,9 @@ test('.not()', t => {
 	failsWith(t, () => {
 		assertions.not('foo', 'foo');
 	}, {
-		actual: 'foo',
 		assertion: 'not',
-		expected: 'foo',
 		message: '',
+		raw: {actual: 'foo', expected: 'foo'},
 		values: [{label: 'Value is the same as:', formatted: /foo/}]
 	});
 
@@ -554,20 +552,18 @@ test('.deepEqual()', t => {
 	failsWith(t, () => {
 		assertions.deepEqual('foo', 'bar');
 	}, {
-		actual: 'foo',
 		assertion: 'deepEqual',
-		expected: 'bar',
 		message: '',
+		raw: {actual: 'foo', expected: 'bar'},
 		values: [{label: 'Difference:', formatted: /- 'foo'\n\+ 'bar'/}]
 	});
 
 	failsWith(t, () => {
 		assertions.deepEqual('foo', 42);
 	}, {
-		actual: 'foo',
 		assertion: 'deepEqual',
-		expected: 42,
 		message: '',
+		raw: {actual: 'foo', expected: 42},
 		values: [{label: 'Difference:', formatted: /- 'foo'\n\+ 42/}]
 	});
 
@@ -600,6 +596,7 @@ test('.notDeepEqual()', t => {
 		assertion: 'notDeepEqual',
 		expected,
 		message: '',
+		raw: {actual, expected},
 		values: [{label: 'Value is deeply equal:', formatted: /.*\{.*\n.*a: 'a'/}]
 	});
 


### PR DESCRIPTION
We support AVA in wallaby.js and have a few custom renderers for displaying assertions diffs in various editors, like:

VS Code:

<img width="478" alt="screen shot 2017-06-30 at 12 09 25 pm" src="https://user-images.githubusercontent.com/979966/27718188-a0042a80-5d8d-11e7-802b-019627d29225.png">

WebStorm:

![screen shot 2017-06-30 at 12 11 50 pm](https://user-images.githubusercontent.com/979966/27718190-a1b06fce-5d8d-11e7-9517-54663ee9ea22.png)

Wallaby App:

![screen shot 2017-06-30 at 12 12 30 pm](https://user-images.githubusercontent.com/979966/27718192-a4c38be2-5d8d-11e7-83b9-eef101735ac3.png)

Other testing frameworks that we support (also various assertion libs, such as `chai`) pass raw `actual` and `expected` objects with their assertion errors, so we (and other custom reporters) are able to display custom diffs.

AVA's new coloured ANSI diff display is great, but in order to display diffs outside of the ANSI supporting viewer (such as in the cases listed above), it would be great if the `AssertionError` contained raw `actual` and `expected` objects, so that a customer reporter integrated with AVA could use them for doing custom diffs/reporting (the screenshots above show how it'd look like once the PR is landed and published in AVA).

The pull request implements passing the raw `actual` and `expected` objects to the `AssertionError` constructor.