### PR TITLE
Export root module

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,5 @@
 'use strict';
+const rootModule = require('get-root-module');
 const worker = require('./test-worker');
 const adapter = require('./process-adapter');
 const serializeError = require('./serialize-error');
@@ -102,3 +103,5 @@ module.exports = runner.chain;
 // an ES2015 default import (`import test from 'ava'`)
 // See: https://github.com/Microsoft/TypeScript/issues/2242#issuecomment-83694181
 module.exports.default = runner.chain;
+
+module.exports.module = rootModule;

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
 		"find-cache-dir": "^1.0.0",
 		"fn-name": "^2.0.0",
 		"get-port": "^3.0.0",
+		"get-root-module": "^0.1.1",
 		"globby": "^6.0.0",
 		"has-flag": "^2.0.0",
 		"hullabaloo-config-manager": "^1.1.0",


### PR DESCRIPTION
Resolves https://github.com/avajs/ava/issues/1460

Needs tests and I need to add docs to `get-root-module` but this is just to demo my proposal in https://github.com/avajs/ava/issues/1460.

Allows you to do:

```js
import { test, module } from 'ava';
```

Rather than having to do:

```js
import test from 'ava';
import module from '../';

// and then in sub folders
import module from '../../';
```

Traverses up the directory tree from `process.cwd()` (whatever dir `ava` was executed from on the cli). When a dir with a `package.json` is found, that dir is `require`d, if no package.json is found `module` will be undefined.

I'll wait to see if you're interested in merging this before going any further.