### PR TITLE
Add support for test logging

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -64,6 +64,7 @@ function wrapAssertions(callbacks) {
 	const pass = callbacks.pass;
 	const pending = callbacks.pending;
 	const fail = callbacks.fail;
+	const comment = callbacks.comment;
 
 	const noop = () => {};
 	const makeRethrow = reason => () => {
@@ -108,6 +109,10 @@ function wrapAssertions(callbacks) {
 			} else {
 				pass(this);
 			}
+		},
+
+		comment(text) {
+			comment(this, text);
 		},
 
 		deepEqual(actual, expected, message) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -64,7 +64,7 @@ function wrapAssertions(callbacks) {
 	const pass = callbacks.pass;
 	const pending = callbacks.pending;
 	const fail = callbacks.fail;
-	const comment = callbacks.comment;
+	const log = callbacks.log;
 
 	const noop = () => {};
 	const makeRethrow = reason => () => {
@@ -111,8 +111,8 @@ function wrapAssertions(callbacks) {
 			}
 		},
 
-		comment(text) {
-			comment(this, text);
+		log(text) {
+			log(this, text);
 		},
 
 		deepEqual(actual, expected, message) {

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -2,7 +2,7 @@
 const chalk = require('chalk');
 
 module.exports = {
-	comment: chalk.gray,
+	log: chalk.gray,
 	title: chalk.bold.white,
 	error: chalk.red,
 	skip: chalk.yellow,

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -2,6 +2,7 @@
 const chalk = require('chalk');
 
 module.exports = {
+	comment: chalk.gray,
 	title: chalk.bold.white,
 	error: chalk.red,
 	skip: chalk.yellow,

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -5,6 +5,7 @@ const lastLineTracker = require('last-line-stream/tracker');
 const plur = require('plur');
 const spinners = require('cli-spinners');
 const chalk = require('chalk');
+const figures = require('figures');
 const cliTruncate = require('cli-truncate');
 const cross = require('figures').cross;
 const indentString = require('indent-string');
@@ -163,6 +164,15 @@ class MiniReporter {
 				}
 
 				status += '  ' + colors.title(test.title) + '\n';
+
+				if (test.logs) {
+					test.logs.forEach(log => {
+						status += '  ' + colors.information(figures.info) + ' ' + colors.log(log) + '\n';
+					});
+
+					status += '\n';
+				}
+
 				if (test.error.source) {
 					status += '  ' + colors.errorSource(test.error.source.file + ':' + test.error.source.line) + '\n';
 

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -167,7 +167,13 @@ class MiniReporter {
 
 				if (test.logs) {
 					test.logs.forEach(log => {
-						status += '  ' + colors.information(figures.info) + ' ' + colors.log(log) + '\n';
+						const logLines = indentString(colors.log(log), 6);
+						const logLinesWithLeadingFigure = logLines.replace(
+							/^ {6}/,
+							`    ${colors.information(figures.info)} `
+						);
+
+						status += logLinesWithLeadingFigure + '\n';
 					});
 
 					status += '\n';

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -49,7 +49,7 @@ class TapReporter {
 		return 'TAP version 13';
 	}
 	test(test) {
-		let output;
+		const output = [];
 
 		let directive = '';
 		const passed = test.todo ? 'not ok' : 'ok';
@@ -62,23 +62,23 @@ class TapReporter {
 
 		const title = stripAnsi(test.title);
 
-		if (test.error) {
-			output = [
-				'# ' + title,
-				format('not ok %d - %s', ++this.i, title),
-				dumpError(test.error, true)
-			];
-		} else {
-			output = [
-				`# ${title}`,
-				format('%s %d - %s %s', passed, ++this.i, title, directive).trim()
-			];
-		}
+		const appendLogs = () => {
+			if (test.logs) {
+				test.logs.forEach(log => {
+					output.push(`  ${log}`);
+				});
+			}
+		};
 
-		if (test.comments) {
-			test.comments.forEach(comment => {
-				output.push(`  ${comment}`);
-			});
+		output.push(`# ${title}`);
+
+		if (test.error) {
+			output.push(format('not ok %d - %s', ++this.i, title));
+			appendLogs();
+			output.push(dumpError(test.error, true));
+		} else {
+			output.push(format('%s %d - %s %s', passed, ++this.i, title, directive).trim());
+			appendLogs();
 		}
 
 		return output.join('\n');

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -65,7 +65,13 @@ class TapReporter {
 		const appendLogs = () => {
 			if (test.logs) {
 				test.logs.forEach(log => {
-					output.push(`  ${log}`);
+					const logLines = indentString(log, 4);
+					const logLinesWithLeadingFigure = logLines.replace(
+						/^ {4}/,
+						'  * '
+					);
+
+					output.push(logLinesWithLeadingFigure);
 				});
 			}
 		};

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -75,6 +75,12 @@ class TapReporter {
 			];
 		}
 
+		if (test.comments) {
+			test.comments.forEach(comment => {
+				output.push(`  ${comment}`);
+			});
+		}
+
 		return output.join('\n');
 	}
 	unhandledError(err) {

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -45,7 +45,13 @@ class VerboseReporter {
 
 		if (test.logs) {
 			test.logs.forEach(log => {
-				lines.push('    ' + colors.information(figures.info) + ' ' + colors.log(log));
+				const logLines = indentString(colors.log(log), 6);
+				const logLinesWithLeadingFigure = logLines.replace(
+					/^ {6}/,
+					`    ${colors.information(figures.info)} `
+				);
+
+				lines.push(logLinesWithLeadingFigure);
 			});
 		}
 
@@ -110,7 +116,13 @@ class VerboseReporter {
 
 				if (test.logs) {
 					test.logs.forEach(log => {
-						output += '    ' + colors.information(figures.info) + ' ' + colors.log(log) + '\n';
+						const logLines = indentString(colors.log(log), 6);
+						const logLinesWithLeadingFigure = logLines.replace(
+							/^ {6}/,
+							`    ${colors.information(figures.info)} `
+						);
+
+						output += logLinesWithLeadingFigure + '\n';
 					});
 
 					output += '\n';

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -24,29 +24,32 @@ class VerboseReporter {
 		return '';
 	}
 	test(test, runStatus) {
+		const lines = [];
 		if (test.error) {
-			return '  ' + colors.error(figures.cross) + ' ' + test.title + ' ' + colors.error(test.error.message);
-		}
-
-		if (test.todo) {
-			return '  ' + colors.todo('- ' + test.title);
+			lines.push('  ' + colors.error(figures.cross) + ' ' + test.title + ' ' + colors.error(test.error.message));
+		} else if (test.todo) {
+			lines.push('  ' + colors.todo('- ' + test.title));
 		} else if (test.skip) {
-			return '  ' + colors.skip('- ' + test.title);
+			lines.push('  ' + colors.skip('- ' + test.title));
+		} else if (test.failing) {
+			lines.push('  ' + colors.error(figures.tick) + ' ' + colors.error(test.title));
+		} else if (runStatus.fileCount === 1 && runStatus.testCount === 1 && test.title === '[anonymous]') {
+			// No output
+		} else {
+			// Display duration only over a threshold
+			const threshold = 100;
+			const duration = test.duration > threshold ? colors.duration(' (' + prettyMs(test.duration) + ')') : '';
+
+			lines.push('  ' + colors.pass(figures.tick) + ' ' + test.title + duration);
 		}
 
-		if (test.failing) {
-			return '  ' + colors.error(figures.tick) + ' ' + colors.error(test.title);
+		if (test.comments) {
+			test.comments.forEach(comment => {
+				lines.push('    ' + colors.information(figures.info) + ' ' + colors.comment(comment));
+			});
 		}
 
-		if (runStatus.fileCount === 1 && runStatus.testCount === 1 && test.title === '[anonymous]') {
-			return undefined;
-		}
-
-		// Display duration only over a threshold
-		const threshold = 100;
-		const duration = test.duration > threshold ? colors.duration(' (' + prettyMs(test.duration) + ')') : '';
-
-		return '  ' + colors.pass(figures.tick) + ' ' + test.title + duration;
+		return lines.length > 0 ? lines.join('\n') : undefined;
 	}
 	unhandledError(err) {
 		if (err.type === 'exception' && err.name === 'AvaError') {

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -43,9 +43,9 @@ class VerboseReporter {
 			lines.push('  ' + colors.pass(figures.tick) + ' ' + test.title + duration);
 		}
 
-		if (test.comments) {
-			test.comments.forEach(comment => {
-				lines.push('    ' + colors.information(figures.info) + ' ' + colors.comment(comment));
+		if (test.logs) {
+			test.logs.forEach(log => {
+				lines.push('    ' + colors.information(figures.info) + ' ' + colors.log(log));
 			});
 		}
 
@@ -107,6 +107,15 @@ class VerboseReporter {
 				}
 
 				output += '  ' + colors.title(test.title) + '\n';
+
+				if (test.logs) {
+					test.logs.forEach(log => {
+						output += '    ' + colors.information(figures.info) + ' ' + colors.log(log) + '\n';
+					});
+
+					output += '\n';
+				}
+
 				if (test.error.source) {
 					output += '  ' + colors.errorSource(test.error.source.file + ':' + test.error.source.line) + '\n';
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -130,7 +130,7 @@ class Runner extends EventEmitter {
 	addTestResult(result) {
 		const test = result.result;
 		const props = {
-			comments: test.comments,
+			logs: test.logs,
 			duration: test.duration,
 			title: test.title,
 			error: result.reason,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -130,6 +130,7 @@ class Runner extends EventEmitter {
 	addTestResult(result) {
 		const test = result.result;
 		const props = {
+			comments: test.comments,
 			duration: test.duration,
 			title: test.title,
 			error: result.reason,

--- a/lib/test.js
+++ b/lib/test.js
@@ -78,6 +78,10 @@ class ExecutionContext {
 
 {
 	const assertions = assert.wrapAssertions({
+		comment(executionContext, text) {
+			executionContext._test.addComment(text);
+		},
+
 		pass(executionContext) {
 			executionContext._test.countPassedAssertion();
 		},
@@ -108,6 +112,7 @@ class Test {
 		this.metadata = options.metadata;
 		this.onResult = options.onResult;
 		this.title = options.title;
+		this.comments = [];
 
 		this.snapshotInvocationCount = 0;
 		this.compareWithSnapshot = assertionOptions => {
@@ -173,6 +178,10 @@ class Test {
 		}
 
 		this.assertCount++;
+	}
+
+	addComment(text) {
+		this.comments.push(text);
 	}
 
 	addPendingAssertion(promise) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -78,8 +78,8 @@ class ExecutionContext {
 
 {
 	const assertions = assert.wrapAssertions({
-		comment(executionContext, text) {
-			executionContext._test.addComment(text);
+		log(executionContext, text) {
+			executionContext._test.addLog(text);
 		},
 
 		pass(executionContext) {
@@ -112,7 +112,7 @@ class Test {
 		this.metadata = options.metadata;
 		this.onResult = options.onResult;
 		this.title = options.title;
-		this.comments = [];
+		this.logs = [];
 
 		this.snapshotInvocationCount = 0;
 		this.compareWithSnapshot = assertionOptions => {
@@ -180,8 +180,8 @@ class Test {
 		this.assertCount++;
 	}
 
-	addComment(text) {
-		this.comments.push(text);
+	addLog(text) {
+		this.logs.push(text);
 	}
 
 	addPendingAssertion(promise) {

--- a/readme.md
+++ b/readme.md
@@ -875,6 +875,10 @@ Plan how many assertion there are in the test. The test will fail if the actual 
 
 End the test. Only works with `test.cb()`.
 
+###### `t.log(message)`
+
+Print a log message contextually alongside the test result instead of immediately streaming the message to stdout like `console.log`.
+
 ## Assertions
 
 Assertions are mixed into the [execution object](#t) provided to each test implementation:

--- a/readme.md
+++ b/readme.md
@@ -877,7 +877,7 @@ End the test. Only works with `test.cb()`.
 
 ###### `t.log(message)`
 
-Print a log message contextually alongside the test result instead of immediately streaming the message to stdout like `console.log`.
+Print a log message contextually alongside the test result instead of immediately printing it to `stdout` like `console.log`.
 
 ## Assertions
 

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -266,3 +266,49 @@ test('stdout and stderr should call process.stderr.write', t => {
 	t.is(stub.callCount, 2);
 	t.end();
 });
+
+test('successful test with logs', t => {
+	const reporter = new TapReporter();
+
+	const actualOutput = reporter.test({
+		title: 'passing',
+		logs: ['log message 1', 'log message 2']
+	});
+
+	const expectedOutput = [
+		'# passing',
+		'ok 1 - passing',
+		'  log message 1',
+		'  log message 2'
+	].join('\n');
+
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});
+
+test('failing test with logs', t => {
+	const reporter = new TapReporter();
+
+	const actualOutput = reporter.test({
+		title: 'failing',
+		error: {
+			name: 'AssertionError',
+			message: 'false == true'
+		},
+		logs: ['log message 1', 'log message 2']
+	});
+
+	const expectedOutput = [
+		'# failing',
+		'not ok 1 - failing',
+		'  log message 1',
+		'  log message 2',
+		'  ---',
+		'    name: AssertionError',
+		'    message: false == true',
+		'  ...'
+	].join('\n');
+
+	t.is(actualOutput, expectedOutput);
+	t.end();
+});

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -272,14 +272,15 @@ test('successful test with logs', t => {
 
 	const actualOutput = reporter.test({
 		title: 'passing',
-		logs: ['log message 1', 'log message 2']
+		logs: ['log message 1\nwith a newline', 'log message 2']
 	});
 
 	const expectedOutput = [
 		'# passing',
 		'ok 1 - passing',
-		'  log message 1',
-		'  log message 2'
+		'  * log message 1',
+		'    with a newline',
+		'  * log message 2'
 	].join('\n');
 
 	t.is(actualOutput, expectedOutput);
@@ -295,14 +296,15 @@ test('failing test with logs', t => {
 			name: 'AssertionError',
 			message: 'false == true'
 		},
-		logs: ['log message 1', 'log message 2']
+		logs: ['log message 1\nwith a newline', 'log message 2']
 	});
 
 	const expectedOutput = [
 		'# failing',
 		'not ok 1 - failing',
-		'  log message 1',
-		'  log message 2',
+		'  * log message 1',
+		'    with a newline',
+		'  * log message 2',
 		'  ---',
 		'    name: AssertionError',
 		'    message: false == true',

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -853,12 +853,13 @@ test('successful test with logs', t => {
 
 	const actualOutput = reporter.test({
 		title: 'successful test',
-		logs: ['log message 1', 'log message 2']
+		logs: ['log message 1\nwith a newline', 'log message 2']
 	}, {});
 
 	const expectedOutput = [
 		'  ' + chalk.green(figures.tick) + ' successful test',
 		'    ' + chalk.magenta(figures.info) + ' ' + chalk.gray('log message 1'),
+		'      ' + chalk.gray('with a newline'),
 		'    ' + chalk.magenta(figures.info) + ' ' + chalk.gray('log message 2')
 	].join('\n');
 
@@ -872,12 +873,13 @@ test('failed test with logs', t => {
 	const actualOutput = reporter.test({
 		title: 'failed test',
 		error: new Error('failure'),
-		logs: ['log message 1', 'log message 2']
+		logs: ['log message 1\nwith a newline', 'log message 2']
 	}, {});
 
 	const expectedOutput = [
 		'  ' + chalk.red(figures.cross) + ' failed test ' + chalk.red('failure'),
 		'    ' + chalk.magenta(figures.info) + ' ' + chalk.gray('log message 1'),
+		'      ' + chalk.gray('with a newline'),
 		'    ' + chalk.magenta(figures.info) + ' ' + chalk.gray('log message 2')
 	].join('\n');
 
@@ -902,7 +904,7 @@ test('results with errors and logs', t => {
 	runStatus.failCount = 1;
 	runStatus.tests = [{
 		title: 'fail one',
-		logs: ['log from failed test', 'another log from failed test'],
+		logs: ['log from failed test\nwith a newline', 'another log from failed test'],
 		error: error1
 	}];
 
@@ -913,6 +915,7 @@ test('results with errors and logs', t => {
 		'',
 		'  ' + chalk.bold.white('fail one'),
 		'    ' + chalk.magenta(figures.info) + ' ' + chalk.gray('log from failed test'),
+		'      ' + chalk.gray('with a newline'),
 		'    ' + chalk.magenta(figures.info) + ' ' + chalk.gray('another log from failed test'),
 		'',
 		'  ' + chalk.grey(`${error1.source.file}:${error1.source.line}`),

--- a/test/test.js
+++ b/test/test.js
@@ -733,3 +733,22 @@ test('failing tests fail with `t.notThrows(throws)`', t => {
 		t.end();
 	});
 });
+
+test('log from tests', t => {
+	let result;
+
+	ava(a => {
+		a.log('a log message from a test');
+		t.true(true);
+		a.log('another log message from a test');
+	}, null, r => {
+		result = r;
+	}).run();
+
+	t.deepEqual(
+		result.result.logs,
+		['a log message from a test', 'another log message from a test']
+	);
+
+	t.end();
+});


### PR DESCRIPTION
There are times when you wish to include comments in your tests that will be shown in context of the test result and not streamed to `stdout` like `console.log` statements are, where they will likely be out of order of the tests they are associated with.

I will happily add tests, and change the API, etc. I just want to get general 👍 or 👎 to the concept of adding comments before I flesh out the tests and other cleanup.

One of the main use cases I have for this, is I am using ava as a runner for my SauceLabs/BrowserSrack/Selenium tests, and I would like to have the link to the job results from SauceLabs/BrowserStack be output in context with the test run. There are certainly many other usecases for this, however, just to give a relevant example of when this is useful.

## Example output

### `--verbose`
<img width="422" alt="1__tmux_and_zoom_meeting_id__571-235-5176" src="https://user-images.githubusercontent.com/23833/28172398-7230c0d8-67b9-11e7-984d-07a2967bb610.png">

### `--tap`
```
TAP version 13                                                                                                                                                              [30/1823]
# file-one › passing test
ok 1 - file-one › passing test
  a comment for passing test
# file-two › passing test
ok 2 - file-two › passing test
  a comment for passing test
# file-one › failing test
not ok 3 - file-one › failing test
  ---
    name: AssertionError
    assertion: is
    values:
      'Difference:': |-
        - true
        + false
    at: 'Test.t [as fn] (file-one.test.js:11:7)'
  ...
  a comment for failing test
# file-two › failing test
not ok 4 - file-two › failing test
  ---
    name: AssertionError
    assertion: is
    values:
      'Difference:': |-
        - true
        + false
    at: 'Test.t [as fn] (file-two.test.js:11:7)'
  ...
  a comment for failing test

1..4
# tests 4
# pass 2
# fail 2
```