### PR TITLE
Load compiled helpers if in the "require" configuration

### DIFF
--- a/lib/test-worker.js
+++ b/lib/test-worker.js
@@ -27,6 +27,11 @@ globals.options = opts;
 
 const serializeError = require('./serialize-error');
 
+// Install before processing opts.require, so if helpers are added to the
+// require configuration the *compiled* helper will be loaded.
+adapter.installSourceMapSupport();
+adapter.installPrecompilerHook();
+
 (opts.require || []).forEach(x => {
 	if (/[/\\]@std[/\\]esm[/\\]index\.js$/.test(x)) {
 		require = require(x)(module); // eslint-disable-line no-global-assign
@@ -34,9 +39,6 @@ const serializeError = require('./serialize-error');
 		require(x);
 	}
 });
-
-adapter.installSourceMapSupport();
-adapter.installPrecompilerHook();
 
 const testPath = opts.file;
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -864,3 +864,10 @@ test('power-assert when babel=false and compileEnhancements=true', t => {
 		t.end();
 	});
 });
+
+test('workers load compiled helpers if in the require configuration', t => {
+	execCli(['test/verify.js'], {dirname: 'fixture/require-compiled-helper'}, err => {
+		t.ifError(err);
+		t.end();
+	});
+});

--- a/test/fixture/require-compiled-helper/dependency.js
+++ b/test/fixture/require-compiled-helper/dependency.js
@@ -1,0 +1,1 @@
+module.exports = '🦄';

--- a/test/fixture/require-compiled-helper/package.json
+++ b/test/fixture/require-compiled-helper/package.json
@@ -1,0 +1,7 @@
+{
+	"ava": {
+		"require": [
+			"./test/_helper"
+		]
+	}
+}

--- a/test/fixture/require-compiled-helper/test/_helper.js
+++ b/test/fixture/require-compiled-helper/test/_helper.js
@@ -1,0 +1,3 @@
+import value from '../dependency';
+
+global.value = value;

--- a/test/fixture/require-compiled-helper/test/verify.js
+++ b/test/fixture/require-compiled-helper/test/verify.js
@@ -1,0 +1,5 @@
+import test from '../../../../';
+
+test(t => {
+	t.is(global.value, '🦄');
+});


### PR DESCRIPTION
AVA now installs its source map support and precompiler hook *before*
processing the "require" paths. This means that helpers can safely be
added to the "require" configuration and their compiled versions will be
loaded. Fixes #1506.
