### PR TITLE
Move to Spectrum

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -5,7 +5,7 @@
 - We realize there is a lot of data requested here. We ask only that you do your best to provide as much information as possible so we can better help you.
 - Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md).
 - Support questions are better asked in one of the following locations:
-	- [Our chat](https://gitter.im/avajs/ava)
+	- [Our chat](https://spectrum.chat/ava)
 	- [Stack Overflow](https://stackoverflow.com/questions/tagged/ava)
 - Ensure the issue isn't already reported.
 - Should be reproducible with the latest AVA version.

--- a/contributing.md
+++ b/contributing.md
@@ -44,11 +44,11 @@ If you're updating dependencies, please make sure you use npm@5.6.0 and commit t
 
 ### Hang out in our chat
 
-We have a [chat](https://gitter.im/avajs/ava). Jump in there and lurk, talk to us, and help others.
+We have a [chat](https://spectrum.chat/ava). Jump in there and lurk, talk to us, and help others.
 
 ## Submitting an issue
 
-- The issue tracker is for issues. Use our [chat](https://gitter.im/avajs/ava) or [Stack Overflow](https://stackoverflow.com/questions/tagged/ava) for support.
+- The issue tracker is for issues. Use our [chat](https://spectrum.chat/ava) or [Stack Overflow](https://stackoverflow.com/questions/tagged/ava) for support.
 - Search the issue tracker before opening an issue.
 - Ensure you're using the latest version of AVA.
 - Use a clear and descriptive title.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,8 @@
 
 > Futuristic test runner
 
-[![Build Status: Linux](https://travis-ci.org/avajs/ava.svg?branch=master)](https://travis-ci.org/avajs/ava) [![Build status: Windows](https://ci.appveyor.com/api/projects/status/e7v91mu2m5x48ehx/branch/master?svg=true)](https://ci.appveyor.com/project/ava/ava/branch/master) [![Coverage Status](https://coveralls.io/repos/github/avajs/ava/badge.svg?branch=master)](https://coveralls.io/github/avajs/ava?branch=master) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo) [![Gitter](https://badges.gitter.im/join_chat.svg)](https://gitter.im/avajs/ava) [![Mentioned in Awesome Node.js](https://awesome.re/mentioned-badge.svg)](https://github.com/sindresorhus/awesome-nodejs)
+[![Build Status: Linux](https://travis-ci.org/avajs/ava.svg?branch=master)](https://travis-ci.org/avajs/ava) [![Build status: Windows](https://ci.appveyor.com/api/projects/status/e7v91mu2m5x48ehx/branch/master?svg=true)](https://ci.appveyor.com/project/ava/ava/branch/master) [![Coverage Status](https://coveralls.io/repos/github/avajs/ava/badge.svg?branch=master)](https://coveralls.io/github/avajs/ava?branch=master) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo) [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/ava)
+ [![Mentioned in Awesome Node.js](https://awesome.re/mentioned-badge.svg)](https://github.com/sindresorhus/awesome-nodejs)
 
 Even though JavaScript is single-threaded, IO in Node.js can happen in parallel due to its async nature. AVA takes advantage of this and runs your tests concurrently, which is especially beneficial for IO heavy tests. In addition, test files are run in parallel as separate processes, giving you even better performance and an isolated environment for each test file. [Switching](https://github.com/sindresorhus/pageres/commit/663be15acb3dd2eb0f71b1956ef28c2cd3fdeed0) from Mocha to AVA in Pageres brought the test time down from 31 to 11 seconds. Having tests run concurrently forces you to write atomic tests, meaning tests don't depend on global state or the state of other tests, which is a great thing!
 
@@ -1176,7 +1177,7 @@ It's the [Andromeda galaxy](https://simple.wikipedia.org/wiki/Andromeda_galaxy).
 ## Support
 
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/ava)
-- [Gitter chat](https://gitter.im/avajs/ava)
+- [Spectrum](https://spectrum.chat/ava)
 - [Twitter](https://twitter.com/ava__js)
 
 ## Related


### PR DESCRIPTION
As Gitter's development seems to have slowed since their acquisition by GitLab we're moving our chat to Spectrum. It's a new product so still rough around the edges, but it's way more than a chat room which we think will be quite useful for the AVA community.

Come join us at https://spectrum.chat/ava!