### PR TITLE
When removing .snap files, only recalculate impacted test

### DIFF
--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -65,7 +65,7 @@ AVA uses [`chokidar`] as the file watcher. Note that even if you see warnings ab
 
 In AVA there's a distinction between *source files* and *test files*. As you can imagine the *test files* contain your tests. *Source files* are all other files that are needed for the tests to run, be it your source code or test fixtures.
 
-By default AVA watches for changes to the test files, snapshot files, `package.json`, and any other `.js` files. It'll ignore files in [certain directories](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) as provided by the [`ignore-by-default`] package.
+By default AVA watches for changes to the test files and any `.js` files. It'll ignore files in [certain directories](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) as provided by the [`ignore-by-default`] package. It also always watches `package.json` an snapshot files (even when you specify other source patterns), unless they are specifically ignored.
 
 You can configure patterns for the source files in the [`ava` section of your `package.json`] file, using the `source` key.
 

--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -145,7 +145,7 @@ class AvaFiles {
 		});
 	}
 	isSource(filePath) {
-		let mixedPatterns = [];
+		const mixedPatterns = [];
 		const defaultIgnorePatterns = getDefaultIgnorePatterns();
 		const overrideDefaultIgnorePatterns = [];
 
@@ -153,8 +153,7 @@ class AvaFiles {
 		this.sources.forEach(pattern => {
 			mixedPatterns.push(pattern);
 
-			// TODO: Why not just `pattern[0] !== '!'`?
-			if (!hasPositivePattern && pattern[0] !== '!') {
+			if (pattern[0] !== '!') {
 				hasPositivePattern = true;
 			}
 
@@ -164,10 +163,15 @@ class AvaFiles {
 				overrideDefaultIgnorePatterns.push(pattern);
 			}
 		});
-
 		// Same defaults as used for Chokidar
 		if (!hasPositivePattern) {
-			mixedPatterns = ['package.json', '**/*.js'].concat(mixedPatterns);
+			mixedPatterns.unshift('**/*.js');
+		}
+		if (mixedPatterns.indexOf('package.json') === -1) {
+			mixedPatterns.unshift('package.json');
+		}
+		if (mixedPatterns.indexOf('**/*.snap') === -1) {
+			mixedPatterns.unshift('**/*.snap');
 		}
 
 		filePath = matchable(filePath);
@@ -242,7 +246,7 @@ class AvaFiles {
 		return multimatch(matchable(filePath), recursivePatterns.concat(excludePatterns)).length === 1;
 	}
 	getChokidarPatterns() {
-		let paths = [];
+		const paths = [];
 		let ignored = [];
 
 		this.sources.forEach(pattern => {
@@ -262,13 +266,22 @@ class AvaFiles {
 			.filter(pattern => defaultIgnore.indexOf(pattern.split('/')[0]) >= 0)
 			.map(pattern => `!${pattern}`);
 
-		ignored = getDefaultIgnorePatterns().concat(ignored, overrideDefaultIgnorePatterns);
+		ignored = getDefaultIgnorePatterns().concat(
+			ignored,
+			overrideDefaultIgnorePatterns
+		);
 
 		if (paths.length === 0) {
-			paths = ['package.json', '**/*.js', '**/*.snap'];
+			paths.unshift('**/*.js');
+		}
+		if (paths.indexOf('package.json') === -1) {
+			paths.unshift('package.json');
+		}
+		if (paths.indexOf('**/*.snap') === -1) {
+			paths.unshift('**/*.snap');
 		}
 
-		paths = paths.concat(this.files);
+		paths.push.apply(paths, this.files);
 
 		return {
 			paths,

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -173,7 +173,7 @@ group('chokidar', (beforeEach, test, group) => {
 
 		t.ok(chokidar.watch.calledOnce);
 		t.strictDeepEqual(chokidar.watch.firstCall.args, [
-			['package.json', '**/*.js', '**/*.snap'].concat(files),
+			['**/*.snap', 'package.json', '**/*.js'].concat(files),
 			{
 				ignored: defaultIgnore.map(dir => `${dir}/**/*`),
 				ignoreInitial: true
@@ -187,7 +187,7 @@ group('chokidar', (beforeEach, test, group) => {
 
 		t.ok(chokidar.watch.calledOnce);
 		t.strictDeepEqual(chokidar.watch.firstCall.args, [
-			['foo.js', 'baz.js'].concat(files),
+			['**/*.snap', 'package.json', 'foo.js', 'baz.js'].concat(files),
 			{
 				ignored: defaultIgnore.map(dir => `${dir}/**/*`).concat('bar.js', 'qux.js'),
 				ignoreInitial: true
@@ -201,7 +201,7 @@ group('chokidar', (beforeEach, test, group) => {
 
 		t.ok(chokidar.watch.calledOnce);
 		t.strictDeepEqual(chokidar.watch.firstCall.args, [
-			['node_modules/foo/*.js'].concat(files),
+			['**/*.snap', 'package.json', 'node_modules/foo/*.js'].concat(files),
 			{
 				ignored: defaultIgnore.map(dir => `${dir}/**/*`).concat('!node_modules/foo/*.js'),
 				ignoreInitial: true


### PR DESCRIPTION
Fixes #1511

This also introduces a slight change in semantics: `package.json` and `**/*.snap` are always considered source files, since they are part of how AVA works and not of the application source files. If that is undesirable, they can be put in the ignore list.