### PR TITLE
Handle Babel not returning source maps

### DIFF
--- a/lib/babel-pipeline.js
+++ b/lib/babel-pipeline.js
@@ -122,9 +122,9 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 		const partialTestConfig = babel.loadPartialConfig(Object.assign({
 			babelrc: false,
 			babelrcRoots: [projectDir],
-			configFile: false,
-			cwd: projectDir
+			configFile: false
 		}, userOptions && userOptions.testOptions, {
+			cwd: projectDir,
 			envName,
 			inputSourceMap,
 			filename,

--- a/lib/babel-pipeline.js
+++ b/lib/babel-pipeline.js
@@ -122,13 +122,13 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 		const partialTestConfig = babel.loadPartialConfig(Object.assign({
 			babelrc: false,
 			babelrcRoots: [projectDir],
-			configFile: false
+			configFile: false,
+			sourceMaps: true
 		}, userOptions && userOptions.testOptions, {
 			cwd: projectDir,
 			envName,
 			inputSourceMap,
-			filename,
-			sourceMaps: true
+			filename
 		}));
 
 		// TODO: Check for `partialTestConfig.config` and include a hash of the file
@@ -178,14 +178,19 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 
 		const {code, map} = babel.transformSync(inputCode, options);
 
-		// Save source map
-		const mapPath = `${cachePath}.map`;
-		writeFileAtomic.sync(mapPath, JSON.stringify(map));
+		if (map) {
+			// Save source map
+			const mapPath = `${cachePath}.map`;
+			writeFileAtomic.sync(mapPath, JSON.stringify(map));
 
-		// Append source map comment to transformed code so that other libraries
-		// (like nyc) can find the source map.
-		const comment = convertSourceMap.generateMapFileComment(mapPath);
-		writeFileAtomic.sync(cachePath, `${code}\n${comment}`);
+			// Append source map comment to transformed code so that other libraries
+			// (like nyc) can find the source map.
+			const comment = convertSourceMap.generateMapFileComment(mapPath);
+			writeFileAtomic.sync(cachePath, `${code}\n${comment}`);
+		} else {
+			writeFileAtomic.sync(cachePath, code);
+		}
+
 		return cachePath;
 	};
 }

--- a/lib/worker/precompiler-hook.js
+++ b/lib/worker/precompiler-hook.js
@@ -4,18 +4,25 @@ const sourceMapSupport = require('source-map-support');
 const installPrecompiler = require('require-precompiled');
 const options = require('./options').get();
 
-const sourceMapCache = new Map();
-
 function installSourceMapSupport() {
 	sourceMapSupport.install({
 		environment: 'node',
 		handleUncaughtExceptions: false,
-		retrieveSourceMap(source) {
-			if (sourceMapCache.has(source)) {
-				return {
-					url: source,
-					map: fs.readFileSync(sourceMapCache.get(source), 'utf8')
-				};
+		retrieveSourceMap(url) {
+			const precompiled = options.precompiled[url];
+			if (!precompiled) {
+				return null;
+			}
+
+			try {
+				const map = fs.readFileSync(`${precompiled}.map`, 'utf8');
+				return {url, map};
+			} catch (err) {
+				if (err.code === 'ENOENT') {
+					return null;
+				}
+
+				throw err;
 			}
 		}
 	});
@@ -26,13 +33,9 @@ function install() {
 
 	installPrecompiler(filename => {
 		const precompiled = options.precompiled[filename];
-
-		if (precompiled) {
-			sourceMapCache.set(filename, `${precompiled}.map`);
-			return fs.readFileSync(precompiled, 'utf8');
-		}
-
-		return null;
+		return precompiled ?
+			fs.readFileSync(precompiled, 'utf8') :
+			null;
 	});
 }
 exports.install = install;

--- a/test/api.js
+++ b/test/api.js
@@ -373,6 +373,33 @@ test('stack traces for exceptions are corrected using a source map file', t => {
 		});
 });
 
+test('babel.testOptions can disable sourceMaps', t => {
+	t.plan(3);
+
+	const api = apiCreator({
+		babelConfig: {
+			testOptions: {
+				sourceMaps: false
+			}
+		},
+		cacheEnabled: true
+	});
+
+	api.on('run', plan => {
+		plan.status.on('stateChange', evt => {
+			if (evt.type === 'uncaught-exception') {
+				t.match(evt.err.message, /Thrown by source-map-fixtures/);
+				t.match(evt.err.stack, /^.*?Immediate\b.*source-map-file.js:7.*$/m);
+			}
+		});
+	});
+
+	return api.run([path.join(__dirname, 'fixture/source-map-file.js')])
+		.then(runStatus => {
+			t.is(runStatus.stats.passedTests, 1);
+		});
+});
+
 test('stack traces for exceptions are corrected using a source map file in what looks like a browser env', t => {
 	t.plan(4);
 


### PR DESCRIPTION
See commits. The first one is a follow-up to #1798, the second fixes #1804.