### PR TITLE
Assume npm@5.4, work around permissions issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
   directories:
     - $HOME/.npm
 before_install:
-  - npm install --global npm@^5.2.0
+  - npm install --global npm@5.4.0
   - npm --version
 install:
   - if [[ ${FRESH_DEPS} == "true" ]]; then npm install --no-shrinkwrap --prefer-online; else npm install --prefer-offline; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ cache:
 before_install:
   - npm install --global npm@^5.2.0
   - npm --version
-  - if [[ ${FRESH_DEPS} == "true" ]]; then rm package-lock.json; fi
 install:
-  - if [[ ${FRESH_DEPS} == "true" ]]; then npm install --prefer-online; else npm install --prefer-offline; fi
+  - if [[ ${FRESH_DEPS} == "true" ]]; then npm install --no-shrinkwrap --prefer-online; else npm install --prefer-offline; fi
 after_success: ./node_modules/.bin/codecov --file=./coverage/lcov.info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ matrix:
       nodejs_version: 4
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install --global npm@^5.2.0
+  - npm install --global npm@5.4.0
   - npm --version
   - git config core.symlinks true
   - git reset --hard

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ skip_commits:
     - '**/*.md'
 configuration:
   - FreshDeps
-  - LockedDeps
+#  - LockedDeps
 environment:
   matrix:
     - nodejs_version: 8
@@ -27,7 +27,7 @@ install:
   - npm --version
   - git config core.symlinks true
   - git reset --hard
-  - if %configuration% == FreshDeps (npm install --no-shrinkwrap --prefer-online)
-  - if %configuration% == LockedDeps (npm install --prefer-offline)
+  - if %configuration% == FreshDeps (npm install --no-optional --no-shrinkwrap --prefer-online)
+  - if %configuration% == LockedDeps (npm install --no-optional --prefer-offline)
 test_script:
   - npm run test-win

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,6 @@ install:
   - git config core.symlinks true
   - git reset --hard
   - if %configuration% == FreshDeps (npm install --no-shrinkwrap --prefer-online)
-  - if %configuration% == LockedDeps (npm install --prefer-online)
+  - if %configuration% == LockedDeps (npm install --prefer-offline)
 test_script:
   - npm run test-win

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,7 @@ install:
   - npm --version
   - git config core.symlinks true
   - git reset --hard
-  - ps: if ($env:configuration -eq "FreshDeps") { Remove-Item package-lock.json }
-  - if %configuration% == FreshDeps (npm install --prefer-online)
+  - if %configuration% == FreshDeps (npm install --no-shrinkwrap --prefer-online)
   - if %configuration% == LockedDeps (npm install --prefer-online)
 test_script:
   - npm run test-win

--- a/package-lock.json
+++ b/package-lock.json
@@ -2942,11 +2942,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2956,6 +2951,11 @@
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "stringstream": {
           "version": "0.0.5",
@@ -6950,14 +6950,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
     },
-    "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
@@ -6965,6 +6957,14 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"node": ">=4"
 	},
 	"scripts": {
-		"test": "xo && flow check test/flow-types && tsc -p test/ts-types && nyc tap --no-cov --timeout=300 --jobs=4 test/*.js test/reporters/*.js",
+		"test": "xo && chmod +x $(node -pe \"require('flow-bin')\") && flow check test/flow-types && tsc -p test/ts-types && nyc tap --no-cov --timeout=300 --jobs=4 test/*.js test/reporters/*.js",
 		"test-win": "tap --no-cov --reporter=classic --timeout=300 --jobs=4 test/*.js test/reporters/*.js",
 		"visual": "node test/visual/run-visual-tests.js",
 		"prepublish": "npm run make-ts",


### PR DESCRIPTION
There's a fair bit of churn between `package-lock.json` files generated with different npm versions (even minor releases). Contributors may be using an older npm version or even Yarn. Thus the `package-lock.json` may regress or not even be updated.

~This PR proposes we pin npm to an exact version. Then in Travis we can check whether the `package-lock.json` is modified and fail the build if this occurs. This should catch regressions or missing dependencies.~

Note that CI is currently failing due to a bug in npm@5.4.0: <https://github.com/npm/npm/issues/18324>. Consequently we shouldn't land it until we can pin to a patched version.