### PR TITLE
Fixes #1553. t.is() prompts to user when objects are different references

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -89,7 +89,7 @@ function wrapAssertions(callbacks) {
 			} else {
 				const result = concordance.compare(actual, expected, concordanceOptions);
 				// Primitive values should be the same, so if actual or expected is primitive
-  				// then the values will never compare. No result.actual and result.expected values returned
+				// then the values will never compare. No result.actual and result.expected values returned
 				const notPrimitives = result.actual && result.expected;
 				if (result.pass && notPrimitives) {
 					return fail(this, new AssertionError({

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -92,20 +92,20 @@ function wrapAssertions(callbacks) {
 				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
 
 				if (result.pass) {
-					return fail(this, new AssertionError({
+					fail(this, new AssertionError({
 						assertion: 'is',
 						message,
 						raw: {actual, expected},
 						values: [formatDescriptorWithLabel('Values are deeply equal to each other, but they are not the same:', actualDescriptor)]
 					}));
+				} else {
+					fail(this, new AssertionError({
+						assertion: 'is',
+						message,
+						raw: {actual, expected},
+						values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
+					}));
 				}
-
-				fail(this, new AssertionError({
-					assertion: 'is',
-					message,
-					raw: {actual, expected},
-					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-				}));
 			}
 		},
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -88,10 +88,7 @@ function wrapAssertions(callbacks) {
 				pass(this);
 			} else {
 				const result = concordance.compare(actual, expected, concordanceOptions);
-				// Primitive values should be the same, so if actual or expected is primitive
-				// then the values will never compare. No result.actual and result.expected values returned
-				const notPrimitives = result.actual && result.expected;
-				if (result.pass && notPrimitives) {
+				if (result.pass) {
 					return fail(this, new AssertionError({
 						assertion: 'is',
 						message,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -87,8 +87,21 @@ function wrapAssertions(callbacks) {
 			if (Object.is(actual, expected)) {
 				pass(this);
 			} else {
-				const actualDescriptor = concordance.describe(actual, concordanceOptions);
-				const expectedDescriptor = concordance.describe(expected, concordanceOptions);
+				const result = concordance.compare(actual, expected, concordanceOptions);
+				// Primitive values should be the same, so if actual or expected is primitive
+  				// then the values will never compare. No result.actual and result.expected values returned
+				const notPrimitives = result.actual && result.expected;
+				if (result.pass && notPrimitives) {
+					return fail(this, new AssertionError({
+						assertion: 'is',
+						message,
+						raw: {actual, expected},
+						values: [formatWithLabel(`Objects are identical, but it's not the same object:`, actual)]
+					}));
+				}
+
+				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
+				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
 				fail(this, new AssertionError({
 					assertion: 'is',
 					message,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -88,17 +88,18 @@ function wrapAssertions(callbacks) {
 				pass(this);
 			} else {
 				const result = concordance.compare(actual, expected, concordanceOptions);
+				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
+				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
+
 				if (result.pass) {
 					return fail(this, new AssertionError({
 						assertion: 'is',
 						message,
 						raw: {actual, expected},
-						values: [formatWithLabel(`Objects are identical, but it's not the same object:`, actual)]
+						values: [formatDescriptorWithLabel('Values are deeply equal to each other, but they are not the same:', actualDescriptor)]
 					}));
 				}
 
-				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
-				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
 				fail(this, new AssertionError({
 					assertion: 'is',
 					message,

--- a/test/assert.js
+++ b/test/assert.js
@@ -238,7 +238,7 @@ test('.is()', t => {
 		actual: {foo: 'bar'},
 		expected: {foo: 'bar'},
 		values: [{
-			label: `Objects are identical, but it's not the same object:`,
+			label: `Values are deeply equal to each other, but they are not the same:`,
 			formatted: /foo/
 		}]
 	});

--- a/test/assert.js
+++ b/test/assert.js
@@ -214,10 +214,6 @@ test('.is()', t => {
 	});
 
 	fails(t, () => {
-		assertions.is({foo: 'bar'}, {foo: 'bar'});
-	});
-
-	fails(t, () => {
 		// eslint-disable-next-line no-new-wrappers
 		assertions.is(new String('foo'), new String('foo'));
 	});
@@ -232,6 +228,19 @@ test('.is()', t => {
 
 	fails(t, () => {
 		assertions.is('foo', NaN);
+	});
+
+	failsWith(t, () => {
+		assertions.is({foo: 'bar'}, {foo: 'bar'});
+	}, {
+		assertion: 'is',
+		message: '',
+		actual: {foo: 'bar'},
+		expected: {foo: 'bar'},
+		values: [{
+			label: `Objects are identical, but it's not the same object:`,
+			formatted: /foo/
+		}]
 	});
 
 	failsWith(t, () => {


### PR DESCRIPTION
t.is() performs deep equality check on objects and prompts to user if objects are equal.
Test for this assertion is changed.