### PR TITLE
Fix typo in `t.notThrows` example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -979,7 +979,7 @@ Assert that `function` does not throw an error or that `promise` does not reject
 Like the `.throws()` assertion, when testing a promise you must wait for the assertion to complete:
 
 ```js
-test('rejects', async t => {
+test('resolves', async t => {
 	await t.notThrows(promise);
 });
 ```


### PR DESCRIPTION
Trivial documentation fix proposal. I think there is a typo in the example for `t.notThrows`. The test name is "rejects" but shouldn't a test with a `notThrows` assertion be checking that the promise under test resolves instead of rejects? It's confusing when compared with the example for `throws` directly above that has a test named "rejects" as well.

Cheers and thanks for Ava!