### PR TITLE
Update readme to remove unreleased feature

### DIFF
--- a/0001-remove-doc-for-unreleased-feature.patch
+++ b/0001-remove-doc-for-unreleased-feature.patch
@@ -1,0 +1,29 @@
+From 130852b880c2f0aaccf3e55047df8329cbc9239c Mon Sep 17 00:00:00 2001
+From: Alyssa Horrocks <alyssa.horrocks2@gmail.com>
+Date: Mon, 13 Nov 2017 16:44:24 -0800
+Subject: [PATCH] remove doc for unreleased feature
+
+---
+ docs/recipes/babelrc.md | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/docs/recipes/babelrc.md b/docs/recipes/babelrc.md
+index 2e2604f..1c61312 100644
+--- a/docs/recipes/babelrc.md
++++ b/docs/recipes/babelrc.md
+@@ -15,12 +15,6 @@ There are multiple options for configuring how AVA transpiles your tests using B
+ 
+ AVA lets you use some nifty JavaScript features, like [async functions](https://github.com/avajs/ava#async-function-support). To make this work on older Node.js versions AVA transpiles the tests and helper files using the [`@ava/stage-4`](https://github.com/avajs/babel-preset-stage-4) Babel preset. This is great for projects where you do not use Babel for your source, but do want to use the newest JavaScript features for your tests.
+ 
+-### Using object rest/spread properties
+-
+-As of Node.js [8.3.0](https://github.com/nodejs/node/blob/v8.3.0/doc/changelogs/CHANGELOG_V8.md#8.3.0) [object rest/spread properties](https://github.com/tc39/proposal-object-rest-spread) is supported directly. This new language feature however has not yet reached [stage 4](http://2ality.com/2015/11/tc39-process.html#stage-4-finished), which means that AVA won't support it by default. That said, if you're using Node.js 8.3.0 or newer, AVA will load the [`syntax-object-rest-spread`](https://www.npmjs.com/package/babel-plugin-syntax-object-rest-spread) plugin for you. This means you *can* use object rest/spread properties in your tests as long as you're not targeting older Node.js versions.
+-
+-Note that if you customize the Babel configuration you'll have to explicitly specify the `syntax-object-rest-spread` plugin.
+-
+ ## Customizing how AVA transpiles your tests
+ 
+ You can override the default Babel configuration AVA uses for test transpilation in `package.json`. For example, the configuration below adds the Babel `rewire` plugin, and adds the Babel [`stage-3`](http://babeljs.io/docs/plugins/preset-stage-3/) preset.
+-- 
+2.14.2.windows.2
+

--- a/docs/recipes/babelrc.md
+++ b/docs/recipes/babelrc.md
@@ -15,12 +15,6 @@ There are multiple options for configuring how AVA transpiles your tests using B
 
 AVA lets you use some nifty JavaScript features, like [async functions](https://github.com/avajs/ava#async-function-support). To make this work on older Node.js versions AVA transpiles the tests and helper files using the [`@ava/stage-4`](https://github.com/avajs/babel-preset-stage-4) Babel preset. This is great for projects where you do not use Babel for your source, but do want to use the newest JavaScript features for your tests.
 
-### Using object rest/spread properties
-
-As of Node.js [8.3.0](https://github.com/nodejs/node/blob/v8.3.0/doc/changelogs/CHANGELOG_V8.md#8.3.0) [object rest/spread properties](https://github.com/tc39/proposal-object-rest-spread) is supported directly. This new language feature however has not yet reached [stage 4](http://2ality.com/2015/11/tc39-process.html#stage-4-finished), which means that AVA won't support it by default. That said, if you're using Node.js 8.3.0 or newer, AVA will load the [`syntax-object-rest-spread`](https://www.npmjs.com/package/babel-plugin-syntax-object-rest-spread) plugin for you. This means you *can* use object rest/spread properties in your tests as long as you're not targeting older Node.js versions.
-
-Note that if you customize the Babel configuration you'll have to explicitly specify the `syntax-object-rest-spread` plugin.
-
 ## Customizing how AVA transpiles your tests
 
 You can override the default Babel configuration AVA uses for test transpilation in `package.json`. For example, the configuration below adds the Babel `rewire` plugin, and adds the Babel [`stage-3`](http://babeljs.io/docs/plugins/preset-stage-3/) preset.


### PR DESCRIPTION
My code (using Node 8.8.1) was throwing syntax errors on the spread operator, which was confusing since I had read the documentation and was sure that ava would pull in the necessary babel plugin. I saw that it had not actually pulled the plugin in and almost put an issue in until I noticed that the fix was submitted 17 days ago and the last release was 20 days ago. 

I think that this information should be removed from the documentation until the issue fix is released. Thanks!