### PR TITLE
Escape backticks in pronuncation of AVA

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1131,7 +1131,7 @@ In contrast AVA is highly opinionated and runs tests concurrently, with a separa
 
 ### How is the name written and pronounced?
 
-AVA, not Ava or ava. Pronounced [`/ˈeɪvə/` ay-və](media/pronunciation.m4a?raw=true).
+AVA, not Ava or ava. Pronounced [\`/ˈeɪvə/\` ay-və](media/pronunciation.m4a?raw=true).
 
 ### What is the header background?
 


### PR DESCRIPTION
In the README, github interprets the backticks in the pronucaion of AVA as code delimiters.

I added `\` before the backticks which prevents this formatting.

I don't understand the phonetic alphabet so I am not 100% sure that it is now correct but there definately should not be code formatting here.

Before: `/ˈeɪvə/` ay-və
Now: \`/ˈeɪvə/\` ay-və
 