### PR TITLE
Allow custom Node executable via environment variable for children processes

### DIFF
--- a/bench/run.js
+++ b/bench/run.js
@@ -13,7 +13,7 @@ function runTests(_args) {
 		const args = [cliPath].concat(arrify(_args));
 		const start = Date.now();
 
-		childProcess.execFile(process.execPath, args, {
+		childProcess.execFile(process.env.NODE_EXEC || process.execPath, args, {
 			cwd: __dirname,
 			maxBuffer: 100000 * 200
 		}, (err, stdout, stderr) => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -32,7 +32,7 @@ function execCli(args, opts, cb) {
 	let stderr;
 
 	const processPromise = new Promise(resolve => {
-		child = childProcess.spawn(process.execPath, [cliPath].concat(args), {
+		child = childProcess.spawn(process.env.NODE_EXEC || process.execPath, [cliPath].concat(args), {
 			cwd: dirname,
 			env,
 			stdio: [null, 'pipe', 'pipe']


### PR DESCRIPTION
# Story

As a developer, I would like to provide my own path to a Node executable so the test children can be ran using that custom Node executable.

# Description

I hate Babel (the line mangling and source mapping, the requirement to compile code in advance for NPM, the implied requirements to compile test code, the unreadable stack traces in production, its malware-like capacity to destroy CPUs on older machines, the language security disaster that awaits us all for using it, the rewarding of terrible mentalities centered around turning JavaScript into a crippled, inferior mutant of C# and Java when, really, just learn Go and call it a day) and my project intentionally goes out of its way to not use it.

I do use Flow because, unlike most use cases of Babel, it's using transpilers to solve an actual problem and not minor annoyances.  I like to keep my developer exposure to Babel as small as possible, which means I need Ava's children processes to run via `flow-node` and not native `node`.

This PR lets you specify an environment variable (`NODE_EXEC`) to contain the path to a custom Node executable for children processes.  This is probably not the best approach, and even if the PR gets rejected, the spirit of the PR should, at the very least, be considered and solved by another form.