### PR TITLE
Add t.log() type for Flowtype and TypeScript

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -84,6 +84,7 @@ type TestContext = AssertContext & {
 	title: string;
 	plan(count: number): void;
 	skip: AssertContext;
+	log(message: string): void;
 };
 type ContextualTestContext         = TestContext & { context: any; };
 type ContextualCallbackTestContext = TestContext & { context: any; end(): void; };

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -99,6 +99,10 @@ export interface TestContext extends AssertContext {
 	plan(count: number): void;
 
 	skip: AssertContext;
+	/**
+	 * Print a log message contextually alongside the test result instead of immediately printing it to stdout like console.log.
+	 */
+	log(message: string): void;
 }
 export interface CallbackTestContext extends TestContext {
 	/**


### PR DESCRIPTION
When using Flowtype, the type validation will fail since there are is no type
declared for the newly implemented `t.log()`.

This commit adds Flowtype and TypeScript declarations for `t.log()`.
