### PR TITLE
t.fail: return never instead of void

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ export interface DeepEqualAssertion {
 
 export interface FailAssertion {
 	/** Fail the test. */
-	(message?: string): void;
+	(message?: string): never;
 
 	/** Skip this assertion. */
 	skip(message?: string): void;


### PR DESCRIPTION
Changes the TypeScript declaration of `t.fail` to return `never` instead of `void`. It'is more correct because the call will never exit with a return value.

This allows to use `t.fail` in shorthand arrow callbacks:

```ts
declare function doStuff(param: string, cb: () => number): void;

test('doStuff', (t) => {
  // this is now possible
  doStuff('foo', () => t.fail('should not be called'));
  
  // before the change you would need to actually return something
  doStuff('foo', () => t.fail('should not be called') || 0);
  // or throw
  doStuff('foo', () => { throw t.fail('should never be called'); });
});
```

Since `never` is assignable to everything, this will not break existing code.