### PR TITLE
Replace --init flag with npx recommendation

### DIFF
--- a/docs/recipes/debugging-with-webstorm.md
+++ b/docs/recipes/debugging-with-webstorm.md
@@ -19,7 +19,7 @@ Save the configuration.
 
 ## Setup using npm
 
-Execute `ava --init` in your project directory to add AVA to your `package.json`.
+Execute `npx ava-init` in your project directory to add AVA to your `package.json`.
 
 Your `package.json` will look something like this:
 
@@ -46,7 +46,7 @@ Your IDE will then execute `npm run test` and thus call `node_modules/.bin/ava` 
 
 In the `Node parameters`, for Node.js 7+ pass `--inspect-brk` or `--debug-brk` for earlier versions.
 
-Don't forget to select a Node.js interpreter. 
+Don't forget to select a Node.js interpreter.
 
 Save the configuration.
 

--- a/docs/recipes/debugging-with-webstorm.md
+++ b/docs/recipes/debugging-with-webstorm.md
@@ -19,7 +19,7 @@ Save the configuration.
 
 ## Setup using npm
 
-Execute `npx ava-init` in your project directory to add AVA to your `package.json`.
+Execute `npx @ava/init` in your project directory to add AVA to your `package.json`.
 
 Your `package.json` will look something like this:
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -30,7 +30,6 @@ exports.run = () => {
 		  ava [<file|directory|glob> ...]
 
 		Options
-		  --init                  Add AVA to your project
 		  --watch, -w             Re-run tests when tests and source files change
 		  --match, -m             Only run tests with matching title (Can be repeated)
 		  --update-snapshots, -u  Update snapshots
@@ -49,15 +48,11 @@ exports.run = () => {
 		  ava test.js test2.js
 		  ava test-*.js
 		  ava test
-		  ava --init
 
 		Default patterns when no arguments:
 		test.js test-*.js test/**/*.js **/__tests__/**/*.js **/*.test.js
 	`, {
 		flags: {
-			init: {
-				type: 'boolean'
-			},
 			watch: {
 				type: 'boolean',
 				alias: 'w'
@@ -115,11 +110,6 @@ exports.run = () => {
 	});
 
 	updateNotifier({pkg: cli.pkg}).notify();
-
-	if (cli.flags.init) {
-		require('ava-init')();
-		return;
-	}
 
 	if (cli.flags.watch && cli.flags.tap && !conf.tap) {
 		throw new Error(`${colors.error(figures.cross)} The TAP reporter is not available when using watch mode.`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -892,11 +892,6 @@
         "arr-flatten": "1.1.0"
       }
     },
-    "arr-exclude": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
-    },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
@@ -983,61 +978,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.0.tgz",
       "integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA=="
-    },
-    "ava-init": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
-      "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-      "requires": {
-        "arr-exclude": "1.0.0",
-        "execa": "0.7.0",
-        "has-yarn": "1.0.0",
-        "read-pkg-up": "2.0.0",
-        "write-pkg": "3.1.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "4.0.2",
-            "shebang-command": "1.2.0",
-            "which": "1.2.14"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        },
-        "sort-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-          "requires": {
-            "is-plain-obj": "1.1.0"
-          }
-        },
-        "write-pkg": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
-          "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-          "requires": {
-            "sort-keys": "2.0.0",
-            "write-json-file": "2.2.0"
-          }
-        }
-      }
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -4479,7 +4419,8 @@
     "has-yarn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
+      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
+      "dev": true
     },
     "hawk": {
       "version": "3.1.3",
@@ -5260,6 +5201,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -7837,6 +7779,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -7902,6 +7845,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
       "requires": {
         "pify": "2.3.0"
       }
@@ -7915,7 +7859,8 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -8195,6 +8140,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
       "requires": {
         "load-json-file": "2.0.0",
         "normalize-package-data": "2.3.8",
@@ -8205,6 +8151,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "read-pkg": "2.0.0"
@@ -8758,6 +8705,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
       "requires": {
         "is-plain-obj": "1.1.0"
       }
@@ -9987,6 +9935,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.2.0.tgz",
       "integrity": "sha1-UYYlBruzthnu+reFnx/WxtBTCHY=",
+      "dev": true,
       "requires": {
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
@@ -9999,7 +9948,8 @@
         "detect-indent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
 		"array-uniq": "^1.0.2",
 		"arrify": "^1.0.0",
 		"auto-bind": "^1.2.0",
-		"ava-init": "^0.2.1",
 		"bluebird": "^3.5.1",
 		"caching-transform": "^1.0.0",
 		"chalk": "^2.3.1",

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ Your `package.json` will then look like this:
 }
 ```
 
-Running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually install `ava` and configure the `test` script in your `package.json` (see above).
+Initialization will work with npm and Yarn, but running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater to be installed. Otherwise, you'll have to manually install `ava` (`npm i -D ava`) and configure the `test` script in your `package.json` (see above).
 
 ### Create your test file
 

--- a/readme.md
+++ b/readme.md
@@ -72,18 +72,10 @@ test('arrays are equal', t => {
 
 ### Add AVA to your project
 
-Install AVA and run it with `--init` to add AVA to your `package.json`:
+To install and set up AVA, run:
 
 ```console
-$ npm install ava@next --save-dev
-$ npx ava --init
-```
-
-If you prefer using [Yarn](https://yarnpkg.com/en/):
-
-```console
-$ yarn add --dev ava@next
-$ yarn run ava --init
+$ npx ava-init
 ```
 
 Your `package.json` will then look like this:
@@ -100,7 +92,7 @@ Your `package.json` will then look like this:
 }
 ```
 
-Running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually configure the `test` script in your `package.json` to use `ava` (see above).
+Running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater. Otherwise, you'll have to manually install `ava` and configure the `test` script in your `package.json` (see above).
 
 ### Create your test file
 

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ test('arrays are equal', t => {
 To install and set up AVA, run:
 
 ```console
-$ npx ava-init
+$ npx @ava/init --next
 ```
 
 Your `package.json` will then look like this:

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,17 @@ Your `package.json` will then look like this:
 }
 ```
 
-Initialization will work with npm and Yarn, but running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater to be installed. Otherwise, you'll have to manually install `ava` (`npm i -D ava`) and configure the `test` script in your `package.json` (see above).
+Initialization will work with npm and Yarn, but running `npx` requires [`npm@5.2.0`](https://github.com/npm/npm/releases/tag/v5.2.0) or greater to be installed. Otherwise, you'll have to manually install `ava` and configure the `test` script in your `package.json` as per above:
+
+```console
+$ npm install --save-dev ava@next
+```
+
+Or if you prefer using Yarn:
+
+```console
+$ yarn add --dev ava@next
+```
 
 ### Create your test file
 


### PR DESCRIPTION
Fixes #1737.

This removes the `--init` flag and associated dependency on `ava-init` in favor of recommending `npx ava-init`. See the linked issue for reasoning.

Happy to update this to `@ava/init` if the package is republished there. 😊

(Does yarn have an npx equivalent? Maybe it doesn't matter, since Yarn users presumably also have npx installed.)