### PR TITLE
Ensure profile.js skips test file compilation like regular runs

### DIFF
--- a/profile.js
+++ b/profile.js
@@ -39,7 +39,8 @@ const conf = pkgConf.sync('ava', {
 	defaults: {
 		babel: {
 			testOptions: {}
-		}
+		},
+		compileEnhancements: true
 	}
 });
 
@@ -78,16 +79,18 @@ const cacheDir = findCacheDir({
 	files: [file]
 }) || uniqueTempDir();
 
-babelConfigHelper.build(process.cwd(), cacheDir, babelConfigHelper.validate(conf.babel), true)
+babelConfigHelper.build(process.cwd(), cacheDir, babelConfigHelper.validate(conf.babel), conf.compileEnhancements === true)
 	.then(result => {
-		const precompiler = new CachingPrecompiler({
-			path: cacheDir,
-			getBabelOptions: result.getOptions,
-			babelCacheKeys: result.cacheKeys
-		});
-
 		const precompiled = {};
-		precompiled[file] = precompiler.precompileFile(file);
+		if (result) {
+			const precompiler = new CachingPrecompiler({
+				path: cacheDir,
+				getBabelOptions: result.getOptions,
+				babelCacheKeys: result.cacheKeys
+			});
+
+			precompiled[file] = precompiler.precompileFile(file);
+		}
 
 		const opts = {
 			file,


### PR DESCRIPTION
Read the 'compileEnhancements' option from package.json and guard
against the Babel config helper not returning any config.

See https://github.com/avajs/ava/issues/1556#issuecomment-361962088.