### PR TITLE
Stage 4 updates

### DIFF
--- a/docs/recipes/babel.md
+++ b/docs/recipes/babel.md
@@ -61,6 +61,26 @@ You can disable AVA's stage-4 preset:
 
 Note that this *does not* stop AVA from compiling your test files using Babel.
 
+## Preserve ES module syntax
+
+By default AVA's stage-4 preset will convert ES module syntax to CommonJS. This can be disabled:
+
+```json
+{
+	"ava": {
+		"babel": {
+			"testOptions": {
+				"presets": [
+					["module:ava/stage-4", {"modules": false}]
+				]
+			}
+		}
+	}
+}
+```
+
+You'll have to use [`@std/esm`](https://github.com/standard-things/esm) so that AVA can still load your test files.
+
 ## Disable AVA's Babel pipeline
 
 You can completely disable AVA's use of Babel:

--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -6,10 +6,10 @@ const figures = require('figures');
 const configManager = require('hullabaloo-config-manager');
 const md5Hex = require('md5-hex');
 const makeDir = require('make-dir');
-const semver = require('semver');
 const colors = require('./colors');
 
 const stage4Path = require.resolve('../stage-4');
+const syntaxAsyncGeneratorsPath = require.resolve('@babel/plugin-syntax-async-generators');
 const syntaxObjectRestSpreadPath = require.resolve('@babel/plugin-syntax-object-rest-spread');
 const transformTestFilesPath = require.resolve('@ava/babel-preset-transform-test-files');
 
@@ -109,7 +109,11 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 
 	const baseOptions = {
 		babelrc: false,
-		plugins: [],
+		plugins: [
+			// TODO: Remove once Babel can parse this syntax unaided.
+			syntaxAsyncGeneratorsPath,
+			syntaxObjectRestSpreadPath
+		],
 		presets: []
 	};
 
@@ -124,12 +128,6 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 		}
 		if (userOptions.testOptions.extends) {
 			baseOptions.extends = userOptions.testOptions.extends;
-		}
-
-		// Include object rest spread support for Node.js versions that support it
-		// natively.
-		if (semver.satisfies(process.versions.node, '>= 8.3.0')) {
-			baseOptions.plugins.push(syntaxObjectRestSpreadPath);
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,16 @@
       "integrity": "sha512-R2A1xb8shFuQ6wVyzi4Fl4MtNbx9WeahLoPPZkQgiPGv6Mz+IOyhGUV1I9yk/BECHCi9LFzBmUmbmj5EXtSY5Q=="
     },
     "@ava/babel-preset-stage-4": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-2.0.0-beta.1.tgz",
-      "integrity": "sha512-6lWnbxCSkU33eiwzqZ7U+b7LdkpagAmQMtWIn2lT9sTdNmV8fcNM0pVRYCCdiaYJczVHtZ9/aBs+EocWLRlS5Q==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-2.0.0-beta.2.tgz",
+      "integrity": "sha512-eEG+Aqv5pEWiOBc1cZ53V5Plcz+NJUc9trFd59weN1jDLCvz9h6w6/6jsuBnArZXpH2mZVAaEyvIjcgcbFJCBw==",
       "requires": {
         "@babel/plugin-check-constants": "7.0.0-beta.38",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0-beta.38",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.38",
         "@babel/plugin-transform-async-to-generator": "7.0.0-beta.38",
         "@babel/plugin-transform-destructuring": "7.0.0-beta.38",
+        "@babel/plugin-transform-dotall-regex": "7.0.0-beta.38",
         "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.38",
         "@babel/plugin-transform-function-name": "7.0.0-beta.38",
         "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.38",
@@ -256,6 +259,28 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-check-constants/-/plugin-check-constants-7.0.0-beta.38.tgz",
       "integrity": "sha512-MjdGn/2sMLu0fnNFbkILut0OsegzRTeCOJ/uGHH88TwTXPzxONx2cTVJ36i3cTQXHMiIOUT3hX6HqzWM99Q6vA=="
     },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.38.tgz",
+      "integrity": "sha512-ATy8xhmvnoZnB8Ycl0LwPVg1djx/7grNEdshLNmREFWvI/xyEwe8euw+H5Cwtd6E8AOPEPI2IVmMKPyWeaVeVg==",
+      "requires": {
+        "@babel/helper-remap-async-to-generator": "7.0.0-beta.38",
+        "@babel/plugin-syntax-async-generators": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.38.tgz",
+      "integrity": "sha512-hmlKGy0xyWSzfkrFee3oVDjtI1BTLiq9uaLSZHJ1q7XxyXHDrwizIJupSKuDnaIcNhNDioW26Strn9lDbo5pJQ==",
+      "requires": {
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.38"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.38.tgz",
+      "integrity": "sha512-YboIs/srf1yKLRvZ6JoaGjpkcW3UYsPKhkPt3hWO54OVouS34A5dwK8wO3wGhvKgUvq2GV+tU4eRNkgEcx7aLA=="
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.38.tgz",
@@ -274,6 +299,15 @@
       "version": "7.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.38.tgz",
       "integrity": "sha512-3DD17TSYkgmwBO+12pO3LP6RK8Pv7EGTLYOfBDU217mMnmC+xaGi4I5BFlTroK+1+IJLys3ObetRMobV4VU0bQ=="
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.38.tgz",
+      "integrity": "sha512-MYjo3Fg3EjmAcZBG+gnbP8HjdmkoRpjGV68+Q9w853Ye9VimO47bz9HBojsClYpXsXbyxNbPRZteGU/jrMcKig==",
+      "requires": {
+        "@babel/helper-regex": "7.0.0-beta.38",
+        "regexpu-core": "4.1.3"
+      }
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.0.0-beta.38",

--- a/package.json
+++ b/package.json
@@ -61,11 +61,12 @@
 		"flow"
 	],
 	"dependencies": {
-		"@ava/babel-preset-stage-4": "^2.0.0-beta.1",
+		"@ava/babel-preset-stage-4": "^2.0.0-beta.2",
 		"@ava/babel-preset-transform-test-files": "^4.0.0-beta.1",
 		"@ava/write-file-atomic": "^2.2.0",
 		"@babel/core": "^7.0.0-beta.38",
 		"@babel/generator": "^7.0.0-beta.38",
+		"@babel/plugin-syntax-async-generators": "^7.0.0-beta.38",
 		"@babel/plugin-syntax-object-rest-spread": "^7.0.0-beta.38",
 		"@concordance/react": "^1.0.0",
 		"@ladjs/time-require": "^0.1.4",
@@ -133,7 +134,6 @@
 		"require-precompiled": "^0.1.0",
 		"resolve-cwd": "^2.0.0",
 		"safe-buffer": "^5.1.1",
-		"semver": "^5.5.0",
 		"slash": "^1.0.0",
 		"source-map-support": "^0.5.3",
 		"stack-utils": "^1.0.1",

--- a/test/babel-config.js
+++ b/test/babel-config.js
@@ -9,19 +9,7 @@ const uniqueTempDir = require('unique-temp-dir');
 const babelConfigHelper = require('../lib/babel-config');
 
 const fixture = name => path.join(__dirname, 'fixture', name);
-const setNodeVersion = value => Object.defineProperty(process.versions, 'node', {value});
-const resetNodeVersion = setNodeVersion.bind(null, process.versions.node);
-
-// Execute `run` with a given stubbed node version, then reset to the real
-// version.
-function withNodeVersion(version, run) {
-	setNodeVersion(version);
-	const promise = new Promise(resolve => {
-		resolve(run());
-	});
-	promise.then(resetNodeVersion, resetNodeVersion);
-	return promise;
-}
+const NUM_SYNTAX_PLUGINS = 2;
 
 function withNodeEnv(value, run) {
 	assert(!('NODE_ENV' in process.env));
@@ -51,11 +39,7 @@ test('includes testOptions in Babel compilation', t => {
 		.then(result => {
 			const options = result.getOptions();
 			t.false(options.babelrc);
-			if (options.plugins.length === 1) {
-				t.is(options.plugins[0][0].wrapped, custom);
-			} else {
-				t.is(options.plugins[1][0].wrapped, custom);
-			}
+			t.is(options.plugins[NUM_SYNTAX_PLUGINS][0].wrapped, custom);
 			t.is(options.presets[0][0].wrapped, require('@ava/babel-preset-stage-4'));
 			t.is(options.presets[1][0].wrapped, custom);
 			t.is(options.presets[2][0].wrapped, require('@ava/babel-preset-transform-test-files'));
@@ -116,39 +100,6 @@ test('supports .babelrc.js files', t => {
 			t.is(options.presets[0][0].wrapped, require('@ava/babel-preset-stage-4'));
 			t.is(options.presets[1][0].wrapped, require('@ava/babel-preset-transform-test-files'));
 			t.same(options.presets[1][1], {powerAssert: true});
-		});
-});
-
-test('adds babel-plugin-syntax-object-rest-spread for node versions > 8.3.0', t => {
-	const projectDir = fixture('no-babel-config');
-	const cacheDir = path.join(uniqueTempDir(), 'cache');
-
-	return withNodeVersion('9.0.0', () => babelConfigHelper.build(projectDir, cacheDir, {testOptions: {}}, true))
-		.then(result => {
-			const options = result.getOptions();
-			t.is(options.plugins[0][0].wrapped, require('@babel/plugin-syntax-object-rest-spread').default);
-		});
-});
-
-test('adds babel-plugin-syntax-object-rest-spread for node versions == 8.3.0', t => {
-	const projectDir = fixture('no-babel-config');
-	const cacheDir = path.join(uniqueTempDir(), 'cache');
-
-	return withNodeVersion('8.3.0', () => babelConfigHelper.build(projectDir, cacheDir, {testOptions: {}}, true))
-		.then(result => {
-			const options = result.getOptions();
-			t.is(options.plugins[0][0].wrapped, require('@babel/plugin-syntax-object-rest-spread').default);
-		});
-});
-
-test('does not add babel-plugin-syntax-object-rest-spread for node versions < 8.3.0', t => {
-	const projectDir = fixture('no-babel-config');
-	const cacheDir = path.join(uniqueTempDir(), 'cache');
-
-	return withNodeVersion('8.2.0', () => babelConfigHelper.build(projectDir, cacheDir, {testOptions: {}}, true))
-		.then(result => {
-			const options = result.getOptions();
-			t.true(!options.plugins);
 		});
 });
 


### PR DESCRIPTION
Prepare to include https://github.com/avajs/babel-preset-stage-4/pull/13. Document the new `modules: false` option, and load syntax plugins for object rest/spread and async generators.