### PR TITLE
Use --verbose when testing CLI output

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -365,7 +365,7 @@ test('watcher reruns test files when snapshot dependencies change', t => {
 test('`"tap": true` config is ignored when --watch is given', t => {
 	let killed = false;
 
-	const child = execCli(['--watch', 'test.js'], {dirname: 'fixture/watcher/tap-in-conf'}, () => {
+	const child = execCli(['--watch', '--verbose', 'test.js'], {dirname: 'fixture/watcher/tap-in-conf'}, () => {
 		t.ok(killed);
 		t.end();
 	});


### PR DESCRIPTION
It cannot be guaranteed that all lines output by the mini reporter are
captured in the stderr of the CLI invocation during testing. Use
--verbose when matching output that the mini reporter may otherwise
rewrite.

Somewhere on at least Node.js 8.2.1, when the package-lock.json is
discarded prior to installation, something in our dependency tree is
different which results in the test title no longer being in the stderr
of the AVA CLI.

Compare:

```
⠋ ESC[2KESC[1AESC[2KESC[G
⠙ ESC[2KESC[1AESC[2KESC[G
⠹ ESC[2KESC[1AESC[2KESC[G
⠸ ESC[2KESC[1AESC[2KESC[G
⠼ ESC[2KESC[1AESC[2KESC[G
⠴ ESC[2KESC[1AESC[2KESC[G
⠦ ESC[2KESC[1AESC[2KESC[G
⠦ test › works…

 1 passedESC[2KESC[1AESC[2KESC[1AESC[2KESC[1AESC[2KESC[G
 1 passed [18:32:54]
```

Versus:

```
⠋ ESC[2KESC[1AESC[2KESC[G
⠙ ESC[2KESC[1AESC[2KESC[G
⠹ ESC[2KESC[1AESC[2KESC[G
⠸ ESC[2KESC[1AESC[2KESC[G
⠼ ESC[2KESC[1AESC[2KESC[G
⠴ ESC[2KESC[1AESC[2KESC[G
⠴ …

 1 passedESC[2KESC[1AESC[2KESC[1AESC[2KESC[1AESC[2KESC[G
⠦ …

 1 passedESC[2KESC[1AESC[2KESC[1AESC[2KESC[1AESC[2KESC[G
 1 passed [18:35:49]
```

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
