### PR TITLE
Update Flow type `PromiseLike` to be compatible with libdefs in Flow v0.70.0

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -1,6 +1,9 @@
 // @flow
 export interface PromiseLike<R> {
-	then<U>(onFulfill?: (value: R) => Promise<U> | U, onReject?: (error: any) => Promise<U> | U): Promise<U>;
+	then<U>(
+		onFulfill: (value: R) => Promise<U> | U,
+		onReject?: (error: any) => Promise<U> | U
+	): Promise<U>;
 }
 
 export interface ObservableLike {


### PR DESCRIPTION
The previous definition of `PromiseLike` gives the `onFulfill` argument to the `then` method as optional. This is not compatible with the libdefs for `Promise` in Flow v0.70.0. Those libdefs were changed as is explained in the Flow changelog:

> Existing Promise libdefs for the cases where null or void is passed as callbacks to then and catch caused us to miss type errors. These libdefs have now been made stricter.

As a result Flow emits an error for every asynchronous test.

The change in this commit changes the `onFulfill` argument to be mandatory so that `PromiseLike` is compatible with the definitions of `Promise` in both Flow v0.70.0 and Flow v0.69.0.

Flow's libdefs changed in v0.70.0 to use overloaded signatures for `then`. It is still possible in v0.70.0 to call `then` with no arguments. But as far as I can tell there is no way to write `PromiseLike` in a way that allows `then` to be called with no arguments that is compatible with both Flow v0.70.0 and Flow v0.69.0.