### PR TITLE
Fix minor typo in Readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -844,7 +844,7 @@ Assertions are bound to their test so you can assign them to a variable or pass 
 
 ```js
 test('unicorns are truthy', t => {
-	const truthy = t.thruthy;
+	const truthy = t.truthy;
 	truthy('unicorn');
 });
 ```


### PR DESCRIPTION
I think there's a (trivial) typo in the documentation here, in the bound assertions example.
(`thruthy` should be `truthy`)

Thanks!