### PR TITLE
Pipe stdin to child test processes if serial is set to true

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -43,6 +43,10 @@ module.exports = (file, opts, execArgv) => {
 		execArgv: execArgv || process.execArgv
 	});
 
+	if (opts.serial) {
+		process.stdin.pipe(ps.stdin);
+	}
+
 	const relFile = path.relative('.', file);
 
 	let exiting = false;


### PR DESCRIPTION
This allows serial test suites to consume key strokes from standard
input during test executions.

Fixes: https://github.com/avajs/ava/issues/1682
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
