### PR TITLE
Make `t.throws()` accept async function as parameter

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -55,13 +55,13 @@ type AssertContext = {
 	deepEqual<U>(value: U, expected: U, message?: string): void;
 	// Assert that value is not deep equal to expected.
 	notDeepEqual<U>(value: U, expected: U, message?: string): void;
-	// Assert that function throws an error or promise rejects.
+	// Assert that the promise rejects, or the function throws or returns a rejected promise.
 	// @param error Can be a constructor, regex, error message or validation function.
 	throws: {
 		(value: PromiseLike<mixed>, error?: ErrorValidator, message?: string): Promise<any>;
 		(value: () => mixed, error?: ErrorValidator, message?: string): any;
 	};
-	// Assert that function doesn't throw an error or promise resolves.
+	// Assert that the promise resolves, or the function doesn't throws or returns a resolved promise.
 	notThrows: {
 		(value: PromiseLike<mixed>, message?: string): Promise<void>;
 		(value: () => mixed, message?: string): void;

--- a/index.js.flow
+++ b/index.js.flow
@@ -61,7 +61,7 @@ type AssertContext = {
 		(value: PromiseLike<mixed>, error?: ErrorValidator, message?: string): Promise<any>;
 		(value: () => mixed, error?: ErrorValidator, message?: string): any;
 	};
-	// Assert that the promise resolves, or the function doesn't throws or returns a resolved promise.
+	// Assert that the promise resolves, or the function doesn't throw or return a resolved promise.
 	notThrows: {
 		(value: PromiseLike<mixed>, message?: string): Promise<void>;
 		(value: () => mixed, message?: string): void;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -198,13 +198,14 @@ function wrapAssertions(callbacks) {
 				coreAssertThrowsErrorArg = err;
 			}
 
+			let maybePromise;
 			const test = (fn, stack) => {
 				let actual;
 				let threw = false;
 				try {
 					coreAssert.throws(() => {
 						try {
-							fn();
+							maybePromise = fn();
 						} catch (err) {
 							actual = err;
 							threw = true;
@@ -224,7 +225,7 @@ function wrapAssertions(callbacks) {
 				}
 			};
 
-			if (promise) {
+			const handlePromise = promise => {
 				// Record stack before it gets lost in the promise chain.
 				const stack = getStack();
 				const intermediate = promise.then(value => {
@@ -238,6 +239,10 @@ function wrapAssertions(callbacks) {
 				pending(this, intermediate);
 				// Don't reject the returned promise, even if the assertion fails.
 				return intermediate.catch(noop);
+			};
+
+			if (promise) {
+				return handlePromise(promise);
 			}
 
 			try {
@@ -245,6 +250,14 @@ function wrapAssertions(callbacks) {
 				pass(this);
 				return retval;
 			} catch (err) {
+				if (maybePromise) {
+					if (isPromise(maybePromise)) {
+						return handlePromise(maybePromise);
+					}
+					if (isObservable(maybePromise)) {
+						return handlePromise(observableToPromise(maybePromise));
+					}
+				}
 				fail(this, err);
 			}
 		},
@@ -265,9 +278,12 @@ function wrapAssertions(callbacks) {
 				return;
 			}
 
+			let maybePromise;
 			const test = (fn, stack) => {
 				try {
-					coreAssert.doesNotThrow(fn);
+					coreAssert.doesNotThrow(() => {
+						maybePromise = fn();
+					});
 				} catch (err) {
 					throw new AssertionError({
 						assertion: 'notThrows',
@@ -278,17 +294,29 @@ function wrapAssertions(callbacks) {
 				}
 			};
 
-			if (promise) {
+			const handlePromise = promise => {
 				// Record stack before it gets lost in the promise chain.
 				const stack = getStack();
 				const intermediate = promise.then(noop, reason => test(makeRethrow(reason), stack));
 				pending(this, intermediate);
 				// Don't reject the returned promise, even if the assertion fails.
 				return intermediate.catch(noop);
+			};
+
+			if (promise) {
+				return handlePromise(promise);
 			}
 
 			try {
 				test(fn);
+				if (maybePromise) {
+					if (isPromise(maybePromise)) {
+						return handlePromise(maybePromise);
+					}
+					if (isObservable(maybePromise)) {
+						return handlePromise(observableToPromise(maybePromise));
+					}
+				}
 				pass(this);
 			} catch (err) {
 				fail(this, err);

--- a/readme.md
+++ b/readme.md
@@ -952,7 +952,7 @@ test('rejects', async t => {
 });
 ```
 
-When testing an `async function` you must also wait for the assertion to complete:
+When testing an asynchronous function you must also wait for the assertion to complete:
 
 ```js
 test('throws', async t => {

--- a/readme.md
+++ b/readme.md
@@ -913,7 +913,7 @@ Assert that `value` is not deeply equal to `expected`. The inverse of `.deepEqua
 
 ### `.throws(function|promise, [error, [message]])`
 
-Assert that `function` throws an error, or `promise` rejects with an error.
+Assert that `function` throws an error, `promise` rejects with an error, or `function` returns a rejected `promise`.
 
 `error` can be an error constructor, error message, regex matched against the error message, or validation function.
 
@@ -952,9 +952,21 @@ test('rejects', async t => {
 });
 ```
 
+When testing an `async function` you must also wait for the assertion to complete:
+
+```js
+test('throws', async t => {
+	const error = await t.throws(async () => {
+		throw new TypeError('🦄');
+	}, TypeError);
+
+	t.is(error.message, '🦄');
+});
+```
+
 ### `.notThrows(function|promise, [message])`
 
-Assert that `function` does not throw an error or that `promise` does not reject with an error.
+Assert that `function` does not throw an error, `promise` does not reject with an error, or `function` returns a promise that does not reject with an error.
 
 Like the `.throws()` assertion, when testing a promise you must wait for the assertion to complete:
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -656,11 +656,7 @@ test('.throws()', t => {
 		});
 	});
 
-	return eventuallyFailsWith(t, assertions.throws(() => Promise.resolve('foo')), {
-		assertion: 'throws',
-		message: 'Expected promise to be rejected, but it was resolved instead',
-		values: [{label: 'Resolved with:', formatted: /'foo'/}]
-	});
+	t.end();
 });
 
 test('.throws() returns the thrown error', t => {
@@ -750,13 +746,7 @@ test('.notThrows()', t => {
 		values: [{label: 'Threw:', formatted: /foo/}]
 	});
 
-	return eventuallyFailsWith(t, assertions.notThrows(() => {
-		return Promise.reject(new Error('foo'));
-	}), {
-		assertion: 'notThrows',
-		message: '',
-		values: [{label: 'Threw:', formatted: /foo/}]
-	});
+	t.end();
 });
 
 test('.notThrows() returns undefined for a fulfilled promise', t => {

--- a/test/assert.js
+++ b/test/assert.js
@@ -6,6 +6,7 @@ const stripAnsi = require('strip-ansi');
 const React = require('react');
 const renderer = require('react-test-renderer');
 const test = require('tap').test;
+const Observable = require('zen-observable');
 const assert = require('../lib/assert');
 const snapshotManager = require('../lib/snapshot-manager');
 const Test = require('../lib/test');
@@ -655,7 +656,11 @@ test('.throws()', t => {
 		});
 	});
 
-	t.end();
+	return eventuallyFailsWith(t, assertions.throws(() => Promise.resolve('foo')), {
+		assertion: 'throws',
+		message: 'Expected promise to be rejected, but it was resolved instead',
+		values: [{label: 'Resolved with:', formatted: /'foo'/}]
+	});
 });
 
 test('.throws() returns the thrown error', t => {
@@ -673,6 +678,28 @@ test('.throws() returns the rejection reason of promise', t => {
 	const expected = new Error();
 
 	return assertions.throws(Promise.reject(expected)).then(actual => {
+		t.is(actual, expected);
+		t.end();
+	});
+});
+
+test('.throws() returns the rejection reason of a promise returned by the function', t => {
+	const expected = new Error();
+
+	return assertions.throws(() => {
+		return Promise.reject(expected);
+	}).then(actual => {
+		t.is(actual, expected);
+		t.end();
+	});
+});
+
+test('.throws() returns the error of an observable returned by the function', t => {
+	const expected = new Error();
+
+	return assertions.throws(() => {
+		return new Observable(observer => observer.error(expected));
+	}).then(actual => {
 		t.is(actual, expected);
 		t.end();
 	});
@@ -723,11 +750,33 @@ test('.notThrows()', t => {
 		values: [{label: 'Threw:', formatted: /foo/}]
 	});
 
-	t.end();
+	return eventuallyFailsWith(t, assertions.notThrows(() => {
+		return Promise.reject(new Error('foo'));
+	}), {
+		assertion: 'notThrows',
+		message: '',
+		values: [{label: 'Threw:', formatted: /foo/}]
+	});
 });
 
 test('.notThrows() returns undefined for a fulfilled promise', t => {
 	return assertions.notThrows(Promise.resolve(Symbol(''))).then(actual => {
+		t.is(actual, undefined);
+	});
+});
+
+test('.notThrows() returns undefined for a fulfilled promise returned by the function', t => {
+	return assertions.notThrows(() => {
+		return Promise.resolve(Symbol(''));
+	}).then(actual => {
+		t.is(actual, undefined);
+	});
+});
+
+test('.notThrows() returns undefined for an observable returned by the function', t => {
+	return assertions.notThrows(() => {
+		return Observable.of(Symbol(''));
+	}).then(actual => {
 		t.is(actual, undefined);
 	});
 });

--- a/test/observable.js
+++ b/test/observable.js
@@ -48,7 +48,7 @@ test('returning an observable from a legacy async fn is an error', t => {
 	t.end();
 });
 
-test('handle throws with thrown observable', t => {
+test('handle throws with erroring observable', t => {
 	let result;
 	ava(a => {
 		a.plan(1);
@@ -67,7 +67,26 @@ test('handle throws with thrown observable', t => {
 	});
 });
 
-test('handle throws with long running thrown observable', t => {
+test('handle throws with erroring observable returned by function', t => {
+	let result;
+	ava(a => {
+		a.plan(1);
+
+		const observable = new Observable(observer => {
+			observer.error(new Error());
+		});
+
+		return a.throws(() => observable);
+	}, r => {
+		result = r;
+	}).run().then(passed => {
+		t.is(passed, true);
+		t.is(result.result.assertCount, 1);
+		t.end();
+	});
+});
+
+test('handle throws with long running erroring observable', t => {
 	let result;
 	ava(a => {
 		a.plan(1);
@@ -95,6 +114,22 @@ test('handle throws with completed observable', t => {
 
 		const observable = Observable.of();
 		return a.throws(observable);
+	}, r => {
+		result = r;
+	}).run().then(passed => {
+		t.is(passed, false);
+		t.is(result.reason.name, 'AssertionError');
+		t.end();
+	});
+});
+
+test('handle throws with completed observable returned by function', t => {
+	let result;
+	ava(a => {
+		a.plan(1);
+
+		const observable = Observable.of();
+		return a.throws(() => observable);
 	}, r => {
 		result = r;
 	}).run().then(passed => {
@@ -188,6 +223,25 @@ test('handle notThrows with thrown observable', t => {
 		});
 
 		return a.notThrows(observable);
+	}, r => {
+		result = r;
+	}).run().then(passed => {
+		t.is(passed, false);
+		t.is(result.reason.name, 'AssertionError');
+		t.end();
+	});
+});
+
+test('handle notThrows with erroring observable returned by function', t => {
+	let result;
+	ava(a => {
+		a.plan(1);
+
+		const observable = new Observable(observer => {
+			observer.error(new Error());
+		});
+
+		return a.notThrows(() => observable);
 	}, r => {
 		result = r;
 	}).run().then(passed => {

--- a/test/promise.js
+++ b/test/promise.js
@@ -151,6 +151,22 @@ test('handle throws with rejected promise', t => {
 	});
 });
 
+test('handle throws with rejected promise returned by function', t => {
+	let result;
+	ava(a => {
+		a.plan(1);
+
+		const promise = Promise.reject(new Error());
+		return a.throws(() => promise);
+	}, r => {
+		result = r;
+	}).run().then(passed => {
+		t.is(passed, true);
+		t.is(result.result.assertCount, 1);
+		t.end();
+	});
+});
+
 // TODO(team): This is a very slow test, and I can't figure out why we need it - James
 test('handle throws with long running rejected promise', t => {
 	let result;
@@ -180,6 +196,22 @@ test('handle throws with resolved promise', t => {
 
 		const promise = Promise.resolve();
 		return a.throws(promise);
+	}, r => {
+		result = r;
+	}).run().then(passed => {
+		t.is(passed, false);
+		t.is(result.reason.name, 'AssertionError');
+		t.end();
+	});
+});
+
+test('handle throws with resolved promise returned by function', t => {
+	let result;
+	ava(a => {
+		a.plan(1);
+
+		const promise = Promise.resolve();
+		return a.throws(() => promise);
 	}, r => {
 		result = r;
 	}).run().then(passed => {
@@ -308,6 +340,38 @@ test('handle notThrows with rejected promise', t => {
 
 		const promise = Promise.reject(new Error());
 		return a.notThrows(promise);
+	}, r => {
+		result = r;
+	}).run().then(passed => {
+		t.is(passed, false);
+		t.is(result.reason.name, 'AssertionError');
+		t.end();
+	});
+});
+
+test('handle notThrows with resolved promise returned by function', t => {
+	let result;
+	ava(a => {
+		a.plan(1);
+
+		const promise = Promise.resolve();
+		return a.notThrows(() => promise);
+	}, r => {
+		result = r;
+	}).run().then(passed => {
+		t.is(passed, true);
+		t.is(result.result.assertCount, 1);
+		t.end();
+	});
+});
+
+test('handle notThrows with rejected promise returned by function', t => {
+	let result;
+	ava(a => {
+		a.plan(1);
+
+		const promise = Promise.reject(new Error());
+		return a.notThrows(() => promise);
 	}, r => {
 		result = r;
 	}).run().then(passed => {

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -67,11 +67,13 @@ export interface AssertContext {
  	 * @param error Can be a constructor, regex, error message or validation function.
  	 */
 	throws(value: PromiseLike<any>, error?: ErrorValidator, message?: string): Promise<any>;
+	throws(value: () => PromiseLike<any>, error?: ErrorValidator, message?: string): Promise<any>;
 	throws(value: () => void, error?: ErrorValidator, message?: string): any;
 	/**
 	 * Assert that function doesn't throw an error or promise resolves.
 	 */
 	notThrows(value: PromiseLike<any>, message?: string): Promise<void>;
+	notThrows(value: () => PromiseLike<any>, message?: string): Promise<void>;
 	notThrows(value: () => void, message?: string): void;
 	/**
 	 * Assert that contents matches regex.


### PR DESCRIPTION
When an async callback is given to ```t.throws()```, it will execute the function and put the returned ```Promise``` to ```promise``` variable. The rest is same as processing ```Promise```.
This commit introduce new private function ```isAsync()``` inside ```asserts.wrapAssertions()```

Refs: https://github.com/avajs/ava/issues/1371

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
