### PR TITLE
Clean up CLI module

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,7 +7,6 @@ const meow = require('meow');
 const Promise = require('bluebird');
 const pkgConf = require('pkg-conf');
 const isCi = require('is-ci');
-const hasFlag = require('has-flag');
 const Api = require('../api');
 const colors = require('./colors');
 const VerboseReporter = require('./reporters/verbose');
@@ -119,24 +118,19 @@ exports.run = () => {
 		return;
 	}
 
+	if (cli.flags.watch && cli.flags.tap && !conf.tap) {
+		throw new Error(`${colors.error(figures.cross)} The TAP reporter is not available when using watch mode.`);
+	}
+
+	if (cli.flags.watch && isCi) {
+		throw new Error(`${colors.error(figures.cross)} Watch mode is not available in CI, as it prevents AVA from terminating.`);
+	}
+
 	if (
-		((hasFlag('--watch') || hasFlag('-w')) && (hasFlag('--tap') || hasFlag('-t'))) ||
-		(conf.watch && conf.tap)
+		cli.flags.concurrency === '' ||
+		(cli.flags.concurrency && (!Number.isInteger(Number.parseFloat(cli.flags.concurrency)) || parseInt(cli.flags.concurrency, 10) < 0))
 	) {
-		throw new Error(colors.error(figures.cross) + ' The TAP reporter is not available when using watch mode.');
-	}
-
-	if ((hasFlag('--watch') || hasFlag('-w')) && isCi) {
-		throw new Error(colors.error(figures.cross) + ' Watch mode is not available in CI, as it prevents AVA from terminating.');
-	}
-
-	if (cli.flags.concurrency === '') {
-		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be provided.');
-	}
-
-	if (cli.flags.concurrency &&
-		(!Number.isInteger(Number.parseFloat(cli.flags.concurrency)) || parseInt(cli.flags.concurrency, 10) < 0)) {
-		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be a nonnegative integer.');
+		throw new Error(`${colors.error(figures.cross)} The --concurrency or -c flag must be provided with a nonnegative integer.`);
 	}
 
 	// Copy resultant cli.flags into conf for use with Api and elsewhere

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -139,10 +139,6 @@ exports.run = () => {
 		throw new Error(colors.error(figures.cross) + ' The --concurrency and -c flags must be a nonnegative integer.');
 	}
 
-	if (hasFlag('--require') || hasFlag('-r')) {
-		throw new Error(colors.error(figures.cross) + ' The --require and -r flags are deprecated. Requirements should be configured in package.json - see documentation.');
-	}
-
 	// Copy resultant cli.flags into conf for use with Api and elsewhere
 	Object.assign(conf, cli.flags);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -72,8 +72,7 @@ exports.run = () => {
 				default: conf.concurrency
 			},
 			init: {
-				type: 'boolean',
-				default: conf.init
+				type: 'boolean'
 			},
 			'fail-fast': {
 				type: 'boolean',
@@ -96,13 +95,11 @@ exports.run = () => {
 			},
 			watch: {
 				type: 'boolean',
-				alias: 'w',
-				default: conf.watch
+				alias: 'w'
 			},
 			'update-snapshots': {
 				type: 'boolean',
-				alias: 'u',
-				default: conf.updateSnapshots
+				alias: 'u'
 			},
 			color: {
 				type: 'boolean',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -133,6 +133,10 @@ exports.run = () => {
 		throw new Error(`${colors.error(figures.cross)} The --concurrency or -c flag must be provided with a nonnegative integer.`);
 	}
 
+	if ('source' in conf) {
+		throw new Error(`${colors.error(figures.cross)} The 'source' option has been renamed. Use 'sources' instead.`);
+	}
+
 	// Copy resultant cli.flags into conf for use with Api and elsewhere
 	Object.assign(conf, cli.flags);
 
@@ -183,7 +187,7 @@ exports.run = () => {
 
 	if (conf.watch) {
 		try {
-			const watcher = new Watcher(logger, api, files, arrify(conf.source));
+			const watcher = new Watcher(logger, api, files, arrify(conf.sources));
 			watcher.observeStdin(process.stdin);
 		} catch (err) {
 			if (err.name === 'AvaError') {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,18 +32,18 @@ exports.run = () => {
 
 		Options
 		  --init                  Add AVA to your project
+		  --watch, -w             Re-run tests when tests and source files change
+		  --match, -m             Only run tests with matching title (Can be repeated)
+		  --update-snapshots, -u  Update snapshots
 		  --fail-fast             Stop after first test failure
+		  --timeout, -T           Set global timeout
 		  --serial, -s            Run tests serially
-		  --tap, -t               Generate TAP output
+		  --concurrency, -c       Max number of test files running at the same time (Default: CPU cores)
 		  --verbose, -v           Enable verbose output
-		  --no-cache              Disable the transpiler cache
+		  --tap, -t               Generate TAP output
+		  --no-cache              Disable the compiler cache
 		  --color                 Force color output
 		  --no-color              Disable color output
-		  --match, -m             Only run tests with matching title (Can be repeated)
-		  --watch, -w             Re-run tests when tests and source files change
-		  --timeout, -T           Set global timeout
-		  --concurrency, -c       Max number of test files running at the same time (Default: CPU cores)
-		  --update-snapshots, -u  Update snapshots
 
 		Examples
 		  ava
@@ -56,58 +56,58 @@ exports.run = () => {
 		test.js test-*.js test/**/*.js **/__tests__/**/*.js **/*.test.js
 	`, {
 		flags: {
+			init: {
+				type: 'boolean'
+			},
+			watch: {
+				type: 'boolean',
+				alias: 'w'
+			},
 			match: {
 				type: 'string',
 				alias: 'm',
 				default: conf.match
+			},
+			'update-snapshots': {
+				type: 'boolean',
+				alias: 'u'
+			},
+			'fail-fast': {
+				type: 'boolean',
+				default: conf.failFast
 			},
 			timeout: {
 				type: 'string',
 				alias: 'T',
 				default: conf.timeout
 			},
-			concurrency: {
-				type: 'string',
-				alias: 'c',
-				default: conf.concurrency
-			},
-			init: {
-				type: 'boolean'
-			},
-			'fail-fast': {
-				type: 'boolean',
-				default: conf.failFast
-			},
 			serial: {
 				type: 'boolean',
 				alias: 's',
 				default: conf.serial
 			},
-			tap: {
-				type: 'boolean',
-				alias: 't',
-				default: conf.tap
+			concurrency: {
+				type: 'string',
+				alias: 'c',
+				default: conf.concurrency
 			},
 			verbose: {
 				type: 'boolean',
 				alias: 'v',
 				default: conf.verbose
 			},
-			watch: {
+			tap: {
 				type: 'boolean',
-				alias: 'w'
-			},
-			'update-snapshots': {
-				type: 'boolean',
-				alias: 'u'
-			},
-			color: {
-				type: 'boolean',
-				default: 'color' in conf ? conf.color : require('supports-color').stdout !== false
+				alias: 't',
+				default: conf.tap
 			},
 			cache: {
 				type: 'boolean',
 				default: conf.cache !== false
+			},
+			color: {
+				type: 'boolean',
+				default: 'color' in conf ? conf.color : require('supports-color').stdout !== false
 			}
 		}
 	});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,7 +51,6 @@ exports.run = () => {
 		  ava test-*.js
 		  ava test
 		  ava --init
-		  ava --init foo.js
 
 		Default patterns when no arguments:
 		test.js test-*.js test/**/*.js **/__tests__/**/*.js **/*.test.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -3886,11 +3886,6 @@
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
 		"fn-name": "^2.0.0",
 		"get-port": "^3.2.0",
 		"globby": "^7.1.1",
-		"has-flag": "^3.0.0",
 		"hullabaloo-config-manager": "^2.0.0-beta.1",
 		"ignore-by-default": "^1.0.0",
 		"import-local": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,6 @@ $ ava --help
     ava test-*.js
     ava test
     ava --init
-    ava --init foo.js
 
   Default patterns when no arguments:
   test.js test-*.js test/**/*.js **/__tests__/**/*.js **/*.test.js

--- a/readme.md
+++ b/readme.md
@@ -162,18 +162,18 @@ $ ava --help
 
   Options
     --init                  Add AVA to your project
+    --watch, -w             Re-run tests when tests and source files change
+    --match, -m             Only run tests with matching title (Can be repeated)
+    --update-snapshots, -u  Update snapshots
     --fail-fast             Stop after first test failure
+    --timeout, -T           Set global timeout
     --serial, -s            Run tests serially
-    --tap, -t               Generate TAP output
+    --concurrency, -c       Max number of test files running at the same time (Default: CPU cores)
     --verbose, -v           Enable verbose output
-    --no-cache              Disable the transpiler cache
+    --tap, -t               Generate TAP output
+    --no-cache              Disable the compiler cache
     --color                 Force color output
     --no-color              Disable color output
-    --match, -m             Only run tests with matching title (Can be repeated)
-    --watch, -w             Re-run tests when tests and source files change
-    --timeout, -T           Set global timeout
-    --concurrency, -c       Max number of test files running at the same time (Default: CPU cores)
-    --update-snapshots, -u  Update snapshots
 
   Examples
     ava

--- a/test/cli.js
+++ b/test/cli.js
@@ -389,14 +389,6 @@ test('`"tap": true` config is ignored when --watch is given', t => {
 	child.stderr.on('data', testOutput);
 });
 
-test('bails when config contains `"tap": true` and `"watch": true`', t => {
-	execCli(['test.js'], {dirname: 'fixture/watcher/tap-and-watch-in-conf'}, (err, stdout, stderr) => {
-		t.is(err.code, 1);
-		t.match(stderr, 'The TAP reporter is not available when using watch mode.');
-		t.end();
-	});
-});
-
 ['--watch', '-w'].forEach(watchFlag => {
 	['--tap', '-t'].forEach(tapFlag => {
 		test(`bails when ${tapFlag} reporter is used while ${watchFlag} is given`, t => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -415,7 +415,7 @@ test('`"tap": true` config is ignored when --watch is given', t => {
 	test(`bails when ${concurrencyFlag} is provided without value`, t => {
 		execCli(['test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be provided.');
+			t.match(stderr, 'The --concurrency or -c flag must be provided with a nonnegative integer.');
 			t.end();
 		});
 	});
@@ -425,7 +425,7 @@ test('`"tap": true` config is ignored when --watch is given', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is a string`, t => {
 		execCli([`${concurrencyFlag}=foo`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be a nonnegative integer.');
+			t.match(stderr, 'The --concurrency or -c flag must be provided with a nonnegative integer.');
 			t.end();
 		});
 	});
@@ -435,7 +435,7 @@ test('`"tap": true` config is ignored when --watch is given', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is a float`, t => {
 		execCli([`${concurrencyFlag}=4.7`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be a nonnegative integer.');
+			t.match(stderr, 'The --concurrency or -c flag must be provided with a nonnegative integer.');
 			t.end();
 		});
 	});
@@ -445,7 +445,7 @@ test('`"tap": true` config is ignored when --watch is given', t => {
 	test(`bails when ${concurrencyFlag} is provided with an input that is negative`, t => {
 		execCli([`${concurrencyFlag}=-1`, 'test.js', concurrencyFlag], {dirname: 'fixture/concurrency'}, (err, stdout, stderr) => {
 			t.is(err.code, 1);
-			t.match(stderr, 'The --concurrency and -c flags must be a nonnegative integer.');
+			t.match(stderr, 'The --concurrency or -c flag must be provided with a nonnegative integer.');
 			t.end();
 		});
 	});

--- a/test/fixture/watcher/tap-and-watch-in-conf/package.json
+++ b/test/fixture/watcher/tap-and-watch-in-conf/package.json
@@ -1,6 +1,0 @@
-{
-  "ava": {
-    "tap": true,
-    "watch": true
-  }
-}

--- a/test/fixture/watcher/tap-and-watch-in-conf/test.js
+++ b/test/fixture/watcher/tap-and-watch-in-conf/test.js
@@ -1,5 +1,0 @@
-import test from '../../../../';
-
-test('works', t => {
-	t.pass();
-});


### PR DESCRIPTION
See commits.

Breaking changes:

* `--init`, `--watch` and `--update-snapshots` could be enabled through AVA's `package.json` configuration. This was unintentional and support has been removed
* I've renamed the `source` configuration to `sources`, to be in line with `files` which takes similar glob values and is a plural. AVA exits with an error if the old property is detected