### PR TITLE
Switched time-require to @ladjs/time-require since main package is unmaintained

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ if (importLocal(__filename)) {
 	debug('Using local install of AVA');
 } else {
 	if (debug.enabled) {
-		require('time-require'); // eslint-disable-line import/no-unassigned-import
+		require('@ladjs/time-require'); // eslint-disable-line import/no-unassigned-import
 	}
 
 	try {

--- a/lib/process-adapter.js
+++ b/lib/process-adapter.js
@@ -48,13 +48,13 @@ if (opts.tty) {
 }
 
 if (debug.enabled) {
-	// Forward the `time-require` `--sorted` flag.
+	// Forward the `@ladjs/time-require` `--sorted` flag.
 	// Intended for internal optimization tests only.
 	if (opts._sorted) {
 		process.argv.push('--sorted');
 	}
 
-	require('time-require'); // eslint-disable-line import/no-unassigned-import
+	require('@ladjs/time-require'); // eslint-disable-line import/no-unassigned-import
 }
 
 const sourceMapCache = new Map();

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,52 @@
         "yargs": "8.0.2"
       }
     },
+    "@ladjs/time-require": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
+      "integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
+      "requires": {
+        "chalk": "0.4.0",
+        "date-time": "0.1.1",
+        "pretty-ms": "0.2.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "requires": {
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
+          }
+        },
+        "parse-ms": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
+          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
+        },
+        "pretty-ms": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
+          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+          "requires": {
+            "parse-ms": "0.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -6643,52 +6689,6 @@
       "requires": {
         "readable-stream": "2.2.10",
         "xtend": "4.0.1"
-      }
-    },
-    "time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "parse-ms": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
-        },
-        "pretty-ms": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "requires": {
-            "parse-ms": "0.1.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
       }
     },
     "time-zone": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"@ava/babel-preset-transform-test-files": "^3.0.0",
 		"@ava/write-file-atomic": "^2.2.0",
 		"@concordance/react": "^1.0.0",
+		"@ladjs/time-require": "^0.1.4",
 		"ansi-escapes": "^3.0.0",
 		"ansi-styles": "^3.1.0",
 		"arr-flatten": "^1.0.1",
@@ -140,7 +141,6 @@
 		"strip-bom-buf": "^1.0.0",
 		"supertap": "^1.0.0",
 		"supports-color": "^5.0.0",
-		"time-require": "^0.1.2",
 		"trim-off-newlines": "^1.0.1",
 		"unique-temp-dir": "^1.0.0",
 		"update-notifier": "^2.3.0"


### PR DESCRIPTION
The `time-require` package at <https://github.com/Jaguard/time-require> is unmaintained, and core bugs such as a typo `treshold` => `threshold` has had an open PR for years now at <https://github.com/Jaguard/time-require/pull/9.

I went ahead and merged that PR into a fork of the repo and published it as `@ladjs/time-require`.  As such I changed it here in ava as well through this pull request.