### PR TITLE
Limit concurrency to 2 in a CI environment and 8 otherwise

### DIFF
--- a/api.js
+++ b/api.js
@@ -161,7 +161,13 @@ class Api extends EventEmitter {
 					this._setupTimeout(runStatus);
 				}
 
-				let concurrency = Math.min(os.cpus().length, 4);
+				let concurrency = os.cpus().length;
+
+				if (process.env.CI) {
+					Math.min(concurrency, 2);
+				} else {
+					Math.min(concurrency, 8);
+				}
 
 				if (this.options.concurrency > 0) {
 					concurrency = this.options.concurrency;

--- a/api.js
+++ b/api.js
@@ -6,6 +6,7 @@ const os = require('os');
 const commonPathPrefix = require('common-path-prefix');
 const uniqueTempDir = require('unique-temp-dir');
 const findCacheDir = require('find-cache-dir');
+const isCi = require('is-ci');
 const resolveCwd = require('resolve-cwd');
 const debounce = require('lodash.debounce');
 const autoBind = require('auto-bind');
@@ -161,7 +162,7 @@ class Api extends EventEmitter {
 					this._setupTimeout(runStatus);
 				}
 
-				let concurrency = Math.min(os.cpus().length, process.env.CI ? 2 : 8);
+				let concurrency = Math.min(os.cpus().length, isCi ? 2 : 8);
 
 				if (this.options.concurrency > 0) {
 					concurrency = this.options.concurrency;

--- a/api.js
+++ b/api.js
@@ -162,7 +162,7 @@ class Api extends EventEmitter {
 					this._setupTimeout(runStatus);
 				}
 
-				let concurrency = Math.min(os.cpus().length, isCi ? 2 : 8);
+				let concurrency = Math.min(os.cpus().length, isCi ? 2 : Infinity);
 
 				if (this.options.concurrency > 0) {
 					concurrency = this.options.concurrency;

--- a/api.js
+++ b/api.js
@@ -161,7 +161,7 @@ class Api extends EventEmitter {
 					this._setupTimeout(runStatus);
 				}
 
-				let concurrency = os.cpus().length;
+				let concurrency = Math.min(os.cpus().length, 4);
 
 				if (this.options.concurrency > 0) {
 					concurrency = this.options.concurrency;

--- a/api.js
+++ b/api.js
@@ -161,13 +161,7 @@ class Api extends EventEmitter {
 					this._setupTimeout(runStatus);
 				}
 
-				let concurrency = os.cpus().length;
-
-				if (process.env.CI) {
-					Math.min(concurrency, 2);
-				} else {
-					Math.min(concurrency, 8);
-				}
+				let concurrency = Math.min(os.cpus().length, process.env.CI ? 2 : 8);
 
 				if (this.options.concurrency > 0) {
 					concurrency = this.options.concurrency;

--- a/docs/common-pitfalls.md
+++ b/docs/common-pitfalls.md
@@ -16,7 +16,7 @@ AVA uses [is-ci](https://github.com/watson/is-ci) to decide if it's in a CI envi
 
 You may be using a service that only allows a limited number of concurrent connections. For example, many database-as-a-service businesses offer a free plan with a limit on how many clients can be using it at the same time. AVA can hit those limits as it runs multiple processes, but well-written services should emit an error or throttle in those cases. If the one you're using doesn't, the tests will hang.
 
-By default, AVA will use as many processes as there are [logical cores](https://superuser.com/questions/1105654/logical-vs-physical-cpu-performance) on your machine. This is capped at eight, or in a CI environment two.
+By default, AVA will use as many processes as there are [logical cores](https://superuser.com/questions/1105654/logical-vs-physical-cpu-performance) on your machine. This is capped at two in a CI environment.
 
 Use the `concurrency` flag to limit the number of processes ran. For example, if your service plan allows 5 clients, you should run AVA with `concurrency=5` or less.
 

--- a/docs/common-pitfalls.md
+++ b/docs/common-pitfalls.md
@@ -16,7 +16,7 @@ AVA uses [is-ci](https://github.com/watson/is-ci) to decide if it's in a CI envi
 
 You may be using a service that only allows a limited number of concurrent connections. For example, many database-as-a-service businesses offer a free plan with a limit on how many clients can be using it at the same time. AVA can hit those limits as it runs multiple processes, but well-written services should emit an error or throttle in those cases. If the one you're using doesn't, the tests will hang.
 
-By default, AVA will use as many processes as there are CPU cores in your machine. This is capped at eight, or in a CI environment two.
+By default, AVA will use as many processes as there are CPU threads on your machine. This is capped at eight, or in a CI environment two.
 
 Use the `concurrency` flag to limit the number of processes ran. For example, if your service plan allows 5 clients, you should run AVA with `concurrency=5` or less.
 

--- a/docs/common-pitfalls.md
+++ b/docs/common-pitfalls.md
@@ -16,7 +16,7 @@ AVA uses [is-ci](https://github.com/watson/is-ci) to decide if it's in a CI envi
 
 You may be using a service that only allows a limited number of concurrent connections. For example, many database-as-a-service businesses offer a free plan with a limit on how many clients can be using it at the same time. AVA can hit those limits as it runs multiple processes, but well-written services should emit an error or throttle in those cases. If the one you're using doesn't, the tests will hang.
 
-By default, AVA will use as many processes as there are CPU cores in your machine.
+By default, AVA will use as many processes as there are CPU cores in your machine. This is capped at eight, or in a CI environment two.
 
 Use the `concurrency` flag to limit the number of processes ran. For example, if your service plan allows 5 clients, you should run AVA with `concurrency=5` or less.
 

--- a/docs/common-pitfalls.md
+++ b/docs/common-pitfalls.md
@@ -16,7 +16,7 @@ AVA uses [is-ci](https://github.com/watson/is-ci) to decide if it's in a CI envi
 
 You may be using a service that only allows a limited number of concurrent connections. For example, many database-as-a-service businesses offer a free plan with a limit on how many clients can be using it at the same time. AVA can hit those limits as it runs multiple processes, but well-written services should emit an error or throttle in those cases. If the one you're using doesn't, the tests will hang.
 
-By default, AVA will use as many processes as there are CPU threads on your machine. This is capped at eight, or in a CI environment two.
+By default, AVA will use as many processes as there are [logical cores](https://superuser.com/questions/1105654/logical-vs-physical-cpu-performance) on your machine. This is capped at eight, or in a CI environment two.
 
 Use the `concurrency` flag to limit the number of processes ran. For example, if your service plan allows 5 clients, you should run AVA with `concurrency=5` or less.
 


### PR DESCRIPTION
The new default of using CPU cores for concurrency works well most of the time, however when running tests in Docker (Travis) it will use the CPU count of the host machine, not what's been allotted to the container.

Discovered when the Got tests where timing out for no apparent reason. [I ran `os.cpus().length` on the container](https://travis-ci.org/lukechilds/got/jobs/288682178) and it returned 32. Capping at 4 resolved the issue.

This PR changes AVA to use whichever is lower out of `os.cpus().length` or `4` for concurrency by default. This seems like a sensible soft limit. You can still manually specify a concurrency that is larger than 4.