### PR TITLE
Make `t.log()` behave like `console.log()`

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -84,7 +84,7 @@ type TestContext = AssertContext & {
 	title: string;
 	plan(count: number): void;
 	skip: AssertContext;
-	log(message: string): void;
+	log(...values: Array<any>): void;
 };
 type ContextualTestContext         = TestContext & { context: any; };
 type ContextualCallbackTestContext = TestContext & { context: any; end(): void; };

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -122,7 +122,8 @@ function wrapAssertions(callbacks) {
 			}
 		},
 
-		log(...args) {
+		log() {
+			const args = Array.prototype.slice.call(arguments);
 			args.forEach((value, index) => {
 				args[index] = typeof value === 'string' ?
 					value : concordance.format(value, concordanceOptions);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -122,8 +122,15 @@ function wrapAssertions(callbacks) {
 			}
 		},
 
-		log(text) {
-			log(this, text);
+		log(...args) {
+			args.forEach((value, index) => {
+				args[index] = typeof value === 'string' ?
+					value : concordance.format(value, concordanceOptions);
+			});
+
+			if (args.length > 0) {
+				log(this, args.join(' '));
+			}
 		},
 
 		deepEqual(actual, expected, message) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -123,11 +123,10 @@ function wrapAssertions(callbacks) {
 		},
 
 		log() {
-			const args = Array.prototype.slice.call(arguments);
-			args.forEach((value, index) => {
-				args[index] = typeof value === 'string' ?
-					value : concordance.format(value, concordanceOptions);
-			});
+			const args = Array.from(arguments, value =>
+				typeof value === 'string' ?
+					value : concordance.format(value, concordanceOptions)
+			);
 
 			if (args.length > 0) {
 				log(this, args.join(' '));

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -123,10 +123,11 @@ function wrapAssertions(callbacks) {
 		},
 
 		log() {
-			const args = Array.from(arguments, value =>
-				typeof value === 'string' ?
-					value : concordance.format(value, concordanceOptions)
-			);
+			const args = Array.from(arguments, value => {
+				return typeof value === 'string' ?
+					value :
+					concordance.format(value, concordanceOptions);
+			});
 
 			if (args.length > 0) {
 				log(this, args.join(' '));

--- a/readme.md
+++ b/readme.md
@@ -890,9 +890,9 @@ Plan how many assertion there are in the test. The test will fail if the actual 
 
 End the test. Only works with `test.cb()`.
 
-###### `t.log(message)`
+###### `t.log(...values)`
 
-Print a log message contextually alongside the test result instead of immediately printing it to `stdout` like `console.log`.
+Log values contextually alongside the test result instead of immediately printing them to `stdout`. Behaves somewhat like `console.log`, but without support for placeholder tokens.
 
 ## Assertions
 

--- a/test/flow-types/log.js.flow
+++ b/test/flow-types/log.js.flow
@@ -1,0 +1,8 @@
+/* @flow */
+
+const test = require('../../index.js.flow');
+
+test('log', t => {
+	t.pass();
+	t.log({object: true}, 42, ['array'], false, new Date(), new Map());
+})

--- a/test/test.js
+++ b/test/test.js
@@ -742,7 +742,7 @@ test('log from tests', t => {
 		t.true(true);
 		a.log('another log message from a test');
 		a.log({b: 1, c: {d: 2}}, 'complex log', 5, 5.1);
-		t.log();
+		a.log();
 	}, null, r => {
 		result = r;
 	}).run();

--- a/test/test.js
+++ b/test/test.js
@@ -741,13 +741,19 @@ test('log from tests', t => {
 		a.log('a log message from a test');
 		t.true(true);
 		a.log('another log message from a test');
+		a.log({b: 1, c: {d: 2}}, 'complex log', 5, 5.1);
+		t.log();
 	}, null, r => {
 		result = r;
 	}).run();
 
 	t.deepEqual(
 		result.result.logs,
-		['a log message from a test', 'another log message from a test']
+		[
+			'a log message from a test',
+			'another log message from a test',
+			'{\n  b: 1,\n  c: {\n    d: 2,\n  },\n} complex log 5 5.1'
+		]
 	);
 
 	t.end();

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -104,9 +104,9 @@ export interface TestContext extends AssertContext {
 
 	skip: AssertContext;
 	/**
-	 * Print a log message contextually alongside the test result instead of immediately printing it to stdout like console.log.
+	 * Log values contextually alongside the test result instead of immediately printing them to `stdout`.
 	 */
-	log(message: string): void;
+	log(...values: any[]): void;
 }
 export interface CallbackTestContext extends TestContext {
 	/**


### PR DESCRIPTION
Fixes #1635 

Use concordance to format all arguments except string arguments as the existing test will fail and I find it awkward this way. Update test to cater `t.log()` and `t.log(n1, n2, n3, ...)`.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
