### PR TITLE
Remove non-existent npm run script in maintaining.md

### DIFF
--- a/maintaining.md
+++ b/maintaining.md
@@ -11,7 +11,6 @@ Read and adhere to the [Code of Conduct](code-of-conduct.md).
 
  - `npm test`: Lint the code and run the entire test suite with coverage.
  - `npm run test-win`: Run the tests on Windows.
- - `npm run visual`: Run a set of visual tests. Useful during the pre-release process.
  - `tap test/fork.js --bail`: Run a specific test file and bail on the first failure (useful when hunting bugs).
 
 

--- a/maintaining.md
+++ b/maintaining.md
@@ -11,7 +11,7 @@ Read and adhere to the [Code of Conduct](code-of-conduct.md).
 
  - `npm test`: Lint the code and run the entire test suite with coverage.
  - `npm run test-win`: Run the tests on Windows.
- - `npm run coverage`: Generate a coverage report for the last test run (opens a browser window).
+ - `npm run visual`: Run a set of visual tests. Useful during the pre-release process.
  - `tap test/fork.js --bail`: Run a specific test file and bail on the first failure (useful when hunting bugs).
 
 


### PR DESCRIPTION
:wave: Hello!

**What**

This PR  updates the documentation, removing the outdated `coverage` script and including the `visual` script.

**Why**

When cloning the repo and setting everything up, I found about the `maintaining.md` file and tried to `npm run coverage` which gave me an error, as somebody new to the project, this was confusing.
