### PR TITLE
Docs: Add link to french translation (babel & support-statement)

### DIFF
--- a/docs/recipes/babel.md
+++ b/docs/recipes/babel.md
@@ -1,5 +1,7 @@
 # Configuring Babel
 
+Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/babel.md)
+
 AVA uses [Babel 7](https://babeljs.io) so you can use the latest JavaScript syntax in your tests. We do this by compiling test and helper files using our [`@ava/stage-4`](https://github.com/avajs/babel-preset-stage-4) preset. We also use a [second preset](https://github.com/avajs/babel-preset-transform-test-files) to enable [enhanced assertion messages](../../readme#enhanced-assertion-messages) and detect improper use of `t.throws()` assertions.
 
 By default our Babel pipeline is applied to test and helper files ending in `.js`. If your project uses Babel then we'll automatically compile files using your project's Babel configuration.

--- a/docs/support-statement.md
+++ b/docs/support-statement.md
@@ -1,5 +1,7 @@
 # Supported Node.js versions
 
+Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/support-statement.md)
+
 AVA supports the latest release of any major version that [is supported by Node.js itself](https://github.com/nodejs/Release#release-schedule).
 
 *Support* here means that we run our test suite under the given Node.js versions and will accept pull requests to fix any bugs (provided they're not known bugs in Node.js itself that will be fixed imminently). Consequently, *dropping support* means we'll remove those Node.js versions from our test matrix and will no longer accept specific pull requests to fix bugs under those versions.


### PR DESCRIPTION
Add links to french translation:
* babel.md
* support-statement.md

Note: The doc is up to date for 1.0.0-beta.1