### PR TITLE
Document how to exclude a directory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,7 +235,7 @@ AVA automatically removes unrelated lines in stack traces, allowing you to find 
 
 ## Configuration
 
-All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. To ignore a file or group of files, prefix an ! to your pattern.
+All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. To ignore a file or directory of files, prefix an ! to your pattern.
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -243,8 +243,8 @@ To ignore a file or directory, prefix the pattern with an `!` (exclamation mark)
 {
 	"ava": {
 		"files": [
-			"my-test-directory/*.js",
-			"!exclude-this-directory/*.js",
+			"my-test-directory/**/*.js",
+			"!my-test-directory/exclude-this-directory/**/*.js",
 			"!**/exclude-this-file.js"
 		],
 		"source": [

--- a/readme.md
+++ b/readme.md
@@ -235,7 +235,7 @@ AVA automatically removes unrelated lines in stack traces, allowing you to find 
 
 ## Configuration
 
-All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. Any patterns prefixed with an ! are ignore patterns.  
+All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. To ignore a file or group of files, prefix an ! to your pattern.
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -235,7 +235,7 @@ AVA automatically removes unrelated lines in stack traces, allowing you to find 
 
 ## Configuration
 
-All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. To ignore a file or directory of files, prefix an ! to your pattern.
+All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. To ignore a file or directory, prefix an ! to your pattern.
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -235,13 +235,16 @@ AVA automatically removes unrelated lines in stack traces, allowing you to find 
 
 ## Configuration
 
-All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. To ignore a file or directory, prefix an ! to your pattern.
+All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. 
+
+To ignore a file or directory, prefix the pattern with an `!` (exclamation mark).
 
 ```json
 {
 	"ava": {
 		"files": [
 			"my-test-folder/*.js",
+			"!exclude-this-folder/*.js",
 			"!**/exclude-this-file.js"
 		],
 		"source": [

--- a/readme.md
+++ b/readme.md
@@ -235,14 +235,14 @@ AVA automatically removes unrelated lines in stack traces, allowing you to find 
 
 ## Configuration
 
-All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt.
+All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. Any patterns prefixed with an ! are ignore patterns.  
 
 ```json
 {
 	"ava": {
 		"files": [
 			"my-test-folder/*.js",
-			"!**/not-this-file.js"
+			"!**/exclude-this-file.js"
 		],
 		"source": [
 			"**/*.{js,jsx}",

--- a/readme.md
+++ b/readme.md
@@ -235,11 +235,7 @@ AVA automatically removes unrelated lines in stack traces, allowing you to find 
 
 ## Configuration
 
-<<<<<<< HEAD
-All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt. 
-=======
 All of the CLI options can be configured in the `ava` section of your `package.json`. This allows you to modify the default behavior of the `ava` command, so you don't have to repeatedly type the same options on the command prompt.
->>>>>>> 24aa6d909431db6c5ade7dc7471fea265f0d8265
 
 To ignore a file or directory, prefix the pattern with an `!` (exclamation mark).
 
@@ -247,8 +243,8 @@ To ignore a file or directory, prefix the pattern with an `!` (exclamation mark)
 {
 	"ava": {
 		"files": [
-			"my-test-folder/*.js",
-			"!exclude-this-folder/*.js",
+			"my-test-directory/*.js",
+			"!exclude-this-directory/*.js",
 			"!**/exclude-this-file.js"
 		],
 		"source": [


### PR DESCRIPTION
This pull request fixes #1750, a need for better documenting of ignore patterns . Before creating this issue user vjpr was unable to find documention on this issue with keyword searches. I added a simple explanation using the words 'ignore' and 'exclude'  so that users unsure how to ignore tests will also be more likely to find my explanation in keyword searches. 
I also changed not-this-file.js to exclude-this-file.js to provide a clearer example to users reading the documentation. 