### PR TITLE
Fix: add types for t.snapshot(content, options)

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -7,6 +7,9 @@ export type ErrorValidator
 export interface Observable {
 	subscribe(observer: (value: {}) => void): void;
 }
+export interface SnapshotOptions {
+	id?: string;
+}
 export type Test = (t: TestContext) => PromiseLike<void> | Iterator<any> | Observable | void;
 export type GenericTest<T> = (t: GenericTestContext<T>) => PromiseLike<void> | Iterator<any> | Observable | void;
 export type CallbackTest = (t: CallbackTestContext) => void;
@@ -78,6 +81,7 @@ export interface AssertContext {
 	 * Assert that contents matches a snapshot.
 	 */
 	snapshot(contents: any, message?: string): void;
+	snapshot(contents: any, options: SnapshotOptions, message?: string): void;
 	/**
 	 * Assert that contents does not match regex.
 	 */


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
While writing my tests in TypeScript I noticed the missing overload signature for `t.snapshot(content, options [, message])`.
This add the missing type declaration.