### PR TITLE
Require unique test titles

### DIFF
--- a/docs/common-pitfalls.md
+++ b/docs/common-pitfalls.md
@@ -25,7 +25,7 @@ Use the `concurrency` flag to limit the number of processes ran. For example, if
 You may be running an asynchronous operation inside a test and wondering why it's not finishing. If your asynchronous operation uses promises, you should return the promise:
 
 ```js
-test(t => {
+test('fetches foo', t => {
 	return fetch().then(data => {
 		t.is(data, 'foo');
 	});
@@ -35,7 +35,7 @@ test(t => {
 Better yet, use `async` / `await`:
 
 ```js
-test(async t => {
+test('fetches foo', async t => {
 	const data = await fetch();
 	t.is(data, 'foo');
 });
@@ -44,7 +44,7 @@ test(async t => {
 If you're using callbacks, use [`test.cb`](https://github.com/avajs/ava#callback-support):
 
 ```js
-test.cb(t => {
+test.cb('fetches foo', t => {
 	fetch((err, data) => {
 		t.is(data, 'foo');
 		t.end();
@@ -55,7 +55,7 @@ test.cb(t => {
 Alternatively, promisify the callback function using something like [`pify`](https://github.com/sindresorhus/pify):
 
 ```js
-test(async t => {
+test('fetches foo', async t => {
 	const data = await pify(fetch)();
 	t.is(data, 'foo');
 });
@@ -70,7 +70,7 @@ AVA [can't trace uncaught exceptions](https://github.com/avajs/ava/issues/214) b
 Ensure that the first parameter passed into your test is named `t`. This is a requirement of [`power-assert`](https://github.com/power-assert-js/power-assert), the library that provides the enhanced messages.
 
 ```js
-test(t => {
+test('one is one', t => {
 	t.is(1, 1);
 });
 ```

--- a/docs/recipes/when-to-use-plan.md
+++ b/docs/recipes/when-to-use-plan.md
@@ -13,7 +13,7 @@ Many users transitioning from `tap`/`tape` are accustomed to using `t.plan()` pr
 `t.plan()` is unnecessary in most sync tests.
 
 ```js
-test(t => {
+test('simple sums', t => {
 	// BAD: there is no branching here - t.plan() is pointless
 	t.plan(2);
 
@@ -27,7 +27,7 @@ test(t => {
 ### Promises that are expected to resolve
 
 ```js
-test(t => {
+test('gives foo', t => {
 	t.plan(1);
 
 	return somePromise().then(result => {
@@ -43,7 +43,7 @@ At a glance, this tests appears to make good use of `t.plan()` since an async pr
 2. It would be better to take advantage of `async`/`await`:
 
 ```js
-test(async t => {
+test('gives foo', async t => {
 	t.is(await somePromise(), 'foo');
 });
 ```
@@ -51,7 +51,7 @@ test(async t => {
 ### Promises with a `.catch()` block
 
 ```js
-test(t => {
+test('rejects with foo', t => {
 	t.plan(2);
 
 	return shouldRejectWithFoo().catch(reason => {
@@ -65,7 +65,7 @@ Here, the use of `t.plan()` seeks to ensure that the code inside the `catch` blo
 Instead, you should take advantage of `t.throws` and `async`/`await`, as this leads to flatter code that is easier to reason about:
 
 ```js
-test(async t => {
+test('rejects with foo', async t => {
 	const reason = await t.throws(shouldRejectWithFoo());
 	t.is(reason.message, 'Hello');
 	t.is(reason.foo, 'bar');
@@ -75,7 +75,7 @@ test(async t => {
 ### Ensuring a catch statement happens
 
 ```js
-test(t => {
+test('throws', t => {
 	t.plan(2);
 
 	try {
@@ -96,7 +96,7 @@ As stated in the previous example, using the `t.throws()` assertion with `async`
 ### Ensuring multiple callbacks are actually called
 
 ```js
-test.cb(t => {
+test.cb('invokes callbacks', t => {
 	t.plan(2);
 
 	const callbackA = () => {
@@ -120,7 +120,7 @@ In most cases, it's a bad idea to use any complex branching inside your tests. A
 const testData = require('./fixtures/test-definitions.json');
 
 testData.forEach(testDefinition => {
-	test(t => {
+	test('foo or bar', t => {
 		const result = functionUnderTest(testDefinition.input);
 
 		// testDefinition should have an expectation for `foo` or `bar` but not both

--- a/index.js.flow
+++ b/index.js.flow
@@ -111,8 +111,8 @@ type ContextualCallbackTest = TestImplementation<ContextualCallbackTestContext, 
  */
 
 type ContextualTestMethod = {
-	(              implementation: ContextualTest): void;
-	(name: string, implementation: ContextualTest): void;
+	(               implementation: ContextualTest): void;
+	(title: string, implementation: ContextualTest): void;
 
 	serial     : ContextualTestMethod;
 	before     : ContextualTestMethod;
@@ -128,8 +128,8 @@ type ContextualTestMethod = {
 };
 
 type ContextualCallbackTestMethod = {
-	(              implementation: ContextualCallbackTest): void;
-	(name: string, implementation: ContextualCallbackTest): void;
+	(               implementation: ContextualCallbackTest): void;
+	(title: string, implementation: ContextualCallbackTest): void;
 
 	serial     : ContextualCallbackTestMethod;
 	before     : ContextualCallbackTestMethod;
@@ -149,8 +149,8 @@ type ContextualCallbackTestMethod = {
  */
 
 declare module.exports: {
-	(              run: ContextualTest, ...args: any): void;
-	(name: string, run: ContextualTest, ...args: any): void;
+	(               run: ContextualTest, ...args: any): void;
+	(title: string, run: ContextualTest, ...args: any): void;
 
 	beforeEach : ContextualTestMethod;
 	afterEach  : ContextualTestMethod;

--- a/lib/test-collection.js
+++ b/lib/test-collection.js
@@ -29,6 +29,7 @@ class TestCollection extends EventEmitter {
 		};
 
 		this.pendingTestInstances = new Set();
+		this.uniqueTestTitles = new Set();
 
 		this._emitTestResult = this._emitTestResult.bind(this);
 	}
@@ -46,6 +47,14 @@ class TestCollection extends EventEmitter {
 				throw new TypeError('Tests must have a title');
 			} else {
 				test.title = `${type} hook`;
+			}
+		}
+
+		if (type === 'test') {
+			if (this.uniqueTestTitles.has(test.title)) {
+				throw new Error(`Duplicate test title: ${test.title}`);
+			} else {
+				this.uniqueTestTitles.add(test.title);
 			}
 		}
 

--- a/lib/test-collection.js
+++ b/lib/test-collection.js
@@ -1,6 +1,5 @@
 'use strict';
 const EventEmitter = require('events');
-const fnName = require('fn-name');
 const Concurrent = require('./concurrent');
 const Sequence = require('./sequence');
 const Test = require('./test');
@@ -42,20 +41,11 @@ class TestCollection extends EventEmitter {
 			throw new Error('Test type must be specified');
 		}
 
-		if (!test.title && test.fn) {
-			test.title = fnName(test.fn);
-		}
-
-		// Workaround for Babel giving anonymous functions a name
-		if (test.title === 'callee$0$0') {
-			test.title = null;
-		}
-
-		if (!test.title) {
+		if (test.title === '' || typeof test.title !== 'string') {
 			if (type === 'test') {
-				test.title = '[anonymous]';
+				throw new TypeError('Tests must have a title');
 			} else {
-				test.title = type;
+				test.title = `${type} hook`;
 			}
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3332,11 +3332,6 @@
       "integrity": "sha1-3dP7Oxg6sas1pdXeycr167ze0Wc=",
       "dev": true
     },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
 		"equal-length": "^1.0.0",
 		"figures": "^2.0.0",
 		"find-cache-dir": "^1.0.0",
-		"fn-name": "^2.0.0",
 		"get-port": "^3.2.0",
 		"globby": "^7.1.1",
 		"has-flag": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -313,7 +313,7 @@ AVA tries to run test files with their current working directory set to the dire
 
 ### Creating tests
 
-To create a test you call the `test` function you imported from AVA. Provide the required title and implementation function. The function will be called when your test is run. It's passed an [execution object](#t) as its first argument.
+To create a test you call the `test` function you imported from AVA. Provide the required title and implementation function. Titles must be unique within each test file. The function will be called when your test is run. It's passed an [execution object](#t) as its first argument.
 
 **Note:** In order for the [enhanced assertion messages](#enhanced-assertion-messages) to behave correctly, the first argument **must** be named `t`.
 

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/rea
 ```js
 import test from 'ava';
 
-test(t => {
+test('arrays are equal', t => {
 	t.deepEqual([1, 2], [1, 2]);
 });
 ```
@@ -313,7 +313,7 @@ AVA tries to run test files with their current working directory set to the dire
 
 ### Creating tests
 
-To create a test you call the `test` function you imported from AVA. Provide the optional title and implementation function. The function will be called when your test is run. It's passed an [execution object](#t) as its first argument.
+To create a test you call the `test` function you imported from AVA. Provide the required title and implementation function. The function will be called when your test is run. It's passed an [execution object](#t) as its first argument.
 
 **Note:** In order for the [enhanced assertion messages](#enhanced-assertion-messages) to behave correctly, the first argument **must** be named `t`.
 
@@ -321,26 +321,6 @@ To create a test you call the `test` function you imported from AVA. Provide the
 import test from 'ava';
 
 test('my passing test', t => {
-	t.pass();
-});
-```
-
-#### Titles
-
-Titles are optional, meaning you can do:
-
-```js
-test(t => {
-	t.pass();
-});
-```
-
-It's recommended to provide test titles if you have more than one test.
-
-If you haven't provided a test title, but the implementation is a named function, that name will be used as the test title:
-
-```js
-test(function name(t) {
 	t.pass();
 });
 ```
@@ -356,7 +336,7 @@ Note that, unlike [`tap`](https://www.npmjs.com/package/tap) and [`tape`](https:
 These examples will result in a passed test:
 
 ```js
-test(t => {
+test('resolves with 3', t => {
 	t.plan(1);
 
 	return Promise.resolve(3).then(n => {
@@ -364,7 +344,7 @@ test(t => {
 	});
 });
 
-test.cb(t => {
+test.cb('invokes callback', t => {
 	t.plan(1);
 
 	someAsyncFunction(() => {
@@ -377,7 +357,7 @@ test.cb(t => {
 These won't:
 
 ```js
-test(t => {
+test('loops twice', t => {
 	t.plan(2);
 
 	for (let i = 0; i < 3; i++) {
@@ -385,7 +365,7 @@ test(t => {
 	}
 }); // Fails, 3 assertions are executed which is too many
 
-test(t => {
+test('invokes callback synchronously', t => {
 	t.plan(1);
 
 	someAsyncFunction(() => {
@@ -399,7 +379,7 @@ test(t => {
 Tests are run concurrently by default, however, sometimes you have to write tests that cannot run concurrently. In these rare cases you can use the `.serial` modifier. It will force those tests to run serially *before* the concurrent ones.
 
 ```js
-test.serial(t => {
+test.serial('passes serially', t => {
 	t.pass();
 });
 ```
@@ -574,7 +554,7 @@ test.afterEach.always(t => {
 	// This runs after each test and other test hooks, even if they failed
 });
 
-test(t => {
+test('title', t => {
 	// Regular test
 });
 ```
@@ -612,7 +592,7 @@ test.beforeEach(t => {
 	t.context.data = generateUniqueData();
 });
 
-test(t => {
+test('context data is foo', t => {
 	t.is(t.context.data + 'bar', 'foobar');
 });
 ```
@@ -624,7 +604,7 @@ test.beforeEach(t => {
 	t.context = 'unicorn';
 });
 
-test(t => {
+test('context is unicorn', t => {
 	t.is(t.context, 'unicorn');
 });
 ```
@@ -703,7 +683,7 @@ You'll have to configure AVA to not fail tests if no assertions are executed, be
 ```js
 import assert from 'assert';
 
-test(t => {
+test('custom assertion', t => {
 	assert(true);
 });
 ```
@@ -737,7 +717,7 @@ You can also transpile your modules in a separate process and refer to the trans
 If you return a promise in the test you don't need to explicitly end the test as it will end when the promise resolves.
 
 ```js
-test(t => {
+test('resolves with unicorn', t => {
 	return somePromise().then(result => {
 		t.is(result, 'unicorn');
 	});
@@ -766,7 +746,7 @@ test(async function (t) {
 });
 
 // Async arrow function
-test(async t => {
+test('promises the truth', async t => {
 	const value = await promiseFn();
 	t.true(value);
 });
@@ -779,7 +759,7 @@ AVA comes with built-in support for [observables](https://github.com/zenparsing/
 *You do not need to use "callback mode" or call `t.end()`.*
 
 ```js
-test(t => {
+test('handles observables', t => {
 	t.plan(3);
 	return Observable.of(1, 2, 3, 4, 5, 6)
 		.filter(n => {
@@ -795,7 +775,7 @@ test(t => {
 AVA supports using `t.end` as the final callback when using node-style error-first callback APIs. AVA will consider any truthy value passed as the first argument to `t.end` to be an error. Note that `t.end` requires "callback mode", which can be enabled by using the `test.cb` chain.
 
 ```js
-test.cb(t => {
+test.cb('data.txt can be read', t => {
 	// `t.end` automatically checks for error as first argument
 	fs.readFile('data.txt', t.end);
 });
@@ -864,7 +844,7 @@ Log values contextually alongside the test result instead of immediately printin
 Assertions are mixed into the [execution object](#t) provided to each test implementation:
 
 ```js
-test(t => {
+test('unicorns are truthy', t => {
 	t.truthy('unicorn'); // Assertion
 });
 ```
@@ -1044,7 +1024,7 @@ If you are running AVA against precompiled test files, AVA will try and use sour
 Any assertion can be skipped using the `skip` modifier. Skipped assertions are still counted, so there is no need to change your planned assertion count.
 
 ```js
-test(t => {
+test('skip assertion', t => {
 	t.plan(2);
 	t.skip.is(foo(), 5); // No need to change your plan count when skipping
 	t.is(1, 1);
@@ -1073,7 +1053,7 @@ AssertionError: false == true
 In AVA however, this test:
 
 ```js
-test(t => {
+test('enhanced assertions', t => {
 	const a = /foo/;
 	const b = 'bar';
 	const c = 'baz';

--- a/test/api.js
+++ b/test/api.js
@@ -69,19 +69,17 @@ function generateTests(prefix, apiCreator) {
 	});
 
 	test(`${prefix} test title prefixes — multiple files`, t => {
-		t.plan(6);
+		t.plan(5);
 
 		const separator = ` ${figures.pointerSmall} `;
 		const files = [
 			path.join(__dirname, 'fixture/async-await.js'),
-			path.join(__dirname, 'fixture/es2015.js'),
 			path.join(__dirname, 'fixture/generators.js'),
 			path.join(__dirname, 'fixture/subdir/in-a-subdir.js')
 		];
 		const expected = [
 			['async-await', 'async function'].join(separator),
 			['async-await', 'arrow async function'].join(separator),
-			['es2015', '[anonymous]'].join(separator),
 			['generators', 'generator function'].join(separator),
 			['subdir', 'in-a-subdir', 'subdir'].join(separator)
 		];

--- a/test/cli.js
+++ b/test/cli.js
@@ -528,7 +528,7 @@ test('use current working directory if `package.json` is not found', () => {
 	const cliPath = require.resolve('../cli.js');
 	const avaPath = require.resolve('../');
 
-	fs.writeFileSync(testFilePath, `import test from ${JSON.stringify(avaPath)};\ntest(t => { t.pass(); });`);
+	fs.writeFileSync(testFilePath, `import test from ${JSON.stringify(avaPath)};\ntest('test', t => { t.pass(); });`);
 
 	return execa(process.execPath, [cliPath], {cwd});
 });

--- a/test/fixture/ava-paths/target/test.js
+++ b/test/fixture/ava-paths/target/test.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
 import test from 'ava';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/caching/test.js
+++ b/test/fixture/caching/test.js
@@ -1,5 +1,5 @@
 import test from '../../../';
 
-test(t => {
+test('test', t => {
 	t.true(2 + 2 === 4);
 });

--- a/test/fixture/circular-reference-on-assertion.js
+++ b/test/fixture/circular-reference-on-assertion.js
@@ -1,6 +1,6 @@
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	const circular = ['a', 'b'];
 	circular.push(circular);
 	t.deepEqual([circular, 'c'], [circular, 'd']);

--- a/test/fixture/debug-arg.js
+++ b/test/fixture/debug-arg.js
@@ -1,5 +1,5 @@
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	t.true(process.execArgv[0].indexOf('--debug') === 0);
 });

--- a/test/fixture/error-in-anonymous-function.js
+++ b/test/fixture/error-in-anonymous-function.js
@@ -4,7 +4,7 @@ const getAnonymousFn = () => () => {
 	throw new Error();
 };
 
-test(t => {
+test('test', t => {
 	getAnonymousFn()();
 	t.pass();
 });

--- a/test/fixture/es2015-source-maps.js
+++ b/test/fixture/es2015-source-maps.js
@@ -1,6 +1,6 @@
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });
 

--- a/test/fixture/es2015.js
+++ b/test/fixture/es2015.js
@@ -1,5 +1,5 @@
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/exclusive-nonexclusive.js
+++ b/test/fixture/exclusive-nonexclusive.js
@@ -1,9 +1,9 @@
 import test from '../../';
 
-test.only(t => {
+test.only('only', t => {
 	t.pass();
 });
 
-test(t => {
+test('test', t => {
 	t.fail();
 });

--- a/test/fixture/exclusive.js
+++ b/test/fixture/exclusive.js
@@ -1,5 +1,5 @@
 import test from '../..';
 
-test.only(t => {
+test.only('test', t => {
 	t.pass();
 });

--- a/test/fixture/fake-timers.js
+++ b/test/fixture/fake-timers.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	sinon.useFakeTimers(Date.now() + 10000);
 	t.pass();
 });

--- a/test/fixture/formatting-color.js
+++ b/test/fixture/formatting-color.js
@@ -1,5 +1,5 @@
 import test from '../..';
 
-test(t => {
+test('test', t => {
 	t.deepEqual({foo: 1}, {foo: 2});
 });

--- a/test/fixture/hooks-failing.js
+++ b/test/fixture/hooks-failing.js
@@ -1,7 +1,7 @@
 import test from '../../';
 
 test.beforeEach(fail);
-test(pass);
+test('pass', pass);
 
 function pass() {}
 

--- a/test/fixture/hooks-passing.js
+++ b/test/fixture/hooks-passing.js
@@ -4,7 +4,7 @@ test.before(pass);
 test.beforeEach(pass);
 test.after(pass);
 test.afterEach(pass);
-test(pass);
+test('pass', pass);
 
 function pass(t) {
 	t.pass();

--- a/test/fixture/ignored-dirs/fixtures/test.js
+++ b/test/fixture/ignored-dirs/fixtures/test.js
@@ -1,5 +1,5 @@
 import test from '../../../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/ignored-dirs/helpers/test.js
+++ b/test/fixture/ignored-dirs/helpers/test.js
@@ -1,5 +1,5 @@
 import test from '../../../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/improper-t-throws/async-callback.js
+++ b/test/fixture/improper-t-throws/async-callback.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test.cb(t => {
+test.cb('test', t => {
 	setTimeout(() => {
 		t.throws(throwSync());
 	});

--- a/test/fixture/improper-t-throws/caught-and-leaked-slowly.js
+++ b/test/fixture/improper-t-throws/caught-and-leaked-slowly.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	try {
 		t.throws(throwSync());
 	} catch (err) {

--- a/test/fixture/improper-t-throws/caught-and-leaked-too-slowly.js
+++ b/test/fixture/improper-t-throws/caught-and-leaked-too-slowly.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	try {
 		t.throws(throwSync());
 	} catch (err) {

--- a/test/fixture/improper-t-throws/caught-and-leaked.js
+++ b/test/fixture/improper-t-throws/caught-and-leaked.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	try {
 		t.throws(throwSync());
 	} catch (err) {

--- a/test/fixture/improper-t-throws/caught.js
+++ b/test/fixture/improper-t-throws/caught.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	try {
 		t.throws(throwSync());
 	} catch (err) {}

--- a/test/fixture/improper-t-throws/leaked-from-promise.js
+++ b/test/fixture/improper-t-throws/leaked-from-promise.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	try {
 		t.throws(throwSync());
 	} catch (err) {

--- a/test/fixture/improper-t-throws/promise.js
+++ b/test/fixture/improper-t-throws/promise.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	return Promise.resolve().then(() => {
 		t.throws(throwSync());
 	});

--- a/test/fixture/improper-t-throws/throws.js
+++ b/test/fixture/improper-t-throws/throws.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	t.throws(throwSync());
 });
 

--- a/test/fixture/improper-t-throws/unhandled-rejection.js
+++ b/test/fixture/improper-t-throws/unhandled-rejection.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test.cb(t => {
+test.cb('test', t => {
 	Promise.resolve().then(() => {
 		t.throws(throwSync());
 	});

--- a/test/fixture/infinity-stack-trace.js
+++ b/test/fixture/infinity-stack-trace.js
@@ -2,7 +2,7 @@ import test from '../../';
 
 Error.stackTraceLimit = 1;
 
-test(t => {
+test('test', t => {
 	const c = () => t.fail();
 	const b = () => c();
 	const a = () => b();

--- a/test/fixture/inspect-arg.js
+++ b/test/fixture/inspect-arg.js
@@ -1,5 +1,5 @@
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	t.true(process.execArgv[0].indexOf('--inspect') === 0);
 });

--- a/test/fixture/just-enhancement-compilation/power-assert.js
+++ b/test/fixture/just-enhancement-compilation/power-assert.js
@@ -2,7 +2,7 @@
 
 const test = require('../../../');
 
-test(t => {
+test('test', t => {
 	const bool = false;
 	t.true(bool);
 });

--- a/test/fixture/long-stack-trace/test.js
+++ b/test/fixture/long-stack-trace/test.js
@@ -3,7 +3,7 @@ import Bluebird from './_enable-trace';
 
 // This promise throwing pattern was used in bluebird documentation for long stack traces
 // http://bluebirdjs.com/docs/api/promise.longstacktraces.html
-test(async t => {
+test('test', async t => {
 	await Bluebird.resolve().then(() => {
 		return Bluebird.resolve().then(() => {
 			return Bluebird.resolve().then(() => {

--- a/test/fixture/match-no-match.js
+++ b/test/fixture/match-no-match.js
@@ -8,6 +8,6 @@ test.only('bar', t => {
 	t.pass();
 });
 
-test.only(t => {
+test.only('baz', t => {
 	t.pass();
 });

--- a/test/fixture/no-babel-compilation/no-power-assert.js
+++ b/test/fixture/no-babel-compilation/no-power-assert.js
@@ -2,7 +2,7 @@
 
 const test = require('../../../');
 
-test(t => {
+test('test', t => {
 	const bool = false;
 	t.true(bool);
 });

--- a/test/fixture/no-babel-compilation/require-helper.js
+++ b/test/fixture/no-babel-compilation/require-helper.js
@@ -2,6 +2,6 @@
 
 const test = require('../../../');
 
-test(t => {
+test('test', t => {
 	t.throws(() => require('./_helper'), SyntaxError);
 });

--- a/test/fixture/pkg-conf/defaults/test.js
+++ b/test/fixture/pkg-conf/defaults/test.js
@@ -2,7 +2,7 @@ import test from '../../../../';
 
 const opts = JSON.parse(process.argv[2]);
 
-test(t => {
+test('test', t => {
 	t.is(opts.failFast, false);
 	t.is(opts.serial, false);
 	t.is(opts.cacheEnabled, true);

--- a/test/fixture/pkg-conf/fail-without-assertions/test.js
+++ b/test/fixture/pkg-conf/fail-without-assertions/test.js
@@ -1,3 +1,3 @@
 import test from '../../../..';
 
-test(() => {});
+test('test', () => {});

--- a/test/fixture/pkg-conf/pkg-overrides/actual.js
+++ b/test/fixture/pkg-conf/pkg-overrides/actual.js
@@ -2,7 +2,7 @@ import test from '../../../../';
 
 const opts = JSON.parse(process.argv[2]);
 
-test(t => {
+test('test', t => {
 	t.is(opts.failFast, true);
 	t.is(opts.serial, true);
 	t.is(opts.cacheEnabled, false);

--- a/test/fixture/pkg-conf/pkg-overrides/test.js
+++ b/test/fixture/pkg-conf/pkg-overrides/test.js
@@ -2,6 +2,6 @@ import test from '../../../../';
 
 // This should never be loaded - package.json overrides files to call `actual.js`
 
-test(t => {
+test('test', t => {
 	t.fail();
 });

--- a/test/fixture/pkg-conf/precedence/a.js
+++ b/test/fixture/pkg-conf/precedence/a.js
@@ -2,6 +2,6 @@ import test from '../../../../';
 
 // This should never be loaded - package.json overrides files to call `actual.js`
 
-test(t => {
+test('test', t => {
 	t.fail();
 });

--- a/test/fixture/pkg-conf/precedence/b.js
+++ b/test/fixture/pkg-conf/precedence/b.js
@@ -2,6 +2,6 @@ import test from '../../../../';
 
 // This should never be loaded - package.json overrides files to call `actual.js`
 
-test(t => {
+test('test', t => {
 	t.fail();
 });

--- a/test/fixture/pkg-conf/resolve-dir/dir-a-wrapper/dir-a/dir-a-wrapper-3.js
+++ b/test/fixture/pkg-conf/resolve-dir/dir-a-wrapper/dir-a/dir-a-wrapper-3.js
@@ -1,5 +1,5 @@
 import test from '../../../../../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/pkg-conf/resolve-dir/dir-a-wrapper/dir-a/dir-a-wrapper-4.js
+++ b/test/fixture/pkg-conf/resolve-dir/dir-a-wrapper/dir-a/dir-a-wrapper-4.js
@@ -1,5 +1,5 @@
 import test from '../../../../../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/pkg-conf/resolve-dir/dir-a/dir-a-base-1.js
+++ b/test/fixture/pkg-conf/resolve-dir/dir-a/dir-a-base-1.js
@@ -1,5 +1,5 @@
 import test from '../../../../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/pkg-conf/resolve-dir/dir-a/dir-a-base-2.js
+++ b/test/fixture/pkg-conf/resolve-dir/dir-a/dir-a-base-2.js
@@ -1,5 +1,5 @@
 import test from '../../../../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/power-assert.js
+++ b/test/fixture/power-assert.js
@@ -1,16 +1,16 @@
 import test from '../../';
 
-test.serial(t => {
+test.serial('bar', t => {
 	const a = 'foo';
 	t.true(a === 'bar');
 });
 
-test.serial(t => {
+test.serial('foo', t => {
 	const a = 'bar';
 	t.true(a === 'foo', 'with message');
 });
 
-test.serial(t => {
+test.serial('span', t => {
 	const React = { // eslint-disable-line no-unused-vars
 		createElement: type => type
 	};

--- a/test/fixture/precompile-helpers/test/test.js
+++ b/test/fixture/precompile-helpers/test/test.js
@@ -2,7 +2,7 @@ import test from '../../../../';
 import a from './helpers/a';
 import b from './_b';
 
-test(async t => {
+test('test', async t => {
 	await a();
 	await b();
 

--- a/test/fixture/process-cwd-default.js
+++ b/test/fixture/process-cwd-default.js
@@ -2,7 +2,7 @@ import path from 'path';
 import pkgConf from 'pkg-conf';
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	const conf = pkgConf.sync('ava');
 	const pkgDir = path.dirname(pkgConf.filepath(conf));
 	t.is(process.cwd(), pkgDir);

--- a/test/fixture/process-cwd-pkgdir.js
+++ b/test/fixture/process-cwd-pkgdir.js
@@ -1,5 +1,5 @@
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	t.is(process.cwd(), __dirname);
 });

--- a/test/fixture/serial.js
+++ b/test/fixture/serial.js
@@ -16,6 +16,6 @@ test.cb('second', t => {
 	}, 100);
 });
 
-test(t => {
+test('test', t => {
 	t.deepEqual(tests, ['first', 'second']);
 });

--- a/test/fixture/skip-only.js
+++ b/test/fixture/skip-only.js
@@ -1,5 +1,5 @@
 import test from '../../';
 
-test.skip(t => {
+test.skip('test', t => {
 	t.fail();
 });

--- a/test/fixture/stalled-tests/callback.js
+++ b/test/fixture/stalled-tests/callback.js
@@ -1,5 +1,5 @@
 import test from '../../..';
 
-test.cb(t => {
+test.cb('test', t => {
 	t.pass();
 });

--- a/test/fixture/stalled-tests/observable.js
+++ b/test/fixture/stalled-tests/observable.js
@@ -1,7 +1,7 @@
 import Observable from 'zen-observable';
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	return new Observable(() => {
 		t.pass();
 	});

--- a/test/fixture/stalled-tests/promise.js
+++ b/test/fixture/stalled-tests/promise.js
@@ -1,6 +1,6 @@
 import test from '../../..';
 
-test(t => {
+test('test', t => {
 	return new Promise(() => {
 		t.pass();
 	});

--- a/test/fixture/symlinkdir/symlink.js
+++ b/test/fixture/symlinkdir/symlink.js
@@ -1,5 +1,5 @@
 import test from '../../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/target-symlink.js
+++ b/test/fixture/target-symlink.js
@@ -1,5 +1,5 @@
 import test from '../../';
 
-test(t => {
+test('test', t => {
 	t.pass();
 });

--- a/test/fixture/trigger-worker-exception/test-fallback.js
+++ b/test/fixture/trigger-worker-exception/test-fallback.js
@@ -1,5 +1,5 @@
 import test from '../../../';
 
-test(async () => {
+test('test', async () => {
 	throw new Error('Hi :)');
 });

--- a/test/fixture/trigger-worker-exception/test.js
+++ b/test/fixture/trigger-worker-exception/test.js
@@ -4,6 +4,6 @@ import {restoreAfterFirstCall} from './hack';
 
 restoreAfterFirstCall();
 
-test(async () => {
+test('test', async () => {
 	throw new Error('Hi :)');
 });

--- a/test/fixture/validate-installed-global.js
+++ b/test/fixture/validate-installed-global.js
@@ -1,3 +1,3 @@
 import test from '../../';
 
-test(t => t.is(global.foo, 'bar'));
+test('test', t => t.is(global.foo, 'bar'));

--- a/test/flow-types/regression-1114.js.flow
+++ b/test/flow-types/regression-1114.js.flow
@@ -11,7 +11,7 @@ test('Named test', t => {
 	t.end();
 });
 
-test(t => {
+test('test', t => {
 	t.pass('Success');
 	// $ExpectError: Unknown method "unknownAssertion"
 	t.unknownAssertion('Whoops');
@@ -20,7 +20,7 @@ test(t => {
 	t.end();
 });
 
-test.cb(t => {
+test.cb('test', t => {
 	t.pass('Success');
 	t.end();
 });

--- a/test/flow-types/regression-1148.js.flow
+++ b/test/flow-types/regression-1148.js.flow
@@ -2,7 +2,7 @@
 
 const test = require('../../index.js.flow');
 
-test(t => {
+test('test', t => {
 	t.throws(() => { throw new Error(); });
 	t.throws(Promise.reject(new Error()));
 

--- a/test/flow-types/regression-1500.js.flow
+++ b/test/flow-types/regression-1500.js.flow
@@ -2,7 +2,7 @@
 
 const test = require('../../index.js.flow');
 
-test(t => {
+test('test', t => {
 	t.snapshot({});
 	t.snapshot({}, "a message");
 	t.snapshot({}, {id: "snapshot-id"});

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -38,7 +38,7 @@ test('before', t => {
 		arr.push('a');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		arr.push('b');
 	});
@@ -58,7 +58,7 @@ test('after', t => {
 		arr.push('b');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		arr.push('a');
 	});
@@ -82,7 +82,7 @@ test('after not run if test failed', t => {
 		arr.push('a');
 	});
 
-	runner.chain.test(() => {
+	runner.chain.test('test', () => {
 		throw new Error('something went wrong');
 	});
 	return runner.run({}).then(() => {
@@ -104,7 +104,7 @@ test('after.always run even if test failed', t => {
 		arr.push('a');
 	});
 
-	runner.chain.test(() => {
+	runner.chain.test('test', () => {
 		throw new Error('something went wrong');
 	});
 	return runner.run({}).then(() => {
@@ -150,7 +150,7 @@ test('stop if before hooks failed', t => {
 		throw new Error('something went wrong');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		arr.push('b');
 		a.end();
@@ -178,12 +178,12 @@ test('before each with concurrent tests', t => {
 		arr[k++].push('b');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('c', a => {
 		a.pass();
 		arr[0].push('c');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('d', a => {
 		a.pass();
 		arr[1].push('d');
 	});
@@ -208,12 +208,12 @@ test('before each with serial tests', t => {
 		arr.push('b');
 	});
 
-	runner.chain.serial(a => {
+	runner.chain.serial('c', a => {
 		a.pass();
 		arr.push('c');
 	});
 
-	runner.chain.serial(a => {
+	runner.chain.serial('d', a => {
 		a.pass();
 		arr.push('d');
 	});
@@ -235,7 +235,7 @@ test('fail if beforeEach hook fails', t => {
 		a.fail();
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		arr.push('b');
 		a.pass();
 	});
@@ -264,12 +264,12 @@ test('after each with concurrent tests', t => {
 		arr[k++].push('b');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('c', a => {
 		a.pass();
 		arr[0].push('c');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('d', a => {
 		a.pass();
 		arr[1].push('d');
 	});
@@ -294,12 +294,12 @@ test('after each with serial tests', t => {
 		arr.push('b');
 	});
 
-	runner.chain.serial(a => {
+	runner.chain.serial('c', a => {
 		a.pass();
 		arr.push('c');
 	});
 
-	runner.chain.serial(a => {
+	runner.chain.serial('d', a => {
 		a.pass();
 		arr.push('d');
 	});
@@ -320,7 +320,7 @@ test('afterEach not run if concurrent tests failed', t => {
 		arr.push('a');
 	});
 
-	runner.chain.test(() => {
+	runner.chain.test('test', () => {
 		throw new Error('something went wrong');
 	});
 
@@ -340,7 +340,7 @@ test('afterEach not run if serial tests failed', t => {
 		arr.push('a');
 	});
 
-	runner.chain.serial(() => {
+	runner.chain.serial('test', () => {
 		throw new Error('something went wrong');
 	});
 
@@ -360,7 +360,7 @@ test('afterEach.always run even if concurrent tests failed', t => {
 		arr.push('a');
 	});
 
-	runner.chain.test(() => {
+	runner.chain.test('test', () => {
 		throw new Error('something went wrong');
 	});
 
@@ -380,7 +380,7 @@ test('afterEach.always run even if serial tests failed', t => {
 		arr.push('a');
 	});
 
-	runner.chain.serial(() => {
+	runner.chain.serial('test', () => {
 		throw new Error('something went wrong');
 	});
 
@@ -400,7 +400,7 @@ test('afterEach.always run even if beforeEach failed', t => {
 		throw new Error('something went wrong');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		arr.push('a');
 	});
@@ -437,7 +437,7 @@ test('ensure hooks run only around tests', t => {
 		arr.push('after');
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		arr.push('test');
 	});
@@ -465,7 +465,7 @@ test('shared context', t => {
 		a.context.arr = ['a'];
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		a.context.arr.push('b');
 		a.deepEqual(a.context.arr, ['a', 'b']);
@@ -492,7 +492,7 @@ test('shared context of any type', t => {
 		a.context = 'foo';
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		a.is(a.context, 'foo');
 	});
@@ -525,7 +525,7 @@ test('display hook title if it failed', t => {
 		.run({})
 		.on('test', test => {
 			t.is(test.error.name, 'AssertionError');
-			t.is(test.title, 'fail for pass');
+			t.is(test.title, 'beforeEach hook for pass');
 		})
 		.then(() => {
 			t.end();

--- a/test/runner.js
+++ b/test/runner.js
@@ -10,7 +10,7 @@ test('nested tests and hooks aren\'t allowed', t => {
 
 	const runner = new Runner();
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		t.throws(() => {
 			runner.chain.test(noop);
 		}, {message: 'All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.'});
@@ -27,7 +27,7 @@ test('tests must be declared synchronously', t => {
 
 	const runner = new Runner();
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		return Promise.resolve();
 	});
@@ -62,17 +62,17 @@ test('run serial tests before concurrent ones', t => {
 	const runner = new Runner();
 	const arr = [];
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		arr.push('c');
 		a.end();
 	});
 
-	runner.chain.serial(a => {
+	runner.chain.serial('serial', a => {
 		arr.push('a');
 		a.end();
 	});
 
-	runner.chain.serial(a => {
+	runner.chain.serial('serial 2', a => {
 		arr.push('b');
 		a.end();
 	});
@@ -106,11 +106,11 @@ test('anything can be skipped', t => {
 	runner.chain.beforeEach(pusher('beforeEach'));
 	runner.chain.beforeEach.skip(pusher('beforeEach.skip'));
 
-	runner.chain.test(pusher('concurrent'));
-	runner.chain.test.skip(pusher('concurrent.skip'));
+	runner.chain.test('concurrent', pusher('concurrent'));
+	runner.chain.test.skip('concurrent.skip', pusher('concurrent.skip'));
 
-	runner.chain.serial(pusher('serial'));
-	runner.chain.serial.skip(pusher('serial.skip'));
+	runner.chain.serial('serial', pusher('serial'));
+	runner.chain.serial.skip('serial.skip', pusher('serial.skip'));
 
 	runner.run({}).then(() => {
 		// Note that afterEach and beforeEach run twice because there are two actual tests - "serial" and "concurrent"
@@ -188,17 +188,14 @@ test('test types and titles', t => {
 	runner.chain.afterEach(named);
 	runner.chain.test('test', fn);
 
-	// See https://github.com/avajs/ava/issues/1027
-	const supportsFunctionNames = noop.name === 'noop';
-
 	const tests = [
 		{
 			type: 'before',
-			title: 'named'
+			title: 'before hook'
 		},
 		{
 			type: 'beforeEach',
-			title: supportsFunctionNames ? 'fn for test' : 'beforeEach for test'
+			title: 'beforeEach hook for test'
 		},
 		{
 			type: 'test',
@@ -206,11 +203,11 @@ test('test types and titles', t => {
 		},
 		{
 			type: 'afterEach',
-			title: 'named for test'
+			title: 'afterEach hook for test'
 		},
 		{
 			type: 'after',
-			title: supportsFunctionNames ? 'fn' : 'after'
+			title: 'after hook'
 		}
 	];
 
@@ -229,12 +226,12 @@ test('skip test', t => {
 	const runner = new Runner();
 	const arr = [];
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		arr.push('a');
 		a.pass();
 	});
 
-	runner.chain.skip(() => {
+	runner.chain.skip('skip', () => {
 		arr.push('b');
 	});
 
@@ -268,7 +265,7 @@ test('todo test', t => {
 	const runner = new Runner();
 	const arr = [];
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		arr.push('a');
 		a.pass();
 	});
@@ -299,12 +296,12 @@ test('only test', t => {
 	const runner = new Runner();
 	const arr = [];
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		arr.push('a');
 		a.pass();
 	});
 
-	runner.chain.only(a => {
+	runner.chain.only('only', a => {
 		arr.push('b');
 		a.pass();
 	});
@@ -495,7 +492,7 @@ test('runOnlyExclusive option test', t => {
 	const options = {runOnlyExclusive: true};
 	const arr = [];
 
-	runner.chain.test(() => {
+	runner.chain.test('test', () => {
 		arr.push('a');
 	});
 
@@ -511,7 +508,7 @@ test('options.serial forces all tests to be serial', t => {
 	const runner = new Runner({serial: true});
 	const arr = [];
 
-	runner.chain.cb(a => {
+	runner.chain.cb('cb', a => {
 		setTimeout(() => {
 			arr.push(1);
 			a.end();
@@ -519,7 +516,7 @@ test('options.serial forces all tests to be serial', t => {
 		a.pass();
 	});
 
-	runner.chain.cb(a => {
+	runner.chain.cb('cb 2', a => {
 		setTimeout(() => {
 			arr.push(2);
 			a.end();
@@ -527,7 +524,7 @@ test('options.serial forces all tests to be serial', t => {
 		a.pass();
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		a.pass();
 		t.strictDeepEqual(arr, [1, 2]);
 		t.end();
@@ -541,12 +538,12 @@ test('options.bail will bail out', t => {
 
 	const runner = new Runner({bail: true});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		t.pass();
 		a.fail();
 	});
 
-	runner.chain.test(() => {
+	runner.chain.test('test 2', () => {
 		t.fail();
 	});
 
@@ -561,7 +558,7 @@ test('options.bail will bail out (async)', t => {
 	const runner = new Runner({bail: true});
 	const tests = [];
 
-	runner.chain.cb(a => {
+	runner.chain.cb('cb', a => {
 		setTimeout(() => {
 			tests.push(1);
 			a.fail();
@@ -570,7 +567,7 @@ test('options.bail will bail out (async)', t => {
 		a.pass();
 	});
 
-	runner.chain.cb(a => {
+	runner.chain.cb('cb 2', a => {
 		setTimeout(() => {
 			tests.push(2);
 			a.end();
@@ -598,7 +595,7 @@ test('options.bail + serial - tests will never happen (async)', t => {
 	});
 	const tests = [];
 
-	runner.chain.cb(a => {
+	runner.chain.cb('cb', a => {
 		setTimeout(() => {
 			tests.push(1);
 			a.fail();
@@ -606,7 +603,7 @@ test('options.bail + serial - tests will never happen (async)', t => {
 		}, 100);
 	});
 
-	runner.chain.cb(a => {
+	runner.chain.cb('cb 2', a => {
 		setTimeout(() => {
 			tests.push(2);
 			a.end();
@@ -644,7 +641,7 @@ test('options.match will not run tests with non-matching titles', t => {
 		a.pass();
 	});
 
-	runner.chain.test(a => {
+	runner.chain.test('test', a => {
 		t.fail();
 		a.pass();
 	});
@@ -707,32 +704,6 @@ test('options.match overrides .only', t => {
 		t.is(stats.skipCount, 0);
 		t.is(stats.passCount, 2);
 		t.is(stats.testCount, 2);
-		t.end();
-	});
-});
-
-test('options.match includes anonymous tests in negative matches', t => {
-	t.plan(4);
-
-	const runner = new Runner({
-		match: ['!*oo']
-	});
-
-	runner.chain.test('foo', a => {
-		t.fail();
-		a.pass();
-	});
-
-	runner.chain.test(a => {
-		t.pass();
-		a.pass();
-	});
-
-	runner.run({}).then(() => {
-		const stats = runner.buildStats();
-		t.is(stats.skipCount, 0);
-		t.is(stats.passCount, 1);
-		t.is(stats.testCount, 1);
 		t.end();
 	});
 });
@@ -848,10 +819,10 @@ test('arrays of macros', t => {
 
 	const runner = new Runner();
 
-	runner.chain.test([macroFnA, macroFnB], 'A');
-	runner.chain.test([macroFnA, macroFnB], 'B');
-	runner.chain.test(macroFnA, 'C');
-	runner.chain.test(macroFnB, 'D');
+	runner.chain.test('A', [macroFnA, macroFnB], 'A');
+	runner.chain.test('B', [macroFnA, macroFnB], 'B');
+	runner.chain.test('C', macroFnA, 'C');
+	runner.chain.test('D', macroFnB, 'D');
 
 	runner.run({}).then(() => {
 		const stats = runner.buildStats();

--- a/test/runner.js
+++ b/test/runner.js
@@ -811,11 +811,13 @@ test('arrays of macros', t => {
 		t.deepEqual(slice.call(arguments, 1), expectedArgsA.shift());
 		a.pass();
 	}
+	macroFnA.title = prefix => `${prefix}.A`;
 
 	function macroFnB(a) {
 		t.deepEqual(slice.call(arguments, 1), expectedArgsB.shift());
 		a.pass();
 	}
+	macroFnB.title = prefix => `${prefix}.B`;
 
 	const runner = new Runner();
 
@@ -853,7 +855,7 @@ test('match applies to arrays of macros', t => {
 		t.fail();
 		a.pass();
 	}
-	bazMacro.title = firstArg => `${firstArg}baz`;
+	bazMacro.title = (title, firstArg) => `${firstArg}baz`;
 
 	const runner = new Runner({
 		match: ['foobar']

--- a/test/test-collection.js
+++ b/test/test-collection.js
@@ -113,7 +113,7 @@ test('throws if you try to set a before hook as always', t => {
 test('throws if you try to set a test as always', t => {
 	const collection = new TestCollection({});
 	t.throws(() => {
-		collection.add(mockTest({always: true}));
+		collection.add(mockTest({always: true}, 'test'));
 	}, {message: '"always" can only be used with after and afterEach hooks'});
 	t.end();
 });

--- a/test/ts-types/regression-1347.ts
+++ b/test/ts-types/regression-1347.ts
@@ -1,5 +1,5 @@
 import test from '../..'
 
-test.cb(t => {
+test.cb('test', t => {
 	t.end()
 })

--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -125,16 +125,14 @@ export interface Macro<T> {
 export type Macros<T> = Macro<T> | Macro<T>[];
 
 interface RegisterBase<T> {
-    (name: string, run: GenericTest<T>): void;
-    (run: GenericTest<T>): void;
-    (name: string, run: Macros<GenericTestContext<T>>, ...args: any[]): void;
+    (title: string, run: GenericTest<T>): void;
+    (title: string, run: Macros<GenericTestContext<T>>, ...args: any[]): void;
     (run: Macros<GenericTestContext<T>>, ...args: any[]): void;
 }
 
 interface CallbackRegisterBase<T> {
-    (name: string, run: GenericCallbackTest<T>): void;
-    (run: GenericCallbackTest<T>): void;
-    (name: string, run: Macros<GenericCallbackTestContext<T>>, ...args: any[]): void;
+    (title: string, run: GenericCallbackTest<T>): void;
+    (title: string, run: Macros<GenericCallbackTestContext<T>>, ...args: any[]): void;
     (run: Macros<GenericCallbackTestContext<T>>, ...args: any[]): void;
 }
 


### PR DESCRIPTION
Stop deriving a title from the test implementation function's name.

Note that this can't quite be expressed in the type definitions.
Hopefully when we tackle #1182 it'll be easier to write the appropriate
definition.

Fixes #1207.