### PR TITLE
Do not clobber forked process color level.

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -4,7 +4,16 @@ const path = require('path');
 const fs = require('fs');
 const Promise = require('bluebird');
 const debug = require('debug')('ava');
+const supportsColor = require('supports-color');
 const AvaError = require('./ava-error');
+
+const colorLevels = {
+	0: 'false',
+	1: 'true',
+	2: '256',
+	3: '16m'
+};
+const currentColorLevel = colorLevels[supportsColor.level];
 
 if (fs.realpathSync(__filename) !== __filename) {
 	console.warn('WARNING: `npm link ava` and the `--preserve-symlink` flag are incompatible. We have detected that AVA is linked via `npm link`, and that you are using either an early version of Node 6, or the `--preserve-symlink` flag. This breaks AVA. You should upgrade to Node 6.2.0+, avoid the `--preserve-symlink` flag, or avoid using `npm link ava`.');
@@ -34,7 +43,8 @@ module.exports = (file, opts, execArgv) => {
 		} : false
 	}, opts);
 
-	const args = [JSON.stringify(opts), opts.color ? '--color' : '--no-color'].concat(opts.workerArgv);
+	const colorArg = opts.color ? `--color=${currentColorLevel}` : '--no-color';
+	const args = [JSON.stringify(opts), colorArg].concat(opts.workerArgv);
 
 	const ps = childProcess.fork(path.join(__dirname, 'test-worker.js'), args, {
 		cwd: opts.projectDir,


### PR DESCRIPTION
Cherry picked changes from #1455 to resolve #1701

---

Chalk uses `supports-color` to determine what color level should be
rendered. However, currently our parent `ava` process uses that to
colorize its output, however, when we fork our test processes we clobber
the color configuration that `supports-color` uses to determine the
level (see https://github.com/chalk/supports-color/blob/master/index.js#L37-L42)

This PR carries the current color level through to the forked processes
so if they log output that is colorized it will remain so with the same
fidelity of colors as the parent ava process.
