### PR TITLE
Share glob caches

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -122,33 +122,31 @@ class AvaFiles {
 		this.files = files;
 		this.sources = options.sources || [];
 		this.cwd = options.cwd || process.cwd();
+		this.globCaches = {
+			cache: Object.create(null),
+			statCache: Object.create(null),
+			realpathCache: Object.create(null),
+			symlinks: Object.create(null)
+		};
 
 		autoBind(this);
 	}
 
 	findTestFiles() {
-		return handlePaths(this.files, this.excludePatterns, {
+		return handlePaths(this.files, this.excludePatterns, Object.assign({
 			cwd: this.cwd,
-			cache: Object.create(null),
-			statCache: Object.create(null),
-			realpathCache: Object.create(null),
-			symlinks: Object.create(null),
 			expandDirectories: false,
 			nodir: false
-		});
+		}, this.globCaches));
 	}
 
 	findTestHelpers() {
-		return handlePaths(defaultHelperPatterns(), ['!**/node_modules/**'], {
+		return handlePaths(defaultHelperPatterns(), ['!**/node_modules/**'], Object.assign({
 			cwd: this.cwd,
 			includeUnderscoredFiles: true,
-			cache: Object.create(null),
-			statCache: Object.create(null),
-			realpathCache: Object.create(null),
-			symlinks: Object.create(null),
 			expandDirectories: false,
 			nodir: false
-		});
+		}, this.globCaches));
 	}
 
 	isSource(filePath) {


### PR DESCRIPTION
Share glob caches when finding test and helper files, and when rerunning all files in watch mode. This should provide a performance improvement, though I suppose certain file changes in watch mode may no longer be detected. I can't quite figure out what those would be though.