### PR TITLE
Ignore nested ignored directories (#1501)

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -94,7 +94,8 @@ const defaultHelperPatterns = () => [
 	'**/test/**/_*.js'
 ];
 
-const getDefaultIgnorePatterns = () => defaultIgnore.map(dir => `${dir}/**/*`);
+const getDefaultIgnorePatterns = () => defaultIgnore.map(dir => `**/${dir}/**/*`);
+const isOverriddenDefaultIgnorePattern = pattern => defaultIgnore.some(dir => pattern.indexOf(`${dir}/`) >= 0);
 
 // Used on paths before they're passed to multimatch to harmonize matching
 // across platforms
@@ -158,9 +159,9 @@ class AvaFiles {
 				hasPositivePattern = true;
 			}
 
-			// Extract patterns that start with an ignored directory. These need to be
+			// Extract patterns that contain an ignored directory. These need to be
 			// rematched separately.
-			if (defaultIgnore.indexOf(pattern.split('/')[0]) >= 0) {
+			if (isOverriddenDefaultIgnorePattern(pattern)) {
 				overrideDefaultIgnorePatterns.push(pattern);
 			}
 		});
@@ -259,7 +260,7 @@ class AvaFiles {
 		// that starts with an ignored directory, ensure the corresponding negation
 		// pattern is added to the ignored paths.
 		const overrideDefaultIgnorePatterns = paths
-			.filter(pattern => defaultIgnore.indexOf(pattern.split('/')[0]) >= 0)
+			.filter(isOverriddenDefaultIgnorePattern)
 			.map(pattern => `!${pattern}`);
 
 		ignored = getDefaultIgnorePatterns().concat(ignored, overrideDefaultIgnorePatterns);

--- a/test/api.js
+++ b/test/api.js
@@ -607,7 +607,12 @@ function generateTests(prefix, apiCreator) {
 			});
 		});
 
-		return api.run([path.join(__dirname, 'fixture/ignored-dirs/node_modules/test.js')]);
+		return api.run([
+			path.join(__dirname, 'fixture/ignored-dirs/node_modules/test.js'),
+			path.join(__dirname, 'fixture/ignored-dirs/a/node_modules/test.js'),
+			path.join(__dirname, 'fixture/ignored-dirs/a/b/node_modules/test.js'),
+			path.join(__dirname, 'fixture/ignored-dirs/a/b/c/node_modules/test.js')
+		]);
 	});
 
 	test(`${prefix} test file in fixtures is ignored`, t => {
@@ -752,12 +757,14 @@ function generateTests(prefix, apiCreator) {
 			});
 
 			// The test files are designed to cause errors so ignore them here.
-			runStatus.on('error', () => {});
+			runStatus.on('error', () => {
+			});
 		});
 
 		const result = api.run(['test/fixture/with-dependencies/*test*.js']);
 
-		return result.catch(() => {});
+		return result.catch(() => {
+		});
 	});
 
 	test(`${prefix} emits stats for test files`, t => {

--- a/test/ava-files.js
+++ b/test/ava-files.js
@@ -48,8 +48,14 @@ test('testMatcher', t => {
 	notTest('foo/_foo-bar.js');
 	notTest('foo-bar.txt');
 	notTest('node_modules/foo.js');
+	notTest('foo/node_modules/bar.js');
+	notTest('foo/bar/baz/node_modules/foo.js');
 	notTest('fixtures/foo.js');
+	notTest('foo/fixtures/bar.js');
+	notTest('foo/bar/baz/fixtures/buz.js');
 	notTest('helpers/foo.js');
+	notTest('foo/helpers/bar.js');
+	notTest('foo/bar/baz/helpers/buz.js');
 	t.end();
 });
 
@@ -82,17 +88,21 @@ test('sourceMatcher - defaults', t => {
 	isSource('bar.js');
 	isSource('bar/bar.js');
 	notSource('node_modules/foo.js');
+	notSource('foo/node_modules/bar.js');
+	notSource('foo/bar/baz/node_modules/buz.js');
 	t.end();
 });
 
 test('sourceMatcher - allow matching specific node_modules directories', t => {
 	const avaFiles = new AvaFiles({
 		files: ['**/foo*'],
-		sources: ['node_modules/foo/**']
+		sources: ['node_modules/foo/**', 'bar/node_modules/foo/**']
 	});
 
 	t.true(avaFiles.isSource('node_modules/foo/foo.js'));
 	t.false(avaFiles.isSource('node_modules/bar/foo.js'));
+	t.true(avaFiles.isSource('bar/node_modules/foo/baz.js'));
+	t.false(avaFiles.isSource('bar/node_modules/baz/foo.js'));
 	t.end();
 });
 

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -175,7 +175,7 @@ group('chokidar', (beforeEach, test, group) => {
 		t.strictDeepEqual(chokidar.watch.firstCall.args, [
 			['package.json', '**/*.js', '**/*.snap'].concat(files),
 			{
-				ignored: defaultIgnore.map(dir => `${dir}/**/*`),
+				ignored: defaultIgnore.map(dir => `**/${dir}/**/*`),
 				ignoreInitial: true
 			}
 		]);
@@ -189,7 +189,7 @@ group('chokidar', (beforeEach, test, group) => {
 		t.strictDeepEqual(chokidar.watch.firstCall.args, [
 			['foo.js', 'baz.js'].concat(files),
 			{
-				ignored: defaultIgnore.map(dir => `${dir}/**/*`).concat('bar.js', 'qux.js'),
+				ignored: defaultIgnore.map(dir => `**/${dir}/**/*`).concat('bar.js', 'qux.js'),
 				ignoreInitial: true
 			}
 		]);
@@ -197,13 +197,16 @@ group('chokidar', (beforeEach, test, group) => {
 
 	test('configured sources can override default ignore patterns', t => {
 		t.plan(2);
-		start(null, ['node_modules/foo/*.js']);
+		start(null, ['node_modules/foo/*.js', 'foo/node_modules/bar/*.js']);
 
 		t.ok(chokidar.watch.calledOnce);
 		t.strictDeepEqual(chokidar.watch.firstCall.args, [
-			['node_modules/foo/*.js'].concat(files),
+			['node_modules/foo/*.js', 'foo/node_modules/bar/*.js'].concat(files),
 			{
-				ignored: defaultIgnore.map(dir => `${dir}/**/*`).concat('!node_modules/foo/*.js'),
+				ignored: defaultIgnore.map(dir => `**/${dir}/**/*`).concat([
+					'!node_modules/foo/*.js',
+					'!foo/node_modules/bar/*.js'
+				]),
 				ignoreInitial: true
 			}
 		]);


### PR DESCRIPTION
Update file matching code to ignore the [ignore-by-default](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) directories at any depth by prepending `**/`.

It's definitely worth considering whether it makes sense to ignore all those directories at any depth. For example, it may make sense to ignore files in `node_modules`, `.git`, and `.nyc_output` at any depth, but not `coverage` which would be a reasonable module name in some projects.
