### PR TITLE
Add more Vue.js recipes

### DIFF
--- a/docs/recipes/debugging-with-webstorm.md
+++ b/docs/recipes/debugging-with-webstorm.md
@@ -40,6 +40,8 @@ Use the following configuration parameters:
 `package.json` : path to your project's `package.json` file
 `Command` : `test`
 
+You IDE will then execute `npm run test` and thus call `node_modules/.bin/ava` and the AVA-configuration you have specified in your package.json.
+
 Do not forget to select a node interpreter.
 
 Save the configuration.

--- a/docs/recipes/debugging-with-webstorm.md
+++ b/docs/recipes/debugging-with-webstorm.md
@@ -5,7 +5,7 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/do
 Starting with version 2016.2, [WebStorm](https://www.jetbrains.com/webstorm/) and other JetBrains IDEs (IntelliJ IDEA Ultimate, PHPStorm, PyCharm Professional, and RubyMine with installed Node.js plugin) allow you to debug AVA tests.
 
 
-## Setup
+## Setup using Node.js
 
 Add a new *Node.js Run/Debug configuration*: select `Edit Configurations...` from the dropdown list on the top right, then click `+` and select *Node.js*.
 
@@ -15,6 +15,34 @@ In the `Application parameters` pass the CLI flags you're using and the test fil
 
 Save the configuration.
 
+## Setup using NPM
+
+Execute `ava --init` in your project directory, to add AVA to your `package.json`.
+
+Your `package.json` will look something like this:
+
+```json
+{
+    "name": "awesome-package",
+    "scripts": {
+        "test": "ava"
+    },
+    "devDependencies": {
+        "ava": "^0.19.0"
+    }
+}
+```
+
+Add a new *NPM Run/Debug configuration*: select `Edit Configurations...` from the dropdown list on the top right, then click `+` and select *NPM*.
+
+Use the following configuration parameters:
+
+`package.json` : path to your project's `package.json` file
+`Command` : `test`
+
+Do not forget to select a node interpreter.
+
+Save the configuration.
 
 ## Debug
 

--- a/docs/recipes/debugging-with-webstorm.md
+++ b/docs/recipes/debugging-with-webstorm.md
@@ -15,34 +15,34 @@ In the `Application parameters` pass the CLI flags you're using and the test fil
 
 Save the configuration.
 
-## Setup using NPM
+## Setup using npm
 
-Execute `ava --init` in your project directory, to add AVA to your `package.json`.
+Execute `ava --init` in your project directory to add AVA to your `package.json`.
 
 Your `package.json` will look something like this:
 
 ```json
 {
-    "name": "awesome-package",
-    "scripts": {
-        "test": "ava"
-    },
-    "devDependencies": {
-        "ava": "^0.19.0"
-    }
+	"name": "awesome-package",
+	"scripts": {
+		"test": "ava"
+	},
+	"devDependencies": {
+		"ava": "^0.20.0"
+	}
 }
 ```
 
-Add a new *NPM Run/Debug configuration*: select `Edit Configurations...` from the dropdown list on the top right, then click `+` and select *NPM*.
+Add a new *npm Run/Debug configuration*: select `Edit Configurations...` from the dropdown list on the top right, then click `+` and select *npm*.
 
 Use the following configuration parameters:
 
-`package.json` : path to your project's `package.json` file
-`Command` : `test`
+- `package.json`: Path to your project's `package.json` file
+- `Command`: `test`
 
-You IDE will then execute `npm run test` and thus call `node_modules/.bin/ava` and the AVA-configuration you have specified in your package.json.
+Your IDE will then execute `npm run test` and thus call `node_modules/.bin/ava` and the AVA-configuration you have specified in your package.json.
 
-Do not forget to select a node interpreter.
+Don't forget to select a Node.js interpreter.
 
 Save the configuration.
 

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -102,14 +102,13 @@ import test from 'ava';
 import Vue from 'vue';
 import Component from 'component.vue';
 
-test('it sees the updated message', t => {
+test('see the updated message', t => {
 
 	const vm = new Vue(Component).$mount();
 	t.is(vm.$el.textContent, 'my message'); 
 
 	vm.message = 'my new message';
 	// this fails here: t.is('my new message', vm.$el.textContent)
-
 
 	Vue.nextTick(() => {
 		t.is(vm.$el.textContent, 'my new message');
@@ -128,7 +127,7 @@ import Vue from 'vue';
 import Component from 'component.vue';
 
 // Don't forget to add the async prefix
-test('it updates the model using promises', async t => {
+test('update the model using promises', async t => {
 
 	// assume the message data property is a pending promise defined in the Component.
 	const vm = new Vue(Component).$mount();

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -5,10 +5,12 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/do
 ## Dependencies
 
 - [Require extension hooks](https://github.com/jackmellis/require-extension-hooks):
-	- `npm i --save-dev require-extension-hooks require-extension-hooks-vue require-extension-hooks-babel`
+
+  `npm install --save-dev require-extension-hooks require-extension-hooks-vue require-extension-hooks-babel`
 
 - [browser-env](browser-testing.md)
-	- `npm i --save-dev browser-env`
+
+	`npm install --save-dev browser-env`
 
 ## Setup
 
@@ -36,13 +38,14 @@ const Vue = require('vue');
 // Setup Vue.js to remove production tip
 Vue.config.productionTip = false;
 
-// Setup vue files to be processed by `require-extension-hooks-vue`
+// Setup Vue files to be processed by `require-extension-hooks-vue`
 hooks('vue').plugin('vue').push();
-// Setup vue and js files to be processed by `require-extension-hooks-babel`
+// Setup Vue and JS files to be processed by `require-extension-hooks-babel`
 hooks(['vue', 'js']).plugin('babel').push();
 ```
 
-When you are using ES6 modules, use the dist-file of vue. Not doing that may cause a not completely accessible (and thus not testable) vue model.
+When you are using ES6 modules, use the dist-file of Vue. Not doing that may cause a not completely accessible (and thus not testable) Vue model.
+
 ```js
 import browserEnv from 'browser-env';
 import hooks from 'require-extension-hooks';
@@ -55,10 +58,8 @@ Vue.config.productionTip = false;
 
 // Setup vue files to be processed by `require-extension-hooks-vue`
 hooks('vue').plugin('vue').push();
-// Setup vue and js files to be processed by `require-extension-hooks-babel`
+// Setup Vue and JS files to be processed by `require-extension-hooks-babel`
 hooks(['vue', 'js']).plugin('babel').push();
-
-
 ```
 
 You can find more information about setting up Babel with AVA in the [babelrc recipe](babelrc.md).
@@ -80,22 +81,21 @@ test('renders', t => {
 ```
 
 ## Sample data test
+
 ```js
 import test from 'ava';
 import Vue from 'vue';
 import Component from 'component.vue';
 
 test('it has a message', t => {
-
 	const vm = new Vue(Component).$mount();
 	t.is('my message', vm.message);
-
 });
 ```
 
 ## Sample DOM testing with data manipulation
 
-When manipulating the data object of a vue model, the DOM will not be updated immediately. It will be changed on the next tick.
+When manipulating the data object of a Vue model, the DOM will not be updated immediately. It will be changed on the next tick.
 
 ```js
 import test from 'ava';
@@ -103,9 +103,8 @@ import Vue from 'vue';
 import Component from 'component.vue';
 
 test('see the updated message', t => {
-
 	const vm = new Vue(Component).$mount();
-	t.is(vm.$el.textContent, 'my message'); 
+	t.is(vm.$el.textContent, 'my message');
 
 	vm.message = 'my new message';
 	// this fails here: t.is('my new message', vm.$el.textContent)
@@ -113,13 +112,12 @@ test('see the updated message', t => {
 	Vue.nextTick(() => {
 		t.is(vm.$el.textContent, 'my new message');
 	});
-
 });
 ```
 
 ## Sample DOM testing with promises
 
-When using promises to fetch data to update the vue model, you have to put your tests in the `then()` function of the pending promise.
+When using promises to fetch data to update the Vue model, you have to put your tests in the `then()` function of the pending promise.
 
 ```js
 import test from 'ava';
@@ -128,14 +126,12 @@ import Component from 'component.vue';
 
 // Don't forget to add the async prefix
 test('update the model using promises', async t => {
-
 	// assume the message data property is a pending promise defined in the Component.
 	const vm = new Vue(Component).$mount();
 
-	
 	// just testing the data model can be achieved by using await
 	t.is(await vm.message, 'my message');
-	
+
 	await vm.message.then((data) => {
 
 		// Set the data property to the result of the pending promise
@@ -145,10 +141,7 @@ test('update the model using promises', async t => {
 		Vue.nextTick(() => {
 			t.is(vm.$el.textContent, 'my message');
 		});
-		
-
 	});
-
 });
 ```
 

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -42,6 +42,25 @@ hooks('vue').plugin('vue').push();
 hooks(['vue', 'js']).plugin('babel').push();
 ```
 
+When you are using ES6 modules, use the dist-file of vue. Not doing that may cause a not completely accessible (and thus not testable) vue model.
+```js
+import browserEnv from 'browser-env';
+import hooks from 'require-extension-hooks';
+import Vue from 'vue/dist/vue';
+
+browserEnv();
+
+// Setup Vue.js to remove production tip
+Vue.config.productionTip = false;
+
+// Setup vue files to be processed by `require-extension-hooks-vue`
+hooks('vue').plugin('vue').push();
+// Setup vue and js files to be processed by `require-extension-hooks-babel`
+hooks(['vue', 'js']).plugin('babel').push();
+
+
+```
+
 You can find more information about setting up Babel with AVA in the [babelrc recipe](babelrc.md).
 
 ## Sample snapshot test
@@ -57,6 +76,80 @@ test('renders', t => {
 		$el: vm.$el.outerHTML
 	};
 	t.snapshot(tree);
+});
+```
+
+## Sample data test
+```js
+import test from 'ava';
+import Vue from 'vue';
+import Component from 'component.vue';
+
+test('it has a message', t => {
+
+	const vm = new Vue(Component).$mount();
+	t.is('my message', vm.message);
+
+});
+```
+
+## Sample DOM testing with data manipulation
+
+When manipulating the data object of a vue model, the DOM will not be updated immediately. It will be changed on the next tick.
+
+```js
+import test from 'ava';
+import Vue from 'vue';
+import Component from 'component.vue';
+
+test('it sees the updated message', t => {
+
+	const vm = new Vue(Component).$mount();
+	t.is(vm.$el.textContent, 'my message'); 
+
+	vm.message = 'my new message';
+	// this fails here: t.is('my new message', vm.$el.textContent)
+
+
+	Vue.nextTick(() => {
+		t.is(vm.$el.textContent, 'my new message');
+	});
+
+});
+```
+
+## Sample DOM testing with promises
+
+When using promises to fetch data to update the vue model, you have to put your tests in the `then()` function of the pending promise.
+
+```js
+import test from 'ava';
+import Vue from 'vue';
+import Component from 'component.vue';
+
+// Don't forget to add the async prefix
+test('it updates the model using promises', async t => {
+
+	// assume the message data property is a pending promise defined in the Component.
+	const vm = new Vue(Component).$mount();
+
+	
+	// just testing the data model can be achieved by using await
+	t.is(await vm.message, 'my message');
+	
+	await vm.message.then((data) => {
+
+		// Set the data property to the result of the pending promise
+		vm.message = data;
+
+		// In the next tick, the data model changes are applied to the DOM
+		Vue.nextTick(() => {
+			t.is(vm.$el.textContent, 'my message');
+		});
+		
+
+	});
+
 });
 ```
 


### PR DESCRIPTION
I have struggled the last days to properly test vue components using ava. To make life easier for others, I added some additional recipes for testing vuejs using ava. 

For example:

* testing the DOM of the component after a change in the data model
* testing data model changes when using async requests and promises
* testing DOM updates when promises are involved
