### PR TITLE
Bound execution context and changed skip

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -72,7 +72,6 @@ function wrapAssertions(callbacks) {
 	const pass = callbacks.pass;
 	const pending = callbacks.pending;
 	const fail = callbacks.fail;
-	const log = callbacks.log;
 
 	const noop = () => {};
 	const makeRethrow = reason => () => {
@@ -127,18 +126,6 @@ function wrapAssertions(callbacks) {
 				}));
 			} else {
 				pass(this);
-			}
-		},
-
-		log() {
-			const args = Array.from(arguments, value => {
-				return typeof value === 'string' ?
-					value :
-					concordance.format(value, concordanceOptions);
-			});
-
-			if (args.length > 0) {
-				log(this, args.join(' '));
 			}
 		},
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -334,7 +334,7 @@ function wrapAssertions(callbacks) {
 
 			let result;
 			try {
-				result = this._test.compareWithSnapshot(options);
+				result = this.compareWithSnapshot(options);
 			} catch (err) {
 				if (!(err instanceof snapshotManager.SnapshotError)) {
 					throw err;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -266,6 +266,7 @@ class Runner extends EventEmitter {
 				task.implementation :
 				t => task.implementation.apply(null, [t].concat(task.args)),
 			compareTestSnapshot: this.boundCompareTestSnapshot,
+			updateSnapshots: this.updateSnapshots,
 			metadata: task.metadata,
 			title: `${task.title}${titleSuffix || ''}`
 		}));
@@ -300,6 +301,7 @@ class Runner extends EventEmitter {
 					task.implementation :
 					t => task.implementation.apply(null, [t].concat(task.args)),
 				compareTestSnapshot: this.boundCompareTestSnapshot,
+				updateSnapshots: this.updateSnapshots,
 				metadata: task.metadata,
 				title: task.title
 			});

--- a/lib/test.js
+++ b/lib/test.js
@@ -74,6 +74,10 @@ class ExecutionContext {
 			log: {value: log.bind(test)},
 			plan: {value: boundPlan}
 		}));
+
+		this.snapshot.skip = () => {
+			test.skipSnapshot();
+		};
 	}
 
 	get end() {
@@ -119,6 +123,14 @@ class Test {
 			const index = assertionOptions.id ? 0 : this.snapshotInvocationCount++;
 			const label = assertionOptions.id ? '' : assertionOptions.message || `Snapshot ${this.snapshotInvocationCount}`;
 			return options.compareTestSnapshot({belongsTo, expected, index, label});
+		};
+		this.skipSnapshot = () => {
+			if (options.updateSnapshots) {
+				this.addFailedAssertion(new Error('Snapshot assertions cannot be skipped when updating snapshots'));
+			} else {
+				this.snapshotInvocationCount++;
+				this.countPassedAssertion();
+			}
 		};
 
 		this.assertCount = 0;

--- a/lib/test.js
+++ b/lib/test.js
@@ -38,6 +38,18 @@ class ExecutionContext {
 		});
 	}
 
+	log() {
+		const args = Array.from(arguments, value => {
+			return typeof value === 'string' ?
+				value :
+				concordance.format(value, concordanceOptions);
+		});
+
+		if (args.length > 0) {
+			this._test.addLog(args.join(' '));
+		}
+	}
+
 	plan(ct) {
 		this._test.plan(ct, captureStack(this.plan));
 	}
@@ -71,10 +83,6 @@ class ExecutionContext {
 
 {
 	const assertions = assert.wrapAssertions({
-		log(executionContext, text) {
-			executionContext._test.addLog(text);
-		},
-
 		pass(executionContext) {
 			executionContext._test.countPassedAssertion();
 		},

--- a/lib/test.js
+++ b/lib/test.js
@@ -15,12 +15,6 @@ function formatErrorValue(label, error) {
 	return {label, formatted};
 }
 
-class SkipApi {
-	constructor(test) {
-		this._test = test;
-	}
-}
-
 const captureStack = start => {
 	const limitBefore = Error.stackTraceLimit;
 	Error.stackTraceLimit = 1;
@@ -30,79 +24,83 @@ const captureStack = start => {
 	return obj.stack;
 };
 
+const assertions = assert.wrapAssertions({
+	pass(test) {
+		test.countPassedAssertion();
+	},
+
+	pending(test, promise) {
+		test.addPendingAssertion(promise);
+	},
+
+	fail(test, error) {
+		test.addFailedAssertion(error);
+	}
+});
+const assertionNames = Object.keys(assertions);
+
+function log() {
+	const args = Array.from(arguments, value => {
+		return typeof value === 'string' ?
+			value :
+			concordance.format(value, concordanceOptions);
+	});
+
+	if (args.length > 0) {
+		this.addLog(args.join(' '));
+	}
+}
+
+function plan(count) {
+	this.plan(count, captureStack(this.plan));
+}
+
+const testMap = new WeakMap();
 class ExecutionContext {
 	constructor(test) {
-		Object.defineProperties(this, {
-			_test: {value: test},
-			skip: {value: new SkipApi(test)}
-		});
-	}
+		testMap.set(this, test);
 
-	log() {
-		const args = Array.from(arguments, value => {
-			return typeof value === 'string' ?
-				value :
-				concordance.format(value, concordanceOptions);
-		});
+		const skip = () => {
+			test.countPassedAssertion();
+		};
+		const boundPlan = plan.bind(test);
+		boundPlan.skip = () => {};
 
-		if (args.length > 0) {
-			this._test.addLog(args.join(' '));
-		}
-	}
-
-	plan(ct) {
-		this._test.plan(ct, captureStack(this.plan));
+		Object.defineProperties(this, assertionNames.reduce((props, name) => {
+			props[name] = {value: assertions[name].bind(test)};
+			props[name].value.skip = skip;
+			return props;
+		}, {
+			log: {value: log.bind(test)},
+			plan: {value: boundPlan}
+		}));
 	}
 
 	get end() {
-		const end = this._test.bindEndCallback();
+		const end = testMap.get(this).bindEndCallback();
 		const endFn = err => end(err, captureStack(endFn));
 		return endFn;
 	}
 
 	get title() {
-		return this._test.title;
+		return testMap.get(this).title;
 	}
 
 	get context() {
-		return this._test.contextRef.get();
+		return testMap.get(this).contextRef.get();
 	}
 
 	set context(context) {
-		this._test.contextRef.set(context);
+		testMap.get(this).contextRef.set(context);
 	}
 
 	_throwsArgStart(assertion, file, line) {
-		this._test.trackThrows({assertion, file, line});
+		testMap.get(this).trackThrows({assertion, file, line});
 	}
 
 	_throwsArgEnd() {
-		this._test.trackThrows(null);
+		testMap.get(this).trackThrows(null);
 	}
-}
-
-{
-	const assertions = assert.wrapAssertions({
-		pass(executionContext) {
-			executionContext._test.countPassedAssertion();
-		},
-
-		pending(executionContext, promise) {
-			executionContext._test.addPendingAssertion(promise);
-		},
-
-		fail(executionContext, error) {
-			executionContext._test.addFailedAssertion(error);
-		}
-	});
-	Object.assign(ExecutionContext.prototype, assertions);
-
-	function skipFn() {
-		this._test.countPassedAssertion();
-	}
-	Object.keys(assertions).forEach(el => {
-		SkipApi.prototype[el] = skipFn;
-	});
 }
 
 class Test {

--- a/readme.md
+++ b/readme.md
@@ -851,6 +851,23 @@ test('unicorns are truthy', t => {
 });
 ```
 
+Assertions are bound to their test so you can assign them to a variable or pass them around:
+
+```js
+test('unicorns are truthy', t => {
+	const truthy = t.thruthy;
+	truthy('unicorn');
+});
+```
+
+Assertions can be skipped by adding `.skip()`:
+
+```js
+test('unicorns are truthy', t => {
+	t.truthy.skip('unicorn');
+});
+```
+
 If multiple assertion failures are encountered within a single test, AVA will only display the *first* one.
 
 ### `.pass([message])`
@@ -1040,7 +1057,7 @@ Any assertion can be skipped using the `skip` modifier. Skipped assertions are s
 ```js
 test('skip assertion', t => {
 	t.plan(2);
-	t.skip.is(foo(), 5); // No need to change your plan count when skipping
+	t.is.skip(foo(), 5); // No need to change your plan count when skipping
 	t.is(1, 1);
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -992,6 +992,8 @@ Assert that `error` is falsy.
 
 Compares the `expected` value with a previously recorded snapshot. Snapshots are stored for each test, so ensure you give your tests unique titles. Alternatively pass an `options` object to select a specific snapshot, for instance `{id: 'my snapshot'}`.
 
+Snapshot assertions cannot be skipped when snapshots are being updated.
+
 ## Snapshot testing
 
 AVA supports snapshot testing, [as introduced by Jest](https://facebook.github.io/jest/docs/snapshot-testing.html), through its [Assertions](#assertions) interface. You can snapshot any value as well as React elements:


### PR DESCRIPTION
* Assertions are now bound. Fixes #1592.
* Assertions are now skipped by calling `.skip()` at the end, e.g. `t.fail.skip()`. This is consistent with the test interface, where `skip()` can only be used at the end of the chain.
* The private `t._test` value has been removed. Instead a WeakMap is used internally to look up the corresponding Test instance given an ExecutionContext.
* Fix `t.snapshot.skip()`. Ensure subsequent `t.snapshot()` calls compare the correct snapshot. Forbid snapshots from being skipped while updating them. Fixes #1425.
