### PR TITLE
Remove unecessary `--` from `--watch` example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ $ npm test
 ### Watch it
 
 ```console
-$ npm test -- --watch
+$ npm test --watch
 ```
 
 AVA comes with an intelligent watch mode. [Learn more in its recipe](docs/recipes/watch-mode.md).


### PR DESCRIPTION
Fixing a typo in watch example on `README.md`