### PR TITLE
Match anonymous tests when all of the match expressions are negative

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -112,7 +112,7 @@ class Runner extends EventEmitter {
 		}
 
 		if (metadata.type === 'test' && this.match.length > 0) {
-			metadata.exclusive = title !== null && matcher([title], this.match).length === 1;
+			metadata.exclusive = matcher([title || ''], this.match).length === 1;
 		}
 
 		const validationError = validateTest(title, fn, metadata);

--- a/test/runner.js
+++ b/test/runner.js
@@ -711,6 +711,32 @@ test('options.match overrides .only', t => {
 	});
 });
 
+test('options.match includes anonymous tests in negative matches', t => {
+	t.plan(4);
+
+	const runner = new Runner({
+		match: ['!*oo']
+	});
+
+	runner.chain.test('foo', a => {
+		t.fail();
+		a.pass();
+	});
+
+	runner.chain.test(a => {
+		t.pass();
+		a.pass();
+	});
+
+	runner.run({}).then(() => {
+		const stats = runner.buildStats();
+		t.is(stats.skipCount, 0);
+		t.is(stats.passCount, 1);
+		t.is(stats.testCount, 1);
+		t.end();
+	});
+});
+
 test('macros: Additional args will be spread as additional args on implementation function', t => {
 	t.plan(3);
 


### PR DESCRIPTION
<strike>(Matching on `'*'`, for example, still excludes tests with no titles, as it did prior to this commit.)</strike>

The motivation here is if I have a test suite with some anonymous tests and some titled tests, and some of the titled tests are tagged with something like `[long-running]`, and I want to run `ava -m '!*[long-running]*'`, I don't want to exclude the anonymous tests. But with current Ava they are excluded.

<strike>For what it's worth, anyone who misses the old behavior could get it back with `-m '*' -m <negative match expression(s)>`.</strike>

**Edit:** Changed so that `-m '*'` matches all tests, including anonymous. For purposes of matching, anonymous tests have empty string titles.