### PR TITLE
[WIP] Use babel-register's source-map-support

### DIFF
--- a/lib/process-adapter.js
+++ b/lib/process-adapter.js
@@ -2,7 +2,6 @@
 const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('ava');
-const sourceMapSupport = require('source-map-support');
 const installPrecompiler = require('require-precompiled');
 
 // Parse and re-emit AVA messages
@@ -74,6 +73,17 @@ const sourceMapCache = new Map();
 const cacheDir = opts.cacheDir;
 
 exports.installSourceMapSupport = () => {
+	// Workaround for https://github.com/avajs/ava/issues/974
+	const sourceMapSupport = (() => {
+		try {
+			/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
+			if (require.resolve('babel-register') in require.cache) {
+				return require('babel-register/node_modules/source-map-support');
+			}
+			/* eslint-enable import/no-extraneous-dependencies, import/no-unresolved */
+		} catch (err) {}
+		return require('source-map-support');
+	})();
 	sourceMapSupport.install({
 		environment: 'node',
 		handleUncaughtExceptions: false,


### PR DESCRIPTION
If babel-register is used in the test process, AVA needs to use its
version of source-map-support. Multiple source-map-supports in use in
the same process don't work together, and can cause stack trace line
numbers to be incorrect.

Fixes #974.

---

Note: no automated tests for this yet. It might take me a while to figure out how to write a good one, but I figured I'd submit this as a work in progress to get early feedback.