### PR TITLE
docs(debugging): recommend skipFiles

### DIFF
--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -18,6 +18,9 @@ Add following to the `configurations` object:
 	"program": "${workspaceRoot}/node_modules/ava/profile.js",
 	"args": [
 	  "${file}"
+	],
+	"skipFiles": [
+		"<node_internals>/**/*.js"
 	]
 }
 ```
@@ -47,6 +50,9 @@ By default AVA runs tests concurrently. This may complicate debugging. Add a con
 	"args": [
 	  "--serial",
 	  "${file}"
+	],
+	"skipFiles": [
+		"<node_internals>/**/*.js"
 	]
 }
 ```


### PR DESCRIPTION
# problem

VSCode steps into native code at each `await` statement.

# solution

using skipFiles on node_internals yields a more dev-expected debug experience

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
