### PR TITLE
Watcher no longer runs all tests when a snap file is deleted (issue #1511)

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -172,7 +172,7 @@ class AvaFiles {
 
 		// Same defaults as used for Chokidar
 		if (!hasPositivePattern) {
-			mixedPatterns = ['package.json', '**/*.js'].concat(mixedPatterns);
+			mixedPatterns = ['package.json', '**/*.js', '**/*.snap'].concat(mixedPatterns);
 		}
 
 		filePath = matchable(filePath);


### PR DESCRIPTION
This pull request has made the change suggested by [novemberborn](https://github.com/avajs/ava/issues/1511#issuecomment-328351206) to resolve issue #1511. 

**Testing Changes:**
    Starting the watcher with two test files:
    ![image](https://user-images.githubusercontent.com/14276431/37919107-0216d3ee-30f1-11e8-9cac-2eae9ab1c15f.png)
    deleting test2.snap:
    ![image](https://user-images.githubusercontent.com/14276431/37919285-774dd090-30f1-11e8-84e0-db64254fe9d8.png)
    deleting test.snap:
    ![image](https://user-images.githubusercontent.com/14276431/37919332-9090907e-30f1-11e8-8c82-e58f5ea01c10.png)
    Changing Test2.js
    ![image](https://user-images.githubusercontent.com/14276431/37920259-602dd394-30f4-11e8-9ce4-fc5ffa607c40.png)