### PR TITLE
Allow tests to be ran with dummy Babel compilation

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -150,7 +150,8 @@ exports.run = () => {
 		concurrency: conf.concurrency ? parseInt(conf.concurrency, 10) : 0,
 		updateSnapshots: conf.updateSnapshots,
 		snapshotDir: conf.snapshotDir ? path.resolve(projectDir, conf.snapshotDir) : null,
-		color: conf.color
+		color: conf.color,
+		compileJavascriptFiles: conf.compileJavascriptFiles !== false
 	});
 
 	let reporter;

--- a/lib/native-caching-precompiler.js
+++ b/lib/native-caching-precompiler.js
@@ -1,0 +1,39 @@
+'use strict';
+const fs = require('fs');
+const cachingTransform = require('caching-transform');
+const packageHash = require('package-hash');
+const stripBomBuf = require('strip-bom-buf');
+const autoBind = require('auto-bind');
+const md5Hex = require('md5-hex');
+
+class NativeCachingPrecompiler {
+
+	constructor(options) {
+		autoBind(this);
+		this.babelCacheKeys = options.babelCacheKeys;
+		this.cacheDirPath = options.path;
+		this.fileHashes = {};
+		this.transform = cachingTransform({
+			cacheDir: this.cacheDirPath,
+			ext: '.js',
+			factory: () => code => code.toString(), // Native raw
+			salt: packageHash.sync([require.resolve('../package.json')], this.babelCacheKeys),
+			hash: (code, filePath, salt) => {
+				const hash = md5Hex([code, filePath, salt]);
+				this.fileHashes[filePath] = hash;
+				return hash;
+			}
+		});
+	}
+
+	precompileFile(filePath) {
+		if (!this.fileHashes[filePath]) {
+			const source = stripBomBuf(fs.readFileSync(filePath));
+			this.transform(source, filePath);
+		}
+
+		return this.fileHashes[filePath];
+	}
+}
+
+module.exports = NativeCachingPrecompiler;

--- a/lib/process-adapter.js
+++ b/lib/process-adapter.js
@@ -78,9 +78,10 @@ exports.installSourceMapSupport = () => {
 exports.installPrecompilerHook = () => {
 	installPrecompiler(filename => {
 		const precompiled = opts.precompiled[filename];
-
 		if (precompiled) {
-			sourceMapCache.set(filename, path.join(cacheDir, `${precompiled}.js.map`));
+			if (opts.compileJavascriptFiles) {
+				sourceMapCache.set(filename, path.join(cacheDir, `${precompiled}.js.map`));
+			}
 			return fs.readFileSync(path.join(cacheDir, `${precompiled}.js`), 'utf8');
 		}
 

--- a/profile.js
+++ b/profile.js
@@ -15,6 +15,7 @@ const arrify = require('arrify');
 const resolveCwd = require('resolve-cwd');
 const babelConfigHelper = require('./lib/babel-config');
 const CachingPrecompiler = require('./lib/caching-precompiler');
+const NativeCachingPrecompiler = require('./lib/native-caching-precompiler');
 const globals = require('./lib/globals');
 
 function resolveModules(modules) {
@@ -78,11 +79,19 @@ const cacheDir = findCacheDir({
 
 babelConfigHelper.build(process.cwd(), cacheDir, conf.babel, true)
 	.then(result => {
-		const precompiler = new CachingPrecompiler({
-			path: cacheDir,
-			getBabelOptions: result.getOptions,
-			babelCacheKeys: result.cacheKeys
-		});
+		let precompiler = null;
+		if (conf.compileJavascriptFiles) {
+			precompiler = new CachingPrecompiler({
+				path: cacheDir,
+				getBabelOptions: result.getOptions,
+				babelCacheKeys: result.cacheKeys
+			});
+		} else {
+			precompiler = new NativeCachingPrecompiler({
+				path: cacheDir,
+				babelCacheKeys: result.cacheKeys
+			});
+		}
 
 		const precompiled = {};
 		precompiled[file] = precompiler.precompileFile(file);


### PR DESCRIPTION
Hi there,

Based on the discussions in #709 and #1556, here is a pull-request to by pass the babel compilation. This is mostly inspired by https://github.com/andywer/ava-ts.

It adds a `compileJavascriptFiles` option to switch between `CachingPrecompiler` and `NativeCachingPrecompiler`. Instead of calling `babel.transform`, this new class just returns native code by calling `toString()` function.
We tested this pull-request against our tests and we were able to debug our code without source mapping issue. Note that we don't use Babel in our project.

This pull request is not ready to be merged (no tests,...). This is mostly to share with you a way to by pass Babel compilation. Is this the right way to do it or do you have another solutions in mind?
