### PR TITLE
Disregard cached Babel options if JS source files are used

### DIFF
--- a/lib/babel-config.js
+++ b/lib/babel-config.js
@@ -11,6 +11,9 @@ const syntaxAsyncGeneratorsPath = require.resolve('@babel/plugin-syntax-async-ge
 const syntaxObjectRestSpreadPath = require.resolve('@babel/plugin-syntax-object-rest-spread');
 const transformTestFilesPath = require.resolve('@ava/babel-preset-transform-test-files');
 
+const BASE_CONFIG_PSEUDO_SOURCE = '(AVA) baseConfig';
+const COMPILE_ENHANCEMENTS_PSEUDO_SOURCE = '(AVA) compileEnhancements';
+
 function validate(conf) {
 	if (conf === false) {
 		return null;
@@ -60,7 +63,7 @@ function verifyExistingOptions(verifierFile, baseConfig, cache, envName) {
 						fs.writeFileSync(verifierFile, result.verifier.toBuffer());
 					}
 
-					return result.cacheKeys;
+					return result;
 				});
 		});
 }
@@ -134,7 +137,7 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 		fileType: 'JSON',
 		hash: md5Hex(JSON.stringify(baseOptions)),
 		options: baseOptions,
-		source: '(AVA) baseConfig'
+		source: BASE_CONFIG_PSEUDO_SOURCE
 	});
 
 	let intermediateConfig = baseConfig;
@@ -165,16 +168,29 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 					[transformTestFilesPath, {powerAssert: true}]
 				]
 			},
-			source: '(AVA) compileEnhancements'
+			source: COMPILE_ENHANCEMENTS_PSEUDO_SOURCE
 		});
 		finalConfig.extend(intermediateConfig);
 	}
 
 	const cache = configManager.prepareCache();
 	return verifyExistingOptions(verifierFile, finalConfig, cache, envName)
-		.then(cacheKeys => {
-			if (cacheKeys) {
-				return cacheKeys;
+		.then(result => {
+			if (result) {
+				// If there are *.js source files, the cache cannot be used since these
+				// files must be loaded *into* the cache before getting options.
+				// Loading just the source files into the cache is insufficient:
+				// plugins and presets must *also* be loaded, *and* given the correct
+				// auto-generated name so they can override the same plugin / preset
+				// instances declared in parent config files. Fall through to the
+				// resolveOptions() call below.
+				const hasJsSources = result.verifier.sources.some(({source}) => {
+					return source !== BASE_CONFIG_PSEUDO_SOURCE && source !== COMPILE_ENHANCEMENTS_PSEUDO_SOURCE && source.endsWith('.js');
+				});
+
+				if (!hasJsSources) {
+					return result.cacheKeys;
+				}
 			}
 
 			return resolveOptions(finalConfig, cache, envName, optionsFile, verifierFile);

--- a/test/babel-config.js
+++ b/test/babel-config.js
@@ -102,6 +102,11 @@ test('supports .babelrc.js files', t => {
 			t.is(options.presets[0][0].wrapped, require('@ava/babel-preset-stage-4'));
 			t.is(options.presets[1][0].wrapped, require('@ava/babel-preset-transform-test-files'));
 			t.same(options.presets[1][1], {powerAssert: true});
+
+			// Repeat, using the cached verifier files.
+			return babelConfigHelper.build(projectDir, cacheDir, {testOptions: {}}, compileEnhancements);
+		}).then(result => {
+			t.doesNotThrow(() => result.getOptions());
 		});
 });
 


### PR DESCRIPTION
If there are *.js source files, the cache cannot be used since these files must be loaded *into* the cache before getting options. Loading just the source files into the cache is insufficient: plugins and presets must *also* be loaded, *and* given the correct auto-generated name so they can override the same plugin / preset instances declared in parent config files.

Fixes https://github.com/novemberborn/hullabaloo-config-manager/issues/29.

@vjpr could you give this a try?