### PR TITLE
Debug serially in the "Debugging tests with VS Code" recipe

### DIFF
--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -34,7 +34,7 @@ Set breakpoints in the code **or** write `debugger;` at the point where it shoul
 
 Hit the green `Debug` button next to the list of configurations on the top left in the `Debug` view. Once the breakpoint is hit, you can evaluate variables and step through the code.
 
-## Serial Debugging
+# Serial Debug Setup
 
 > **Note:** The configuration will run tests concurrently, Ava's default, so breakpoints will not be hit sequentially.  To avoid this, optionally add the following to the `configurations` object to run the Ava test serially.
 

--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -36,7 +36,7 @@ Hit the green `Debug` button next to the list of configurations on the top left 
 
 # Serial Debug Setup
 
-> **Note:** The configuration will run tests concurrently, Ava's default, so breakpoints will not be hit sequentially.  To avoid this, optionally add the following to the `configurations` object to run the Ava test serially.
+> **Note:** The configuration above will run tests concurrently, Ava's default, so breakpoints will not be hit sequentially.  To avoid this, optionally add the following to the `configurations` object to run the Ava test serially.
 
 ```json
 {

--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -34,9 +34,9 @@ Set breakpoints in the code **or** write `debugger;` at the point where it shoul
 
 Hit the green `Debug` button next to the list of configurations on the top left in the `Debug` view. Once the breakpoint is hit, you can evaluate variables and step through the code.
 
-# Serial Debug Setup
+## Serial debugging
 
-> **Note:** The configuration above will run tests concurrently, Ava's default, so breakpoints will not be hit sequentially.  To avoid this, optionally add the following to the `configurations` object to run the Ava test serially.
+By default AVA runs tests concurrently. This may complicate debugging. Add a configuration with the `--serial` argument so AVA runs only one test at a time:
 
 ```json
 {
@@ -51,3 +51,4 @@ Hit the green `Debug` button next to the list of configurations on the top left 
 }
 ```
 
+*Note that, if your tests aren't properly isolated, certain test failures may not appear when running the tests serially.*

--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -17,7 +17,6 @@ Add following to the `configurations` object:
 	"name": "Run AVA test",
 	"program": "${workspaceRoot}/node_modules/ava/profile.js",
 	"args": [
-	  "--serial",
 	  "${file}"
 	]
 }
@@ -34,3 +33,21 @@ Save this configuration after you added it.
 Set breakpoints in the code **or** write `debugger;` at the point where it should stop.
 
 Hit the green `Debug` button next to the list of configurations on the top left in the `Debug` view. Once the breakpoint is hit, you can evaluate variables and step through the code.
+
+## Serial Debugging
+
+> **Note:** The configuration will run tests concurrently, Ava's default, so breakpoints will not be hit sequentially.  To avoid this, optionally add the following to the `configurations` object to run the Ava test serially.
+
+```json
+{
+	"type": "node",
+	"request": "launch",
+	"name": "Run AVA test serially",
+	"program": "${workspaceRoot}/node_modules/ava/profile.js",
+	"args": [
+	  "--serial",
+	  "${file}"
+	]
+}
+```
+

--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -17,6 +17,7 @@ Add following to the `configurations` object:
 	"name": "Run AVA test",
 	"program": "${workspaceRoot}/node_modules/ava/profile.js",
 	"args": [
+	  "--serial",
 	  "${file}"
 	]
 }


### PR DESCRIPTION
Debug serially to avoid confusing execution paths in async code, e.g. swapping from one test's execution context to the next.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
