### PR TITLE
Remove the `t.ifError` assert method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,6 @@ export interface Assertions {
 	fail(message?: string): void;
 	false(actual: any, message?: string): void;
 	falsy(actual: any, message?: string): void;
-	ifError(error: any, message?: string): void;
 	is<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
 	not<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
 	notDeepEqual<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;

--- a/index.js.flow
+++ b/index.js.flow
@@ -27,7 +27,6 @@ export interface Assertions {
 	fail(message?: string): void;
 	false(actual: any, message?: string): void;
 	falsy(actual: any, message?: string): void;
-	ifError(error: any, message?: string): void;
 	is(actual: any, expected: any, message?: string): void;
 	not(actual: any, expected: any, message?: string): void;
 	notDeepEqual(actual: any, expected: any, message?: string): void;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -461,18 +461,6 @@ function wrapAssertions(callbacks) {
 			pass(this);
 		},
 
-		ifError(actual, message) {
-			if (actual) {
-				fail(this, new AssertionError({
-					assertion: 'ifError',
-					message,
-					values: [formatWithLabel('Error:', actual)]
-				}));
-			} else {
-				pass(this);
-			}
-		},
-
 		snapshot(expected, optionsOrMessage, message) {
 			const options = {};
 			if (typeof optionsOrMessage === 'string') {

--- a/readme.md
+++ b/readme.md
@@ -990,10 +990,6 @@ Assert that `contents` matches `regex`.
 
 Assert that `contents` does not match `regex`.
 
-### `.ifError(error, [message])`
-
-Assert that `error` is falsy.
-
 ### `.snapshot(expected, [message])`
 ### `.snapshot(expected, [options], [message])`
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -1123,18 +1123,6 @@ test('.notThrows() fails if passed a bad value', t => {
 	t.end();
 });
 
-test('.ifError()', t => {
-	fails(t, () => {
-		assertions.ifError(new Error());
-	});
-
-	passes(t, () => {
-		assertions.ifError(null);
-	});
-
-	t.end();
-});
-
 test('.snapshot()', t => {
 	// Set to `true` to update the snapshot, then run:
 	// "$(npm bin)"/tap --no-cov -R spec test/assert.js

--- a/test/test.js
+++ b/test/test.js
@@ -411,7 +411,7 @@ test('fails with thrown non-error object', t => {
 
 test('skipped assertions count towards the plan', t => {
 	const instance = ava(a => {
-		a.plan(16);
+		a.plan(15);
 		a.pass.skip();
 		a.fail.skip();
 		a.is.skip(1, 1);
@@ -422,7 +422,6 @@ test('skipped assertions count towards the plan', t => {
 			throw new Error(); // eslint-disable-line unicorn/error-message
 		});
 		a.notThrows.skip(() => {});
-		a.ifError.skip(null);
 		a.snapshot.skip({});
 		a.truthy.skip(true);
 		a.falsy.skip(false);
@@ -433,14 +432,14 @@ test('skipped assertions count towards the plan', t => {
 	});
 	return instance.run().then(result => {
 		t.is(result.passed, true);
-		t.is(instance.planCount, 16);
-		t.is(instance.assertCount, 16);
+		t.is(instance.planCount, 15);
+		t.is(instance.assertCount, 15);
 	});
 });
 
 test('assertion.skip() is bound', t => {
 	const instance = ava(a => {
-		a.plan(16);
+		a.plan(15);
 		(a.pass.skip)();
 		(a.fail.skip)();
 		(a.is.skip)(1, 1);
@@ -451,7 +450,6 @@ test('assertion.skip() is bound', t => {
 			throw new Error(); // eslint-disable-line unicorn/error-message
 		});
 		(a.notThrows.skip)(() => {});
-		(a.ifError.skip)(null);
 		(a.snapshot.skip)({});
 		(a.truthy.skip)(true);
 		(a.falsy.skip)(false);
@@ -462,8 +460,8 @@ test('assertion.skip() is bound', t => {
 	});
 	return instance.run().then(result => {
 		t.is(result.passed, true);
-		t.is(instance.planCount, 16);
-		t.is(instance.assertCount, 16);
+		t.is(instance.planCount, 15);
+		t.is(instance.assertCount, 15);
 	});
 });
 
@@ -699,7 +697,7 @@ test('log from tests', t => {
 test('assertions are bound', t => {
 	// This does not test .fail() and .snapshot(). It'll suffice.
 	return ava(a => {
-		(a.plan)(14);
+		(a.plan)(13);
 		(a.pass)();
 		(a.is)(1, 1);
 		(a.not)(1, 2);
@@ -709,7 +707,6 @@ test('assertions are bound', t => {
 			throw new Error(); // eslint-disable-line unicorn/error-message
 		});
 		(a.notThrows)(() => {});
-		(a.ifError)(null);
 		(a.truthy)(true);
 		(a.falsy)(false);
 		(a.true)(true);


### PR DESCRIPTION
Fixes #1720 

Remove `ifError()` method , remove `t.ifError` documentation on readme and update affected tests

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
