### PR TITLE
Dont' set `Error.stackTraceLimit` to Infinity globally

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -49,14 +49,22 @@ class AssertionError extends Error {
 
 		if (opts.stack) {
 			this.stack = opts.stack;
+		} else {
+			const limitBefore = Error.stackTraceLimit;
+			Error.stackTraceLimit = Infinity;
+			Error.captureStackTrace(this);
+			Error.stackTraceLimit = limitBefore;
 		}
 	}
 }
 exports.AssertionError = AssertionError;
 
 function getStack() {
+	const limitBefore = Error.stackTraceLimit;
+	Error.stackTraceLimit = Infinity;
 	const obj = {};
 	Error.captureStackTrace(obj, getStack);
+	Error.stackTraceLimit = limitBefore;
 	return obj.stack;
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,8 +23,6 @@ worker.setRunner(runner);
 // that no more tests should be logged
 let isFailed = false;
 
-Error.stackTraceLimit = Infinity;
-
 function test(props) {
 	if (isFailed) {
 		return;

--- a/test/cli.js
+++ b/test/cli.js
@@ -83,6 +83,16 @@ test('enabling long stack traces will provide detailed debug information', t => 
 	});
 });
 
+test('`AssertionError` should capture infinity stack trace', t => {
+	execCli('fixture/infinity-stack-trace.js', (err, stdout, stderr) => {
+		t.ok(err);
+		t.match(stderr, /c \(.+?infinity-stack-trace\.js:6:20\)/);
+		t.match(stderr, /b \(.+?infinity-stack-trace\.js:7:18\)/);
+		t.match(stderr, /a \(.+?infinity-stack-trace\.js:8:18\)/);
+		t.end();
+	});
+});
+
 test('timeout', t => {
 	execCli(['fixture/long-running.js', '-T', '1s'], (err, stdout, stderr) => {
 		t.ok(err);

--- a/test/fixture/infinity-stack-trace.js
+++ b/test/fixture/infinity-stack-trace.js
@@ -1,0 +1,11 @@
+import test from '../../';
+
+Error.stackTraceLimit = 1;
+
+test(t => {
+	const c = () => t.fail();
+	const b = () => c();
+	const a = () => b();
+
+	a();
+});


### PR DESCRIPTION
Refs: https://github.com/avajs/ava/issues/483

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
