### PR TITLE
Update readme.md to include running init with npx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ Your `package.json` will then look like this:
 }
 ```
 
-NOTE: Running `npx` requires [`npm` version `5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually configure the `test` script in your `package.json` to use `ava` (see above).
+NOTE: Running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually configure the `test` script in your `package.json` to use `ava` (see above).
 
 ### Create your test file
 

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ $ npm install ava@next --save-dev
 $ npx ava --init
 ```
 
-If you prefer using `yarn`:
+If you prefer using [Yarn](https://yarnpkg.com/en/):
 
 ```console
 $ yarn add --dev ava@next
@@ -95,12 +95,12 @@ Your `package.json` will then look like this:
 		"test": "ava"
 	},
 	"devDependencies": {
-		"ava": "^1.0.0-beta.1"
+		"ava": "^1.0.0-beta.3"
 	}
 }
 ```
 
-NOTE: Running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually configure the `test` script in your `package.json` to use `ava` (see above).
+Running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually configure the `test` script in your `package.json` to use `ava` (see above).
 
 ### Create your test file
 

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,13 @@ Alternatively using Yarn:
 $ yarn add --dev ava@next
 ```
 
-You'll have to configure the `test` script in your `package.json` to use `ava` (see above).
+If you're running at least npm@5.2.0, you can run ava setup with:
+
+```console
+$ npx ava --init
+```
+
+Otherwise, you'll have to configure the `test` script in your `package.json` to use `ava` (see above).
 
 ### Create your test file
 

--- a/readme.md
+++ b/readme.md
@@ -72,14 +72,14 @@ test('arrays are equal', t => {
 
 ### Add AVA to your project
 
-Install AVA and run it with --init to add AVA to your package.json:
+Install AVA and run it with `--init` to add AVA to your `package.json`:
 
 ```console
 $ npm install ava@next --save-dev
 $ npx ava --init
 ```
 
-If you prefer using Yarn:
+If you prefer using `yarn`:
 
 ```console
 $ yarn add --dev ava@next

--- a/readme.md
+++ b/readme.md
@@ -72,19 +72,18 @@ test('arrays are equal', t => {
 
 ### Add AVA to your project
 
-Install AVA globally and run it with `--init` to add AVA to your `package.json`.
-
+Install AVA and run it with --init to add AVA to your package.json:
 
 ```console
-$ npm install --global ava@next
-$ ava --init
+$ npm install ava@next --save-dev
+$ npx ava --init
 ```
 
 If you prefer using Yarn:
 
 ```console
-$ yarn global add ava@next
-$ ava --init
+$ yarn add --dev ava@next
+$ yarn run ava --init
 ```
 
 Your `package.json` will then look like this:
@@ -101,29 +100,8 @@ Your `package.json` will then look like this:
 }
 ```
 
-Any arguments passed after `--init` are added as config to `package.json`.
-
-#### Manual installation
-
-You can also install AVA directly:
-
-```console
-$ npm install --save-dev ava@next
-```
-
-Alternatively using Yarn:
-
-```console
-$ yarn add --dev ava@next
-```
-
-If you're running at least npm@5.2.0, you can run ava setup with:
-
-```console
-$ npx ava --init
-```
-
-Otherwise, you'll have to configure the `test` script in your `package.json` to use `ava` (see above).
+NOTE: Running `npx` requires `npm` version `0.5.2` or greater. Otherwise, you'll have to 
+configure the `test` script in your `package.json` to use `ava` (see above).
 
 ### Create your test file
 

--- a/readme.md
+++ b/readme.md
@@ -100,8 +100,7 @@ Your `package.json` will then look like this:
 }
 ```
 
-NOTE: Running `npx` requires `npm` version `0.5.2` or greater. Otherwise, you'll have to 
-configure the `test` script in your `package.json` to use `ava` (see above).
+NOTE: Running `npx` requires [`npm` version `5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually configure the `test` script in your `package.json` to use `ava` (see above).
 
 ### Create your test file
 


### PR DESCRIPTION
Added instructions for running `ava --init` with `npx` when installing ava locally and at least `npm@0.5.2`