### PR TITLE
Fail hard when `--concurrency` is set to invalid values

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -119,7 +119,15 @@ exports.run = () => {
 	}
 
 	if (cli.flags.concurrency === '') {
-		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided the maximum number of test files to run at once.');
+		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided.');
+	}
+
+	if (cli.flags.concurrency && isNaN(parseInt(cli.flags.concurrency, 10))) {
+		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be an integer.');
+	}
+
+	if (parseInt(cli.flags.concurrency, 10) === 0) {
+		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be greater than 0.');
 	}
 
 	if (hasFlag('--require') || hasFlag('-r')) {
@@ -142,7 +150,7 @@ exports.run = () => {
 		resolveTestsFrom: cli.input.length === 0 ? projectDir : process.cwd(),
 		projectDir,
 		timeout: conf.timeout,
-		concurrency: conf.concurrency ? parseInt(conf.concurrency, 10) : 0,
+		concurrency: cli.flags.concurrency ? parseInt(cli.flags.concurrency, 10) : 1,
 		updateSnapshots: conf.updateSnapshots,
 		color: conf.color
 	});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -150,7 +150,7 @@ exports.run = () => {
 		resolveTestsFrom: cli.input.length === 0 ? projectDir : process.cwd(),
 		projectDir,
 		timeout: conf.timeout,
-		concurrency: cli.flags.concurrency ? parseInt(cli.flags.concurrency, 10) : 1,
+		concurrency: conf.concurrency ? parseInt(conf.concurrency, 10) : 1,
 		updateSnapshots: conf.updateSnapshots,
 		color: conf.color
 	});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -122,8 +122,9 @@ exports.run = () => {
 		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided.');
 	}
 
-	if (cli.flags.concurrency && !Number.isInteger(Number.parseFloat(cli.flags.concurrency, 10))) {
-		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be an integer.');
+	if (cli.flags.concurrency &&
+		(!Number.isInteger(Number.parseFloat(cli.flags.concurrency)) || parseInt(cli.flags.concurrency, 10) < 0)) {
+		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be a positive integer.');
 	}
 
 	if (hasFlag('--require') || hasFlag('-r')) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -124,7 +124,7 @@ exports.run = () => {
 
 	if (cli.flags.concurrency &&
 		(!Number.isInteger(Number.parseFloat(cli.flags.concurrency)) || parseInt(cli.flags.concurrency, 10) < 0)) {
-		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be a positive integer.');
+		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be a nonnegative integer.');
 	}
 
 	if (hasFlag('--require') || hasFlag('-r')) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -122,12 +122,8 @@ exports.run = () => {
 		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided.');
 	}
 
-	if (cli.flags.concurrency && isNaN(parseInt(cli.flags.concurrency, 10))) {
+	if (cli.flags.concurrency && !Number.isInteger(Number.parseFloat(cli.flags.concurrency, 10))) {
 		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be an integer.');
-	}
-
-	if (parseInt(cli.flags.concurrency, 10) === 0) {
-		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be greater than 0.');
 	}
 
 	if (hasFlag('--require') || hasFlag('-r')) {
@@ -150,7 +146,7 @@ exports.run = () => {
 		resolveTestsFrom: cli.input.length === 0 ? projectDir : process.cwd(),
 		projectDir,
 		timeout: conf.timeout,
-		concurrency: conf.concurrency ? parseInt(conf.concurrency, 10) : 1,
+		concurrency: conf.concurrency ? parseInt(conf.concurrency, 10) : 0,
 		updateSnapshots: conf.updateSnapshots,
 		color: conf.color
 	});

--- a/test/cli.js
+++ b/test/cli.js
@@ -427,7 +427,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is a string`, t => {
 		execCli([`${concurrencyFlag}=foo`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be an integer.');
+			t.match(stderr, 'The --concurrency and -c flags must be a positive integer.');
 			t.end();
 		});
 	});
@@ -437,7 +437,17 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is a float`, t => {
 		execCli([`${concurrencyFlag}=4.7`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be an integer.');
+			t.match(stderr, 'The --concurrency and -c flags must be a positive integer.');
+			t.end();
+		});
+	});
+});
+
+['--concurrency', '-c'].forEach(concurrencyFlag => {
+	test(`bails when ${concurrencyFlag} is provided with an input that is negative`, t => {
+		execCli([`${concurrencyFlag}=-1`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+			t.is(err.code, 1);
+			t.match(stderr, 'The --concurrency and -c flags must be a positive integer.');
 			t.end();
 		});
 	});

--- a/test/cli.js
+++ b/test/cli.js
@@ -425,7 +425,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 
 ['--concurrency', '-c'].forEach(concurrencyFlag => {
 	test(`bails when ${concurrencyFlag} is provided with an input that isn't an integer`, t => {
-		execCli([`${concurrencyFlag}=foo`,'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+		execCli([`${concurrencyFlag}=foo`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
 			t.match(stderr, 'The --concurrency and -c flags must be an integer.');
 			t.end();
@@ -435,7 +435,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 
 ['--concurrency', '-c'].forEach(concurrencyFlag => {
 	test(`bails when ${concurrencyFlag} is provided with zero`, t => {
-		execCli([`${concurrencyFlag}=0`,'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+		execCli([`${concurrencyFlag}=0`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
 			t.match(stderr, 'The --concurrency and -c flags must be greater than 0.');
 			t.end();

--- a/test/cli.js
+++ b/test/cli.js
@@ -427,7 +427,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is a string`, t => {
 		execCli([`${concurrencyFlag}=foo`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be a positive integer.');
+			t.match(stderr, 'The --concurrency and -c flags must be a nonnegative integer.');
 			t.end();
 		});
 	});
@@ -437,7 +437,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is a float`, t => {
 		execCli([`${concurrencyFlag}=4.7`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be a positive integer.');
+			t.match(stderr, 'The --concurrency and -c flags must be a nonnegative integer.');
 			t.end();
 		});
 	});
@@ -447,7 +447,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is negative`, t => {
 		execCli([`${concurrencyFlag}=-1`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be a positive integer.');
+			t.match(stderr, 'The --concurrency and -c flags must be a nonnegative integer.');
 			t.end();
 		});
 	});

--- a/test/cli.js
+++ b/test/cli.js
@@ -424,7 +424,7 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 });
 
 ['--concurrency', '-c'].forEach(concurrencyFlag => {
-	test(`bails when ${concurrencyFlag} is provided with an input that isn't an integer`, t => {
+	test(`bails when ${concurrencyFlag} is provided with an input that is a string`, t => {
 		execCli([`${concurrencyFlag}=foo`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
 			t.match(stderr, 'The --concurrency and -c flags must be an integer.');
@@ -434,10 +434,10 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 });
 
 ['--concurrency', '-c'].forEach(concurrencyFlag => {
-	test(`bails when ${concurrencyFlag} is provided with zero`, t => {
-		execCli([`${concurrencyFlag}=0`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+	test(`bails when ${concurrencyFlag} is provided with an input that is a float`, t => {
+		execCli([`${concurrencyFlag}=4.7`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be greater than 0.');
+			t.match(stderr, 'The --concurrency and -c flags must be an integer.');
 			t.end();
 		});
 	});

--- a/test/cli.js
+++ b/test/cli.js
@@ -414,17 +414,37 @@ test('bails when config contains `"tap": true` and `"watch": true`', t => {
 });
 
 ['--concurrency', '-c'].forEach(concurrencyFlag => {
-	test(`bails when ${concurrencyFlag} provided without value`, t => {
+	test(`bails when ${concurrencyFlag} is provided without value`, t => {
 		execCli(['test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be provided the maximum number of test files to run at once.');
+			t.match(stderr, 'The --concurrency and -c flags must be provided.');
 			t.end();
 		});
 	});
 });
 
 ['--concurrency', '-c'].forEach(concurrencyFlag => {
-	test(`works when ${concurrencyFlag} provided with value`, t => {
+	test(`bails when ${concurrencyFlag} is provided with an input that isn't an integer`, t => {
+		execCli([`${concurrencyFlag}=foo`,'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+			t.is(err.code, 1);
+			t.match(stderr, 'The --concurrency and -c flags must be an integer.');
+			t.end();
+		});
+	});
+});
+
+['--concurrency', '-c'].forEach(concurrencyFlag => {
+	test(`bails when ${concurrencyFlag} is provided with zero`, t => {
+		execCli([`${concurrencyFlag}=0`,'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
+			t.is(err.code, 1);
+			t.match(stderr, 'The --concurrency and -c flags must be greater than 0.');
+			t.end();
+		});
+	});
+});
+
+['--concurrency', '-c'].forEach(concurrencyFlag => {
+	test(`works when ${concurrencyFlag} is provided with a value`, t => {
 		execCli([`${concurrencyFlag}=1`, 'test.js'], {dirname: 'fixture/concurrency'}, err => {
 			t.ifError(err);
 			t.end();


### PR DESCRIPTION
Fixes #1476.

**Changes:**
- Added `0` check.
- Changed the message if  `concurrency` was set to an empty string, because the error message seemed a bit weird.
- Introduced an extra check to validate if `concurrency` is an integer.
- Changed default `concurrency` from `0` to `1` if no `concurrency` is given. 
