### PR TITLE
Add inline docs to Assertions interface in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,20 +26,61 @@ export type SnapshotOptions = {
 };
 
 export interface Assertions {
+	/** Assert that `actual` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
 	deepEqual: DeepEqualAssertion;
+
+	/** Fail the test. */
 	fail: FailAssertion;
+
+	/** Assert that `actual` is strictly false. */
 	false: FalseAssertion;
+
+	/** Assert that `actual` is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy). */
 	falsy: FalsyAssertion;
+
+	/**
+	 * Assert that `actual` is [the same
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	 */
 	is: IsAssertion;
+
+	/**
+	 * Assert that `actual` is not [the same
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	*/
 	not: NotAssertion;
+	
+	/** Assert that `actual` is not [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
 	notDeepEqual: NotDeepEqualAssertion;
+
+	/** Assert that `string` does not match the regular expression. */
 	notRegex: NotRegexAssertion;
+
+	/** Assert that the function does not throw. */
 	notThrows: NotThrowsAssertion;
+
+	/** Count a passing assertion. */
 	pass: PassAssertion;
+
+	/** Assert that `string` matches the regular expression. */
 	regex: RegexAssertion;
+
+	/**
+	 * Assert that `expected` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to a
+	 * previously recorded [snapshot](https://github.com/concordancejs/concordance#serialization-details), or if
+	 * necessary record a new snapshot.
+	*/
 	snapshot: SnapshotAssertion;
+
+	/**
+	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
+	*/
 	throws: ThrowsAssertion;
+
+	/** Assert that `actual` is strictly true. */
 	true: TrueAssertion;
+
+	/** Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy). */
 	truthy: TruthyAssertion;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,9 +47,9 @@ export interface Assertions {
 	/**
 	 * Assert that `actual` is not [the same
 	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
-	*/
+	 */
 	not: NotAssertion;
-	
+
 	/** Assert that `actual` is not [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
 	notDeepEqual: NotDeepEqualAssertion;
 
@@ -69,12 +69,12 @@ export interface Assertions {
 	 * Assert that `expected` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to a
 	 * previously recorded [snapshot](https://github.com/concordancejs/concordance#serialization-details), or if
 	 * necessary record a new snapshot.
-	*/
+	 */
 	snapshot: SnapshotAssertion;
 
 	/**
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
-	*/
+	 */
 	throws: ThrowsAssertion;
 
 	/** Assert that `actual` is strictly true. */

--- a/index.js.flow
+++ b/index.js.flow
@@ -46,15 +46,15 @@ export interface Assertions {
 	/**
 	 * Assert that `actual` is [the same
 	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
-	*/
+	 */
 	is: IsAssertion;
 
 	/**
 	 * Assert that `actual` is not [the same
 	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
-	*/
+	 */
 	not: NotAssertion;
-	
+
 	/** Assert that `actual` is not [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
 	notDeepEqual: NotDeepEqualAssertion;
 
@@ -74,12 +74,12 @@ export interface Assertions {
 	 * Assert that `expected` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to a
 	 * previously recorded [snapshot](https://github.com/concordancejs/concordance#serialization-details), or if
 	 * necessary record a new snapshot.
-	*/
+	 */
 	snapshot: SnapshotAssertion;
 
 	/**
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
-	*/
+	 */
 	throws: ThrowsAssertion;
 
 	/** Assert that `actual` is strictly true. */

--- a/index.js.flow
+++ b/index.js.flow
@@ -31,20 +31,61 @@ export type SnapshotOptions = {
 };
 
 export interface Assertions {
+	/** Assert that `actual` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
 	deepEqual: DeepEqualAssertion;
+
+	/** Fail the test. */
 	fail: FailAssertion;
+
+	/** Assert that `actual` is strictly false. */
 	false: FalseAssertion;
+
+	/** Assert that `actual` is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy). */
 	falsy: FalsyAssertion;
+
+	/**
+	 * Assert that `actual` is [the same
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	 */
 	is: IsAssertion;
+
+	/**
+	 * Assert that `actual` is not [the same
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	*/
 	not: NotAssertion;
+	
+	/** Assert that `actual` is not [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
 	notDeepEqual: NotDeepEqualAssertion;
+
+	/** Assert that `string` does not match the regular expression. */
 	notRegex: NotRegexAssertion;
+
+	/** Assert that the function does not throw. */
 	notThrows: NotThrowsAssertion;
+
+	/** Count a passing assertion. */
 	pass: PassAssertion;
+
+	/** Assert that `string` matches the regular expression. */
 	regex: RegexAssertion;
+
+	/**
+	 * Assert that `expected` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to a
+	 * previously recorded [snapshot](https://github.com/concordancejs/concordance#serialization-details), or if
+	 * necessary record a new snapshot.
+	*/
 	snapshot: SnapshotAssertion;
+
+	/**
+	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
+	*/
 	throws: ThrowsAssertion;
+
+	/** Assert that `actual` is strictly true. */
 	true: TrueAssertion;
+
+	/** Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy). */
 	truthy: TruthyAssertion;
 }
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -46,7 +46,7 @@ export interface Assertions {
 	/**
 	 * Assert that `actual` is [the same
 	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
-	 */
+	*/
 	is: IsAssertion;
 
 	/**


### PR DESCRIPTION
I believe it is valuable to have inline docs here. If I type `t.` in my editor I like to be able to scroll through all the assertion options and see what they do.