### PR TITLE
Update npm, test Node.js 9, detect package-lock churn in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 bench/.results
 types/generated.d.ts
+/package-lock.json.md5

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_install:
   - npm --version
 install:
   - if [[ ${FRESH_DEPS} == "true" ]]; then npm install --no-shrinkwrap --prefer-online; else npm install --prefer-offline; fi
-after_success: ./node_modules/.bin/codecov --file=./coverage/lcov.info
+after_success: npx codecov --file=./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,15 @@ cache:
 before_install:
   - npm install --global npm@5.6.0
   - npm --version
-install:
-  - if [[ ${FRESH_DEPS} == "true" ]]; then npm install --no-shrinkwrap --prefer-online; else npm install --prefer-offline; fi
+  - md5sum package-lock.json > package-lock.json.md5
+install: |
+  if [[ ${FRESH_DEPS} == "true" ]]; then
+    npm install --no-shrinkwrap --prefer-online;
+  else
+    npm install --prefer-offline;
+    if ! md5sum --quiet -c package-lock.json.md5; then
+      echo "package-lock.json was modified unexpectedly. Please rebuild it using npm@$(npm -v) and commit the changes.";
+      exit 1;
+    fi
+  fi
 after_success: npx codecov --file=./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 9
   - 8
   - 6
   - 4
@@ -8,6 +9,8 @@ env:
   - FRESH_DEPS=true
 matrix:
   exclude:
+    - node_js: 9
+      env: FRESH_DEPS=true
     - node_js: 6
       env: FRESH_DEPS=true
     - node_js: 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
   directories:
     - $HOME/.npm
 before_install:
-  - npm install --global npm@5.4.2
+  - npm install --global npm@5.6.0
   - npm --version
 install:
   - if [[ ${FRESH_DEPS} == "true" ]]; then npm install --no-shrinkwrap --prefer-online; else npm install --prefer-offline; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ matrix:
       nodejs_version: 4
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install --global npm@5.4.2
+  - npm install --global npm@5.6.0
   - npm --version
   - git config core.symlinks true
   - git reset --hard

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,15 @@ configuration:
   - LockedDeps
 environment:
   matrix:
+    - nodejs_version: 9
     - nodejs_version: 8
     - nodejs_version: 6
     - nodejs_version: 4
 matrix:
   fast_finish: true
   exclude:
+    - configuration: FreshDeps
+      nodejs_version: 9
     - configuration: FreshDeps
       nodejs_version: 6
     - configuration: FreshDeps

--- a/contributing.md
+++ b/contributing.md
@@ -40,6 +40,8 @@ You may find an issue is assigned, or has the [`assigned` label](https://github.
 
 We'd like to fix [`priority` issues](https://github.com/avajs/ava/labels/priority) first. We'd love to see progress on [`low-priority` issues](https://github.com/avajs/ava/labels/low%20priority) too. [`future` issues](https://github.com/avajs/ava/labels/future) are those that we'd like to get to, but not anytime soon. Please check before working on these since we may not yet want to take on the burden of supporting those features.
 
+If you're updating dependencies, please make sure you use npm@5.6.0 and commit the updated `package-lock.json` file.
+
 ### Hang out in our chat
 
 We have a [chat](https://gitter.im/avajs/ava). Jump in there and lurk, talk to us, and help others.


### PR DESCRIPTION
[npm 5.6.0](https://github.com/npm/npm/releases/tag/v5.6.0) means we can now safely test with Node.js 9, so I've added that to the test matrix.

I've also added a way of verifying the `package-lock.json` file is up to date. This should help detect unexpected or missing changes in future pull requests and reduce any churn to just when the npm version itself is updated. See https://travis-ci.org/avajs/ava/jobs/308555431 for an example of when `package-lock.json` is outdated.