### PR TITLE
Ensure assertion message is a string

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -32,6 +32,9 @@ const hasOwnProperty = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, 
 
 class AssertionError extends Error {
 	constructor(opts) {
+		if (opts.message !== undefined && typeof opts.message !== 'string') {
+			throw new TypeError('Assertion message must be a string');
+		}
 		super(opts.message || '');
 		this.name = 'AssertionError';
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -169,6 +169,14 @@ function eventuallyPasses(t, fn) {
 	});
 }
 
+test('AssertionError throws when message is not a string', t => {
+	const input = new Error('an error object');
+	const AssertionError = assert.AssertionError;
+	const expectedError = new TypeError('Assertion message must be a string');
+	t.throws(() => new AssertionError({message: input}), expectedError);
+	t.end();
+});
+
 test('.pass()', t => {
 	passes(t, () => {
 		assertions.pass();


### PR DESCRIPTION
This adds a typecheck for the optional assertion message parameter, ensuring it's a string if it is provided. Implementation is the same as in #1174, but this time with a test. 

Fixes #1125.
