### PR TITLE
Add more clarification for different Babel config in .babelrc.md

### DIFF
--- a/docs/recipes/babelrc.md
+++ b/docs/recipes/babelrc.md
@@ -36,7 +36,7 @@ You can override the default Babel configuration AVA uses for test transpilation
 }
 ```
 
-Note that this only overrides Babel for transpiling tests. If you have sources linked to a test, then you still need to add separate Babel configuration for sources explained [here](#transpiling-sources).
+Note that this only affects how AVA transpiles your tests. If you use `babel-register` you'll still need to add separate Babel configuration as explained [here](#transpiling-sources).
 
 ## Use Babel Polyfills
 

--- a/docs/recipes/babelrc.md
+++ b/docs/recipes/babelrc.md
@@ -36,7 +36,7 @@ You can override the default Babel configuration AVA uses for test transpilation
 }
 ```
 
-Note that this only overrides babel for transpiling tests. If you have sources linked to a test, then you still need to add separate babel configuration for sources explained [here](#transpiling-sources).
+Note that this only overrides Babel for transpiling tests. If you have sources linked to a test, then you still need to add separate Babel configuration for sources explained [here](#transpiling-sources).
 
 ## Use Babel Polyfills
 

--- a/docs/recipes/babelrc.md
+++ b/docs/recipes/babelrc.md
@@ -36,6 +36,8 @@ You can override the default Babel configuration AVA uses for test transpilation
 }
 ```
 
+Note that this only overrides babel for transpiling tests. If you have sources linked to a test, then you still need to add separate babel configuration for sources explained [here](#transpiling-sources).
+
 ## Use Babel Polyfills
 
 AVA lets you write your tests using new JavaScript syntax, even on Node.js versions that otherwise wouldn't support it. However, it doesn't add or modify built-ins of your current environment. Using AVA would, for example, not provide modern features such as `Array.prototype.includes()` to an underlying Node.js 4 environment.


### PR DESCRIPTION
Fixes #1640. Add more explanation for the difference between tests vs sources babel configuration.

We may need to update the france translation later.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
