### PR TITLE
Update code-excerpt to ^2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,9 +1282,9 @@
       }
     },
     "code-excerpt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
-      "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
+      "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
       "requires": {
         "convert-to-spaces": "1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"cli-spinners": "^1.0.0",
 		"cli-truncate": "^1.0.0",
 		"co-with-promise": "^4.6.0",
-		"code-excerpt": "^2.1.0",
+		"code-excerpt": "^2.1.1",
 		"common-path-prefix": "^1.0.0",
 		"concordance": "^3.0.0",
 		"convert-source-map": "^1.5.1",


### PR DESCRIPTION
Fixes #1636 

Updated code-excerpt dependency to 2.1.1 , this version contains the fix for the abnormal display on CRLF line breaks

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
