### PR TITLE
Update snapshot signature for flow types

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -69,7 +69,7 @@ type AssertContext = {
 	// Assert that contents matches regex.
 	regex(contents: string, regex: RegExp, message?: string): void;
 	// Assert that contents matches a snapshot.
-	snapshot(contents: any, message?: string): void;
+	snapshot: ((contents: any, message?: string) => void) & ((contents: any, options: {id: string}, message?: string) => void);
 	// Assert that contents does not match regex.
 	notRegex(contents: string, regex: RegExp, message?: string): void;
 	// Assert that error is falsy.

--- a/test/flow-types/regression-1500.js.flow
+++ b/test/flow-types/regression-1500.js.flow
@@ -1,0 +1,17 @@
+/* @flow */
+
+const test = require('../../index.js.flow');
+
+test(t => {
+	t.snapshot({});
+	t.snapshot({}, "a message");
+	t.snapshot({}, {id: "snapshot-id"});
+	t.snapshot({}, {id: "snapshot-id"}, "a message");
+
+	// $ExpectError Message should be a string
+	t.snapshot({}, 1);
+	// $ExpectError unknownOption is an unknown options attribute
+	t.snapshot({}, { unknownOption: true });
+	// $ExpectError Message should be a string
+	t.snapshot({}, { id: "snapshot-id" }, 1);
+});


### PR DESCRIPTION
I updated the flow types for the snapshot function to allow an options object as a parameter.