### PR TITLE
Fix --fail-fast accidentally interrupting test files

### DIFF
--- a/api.js
+++ b/api.js
@@ -98,10 +98,10 @@ class Api extends EventEmitter {
 					runStatus.on('test', test => {
 						if (test.error) {
 							bailed = true;
-						}
 
-						for (const fork of pendingForks) {
-							fork.notifyOfPeerFailure();
+							for (const fork of pendingForks) {
+								fork.notifyOfPeerFailure();
+							}
 						}
 					});
 				}

--- a/test/api.js
+++ b/test/api.js
@@ -385,6 +385,37 @@ test('fail-fast mode - timeout & serial', t => {
 		});
 });
 
+test('fail-fast mode - no errors', t => {
+	const api = apiCreator({
+		failFast: true
+	});
+
+	const tests = [];
+	const errors = [];
+
+	api.on('test-run', runStatus => {
+		runStatus.on('test', test => {
+			tests.push({
+				ok: !test.error,
+				title: test.title
+			});
+		});
+		runStatus.on('error', err => {
+			errors.push(err);
+		});
+	});
+
+	return api.run([
+		path.join(__dirname, 'fixture/fail-fast/without-error/a.js'),
+		path.join(__dirname, 'fixture/fail-fast/without-error/b.js')
+	])
+		.then(result => {
+			t.ok(api.options.failFast);
+			t.is(result.passCount, 2);
+			t.is(result.failCount, 0);
+		});
+});
+
 test('serial execution mode', t => {
 	const api = apiCreator({
 		serial: true

--- a/test/fixture/fail-fast/without-error/a.js
+++ b/test/fixture/fail-fast/without-error/a.js
@@ -1,0 +1,3 @@
+import test from '../../../..';
+
+test('pass', t => t.pass());

--- a/test/fixture/fail-fast/without-error/b.js
+++ b/test/fixture/fail-fast/without-error/b.js
@@ -1,0 +1,5 @@
+import test from '../../../..';
+
+setTimeout(() => {
+  test.serial('pass', t => t.pass());
+}, 2000);


### PR DESCRIPTION
The interrupt call wasn't properly guarded and ran whenever a test result was received, rather than when a test failed.
