### PR TITLE
Fix Missing Import In bench/run.js

### DIFF
--- a/bench/run.js
+++ b/bench/run.js
@@ -2,6 +2,7 @@
 const childProcess = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const Promise = require('bluebird');
 const arrify = require('arrify');
 const makeDir = require('make-dir');
 const branch = require('git-branch').sync(path.join(__dirname, '..'));


### PR DESCRIPTION
`bench/run.js` did not import `bluebird` but used `Promise.each()` which resulted in an error.

![Image](https://user-images.githubusercontent.com/35649991/38160920-cb3ac998-34e2-11e8-8693-925b300b26cb.png)

