### PR TITLE
docs: add missing esm config instructions to es modules recipe

### DIFF
--- a/docs/recipes/es-modules.md
+++ b/docs/recipes/es-modules.md
@@ -26,6 +26,24 @@ Configure it in your `package.json` file, and add it to AVA's `"require"` option
 
 By default AVA converts ES module syntax to CommonJS. [You can disable this](./babel.md#preserve-es-module-syntax).
 
+Additionally, [configure](https://github.com/standard-things/esm#options) the `esm`, instructing it to enable top-level await in modules without ESM exports and CJS features in ESM.
+
+Your package.json will now contain a setup, similar to:
+
+```json
+"esm": {
+	"await": true,
+	"cjs": true
+},
+"ava": {
+	"compileEnhancements": false,
+	"require": [
+		"esm"
+	],
+	"verbose": true
+},
+```
+
 You can now use native ES modules with AVA:
 
 ```js


### PR DESCRIPTION
Currently, our recipe for ES modules workflow is missing the `esm` config. I followed its instructions myself and for example, in [this](https://github.com/codsen/array-of-arrays-sort-by-col/tree/0ace6a1befeeee911524896221fd105f9bff45c3) library, ava accepted the raw, untranspiled ES modules code only when called with `nyc` in front:

```
nyc --require esm --reporter=html --reporter=text ava
```
Simply calling `ava` from command line would resulted in "Unexpected identifier" errors where first `import` is not recognised. Even though, exactly as per instructions, `ava` `require` `esm` was present!

Adding `esm` config into `package.json` solves this problem.

The `package.json` example in here is taken from a library `array-of-arrays-sort-by-col`, where I tested the code.