### PR TITLE
Make links point to specific git tag

### DIFF
--- a/lib/babel-pipeline.js
+++ b/lib/babel-pipeline.js
@@ -8,6 +8,7 @@ const isPlainObject = require('is-plain-object');
 const md5Hex = require('md5-hex');
 const packageHash = require('package-hash');
 const stripBomBuf = require('strip-bom-buf');
+const pkg = require('../package.json');
 const chalk = require('./chalk').get();
 
 function getSourceMap(filePath, code) {
@@ -46,7 +47,7 @@ function validate(conf) {
 		(conf.testOptions !== undefined && !isPlainObject(conf.testOptions)) ||
 		(conf.extensions !== undefined && !isValidExtensions(conf.extensions))
 	) {
-		throw new Error(`Unexpected Babel configuration for AVA. See ${chalk.underline('https://github.com/avajs/ava/blob/master/docs/recipes/babel.md')} for allowed values.`);
+		throw new Error(`Unexpected Babel configuration for AVA. See ${chalk.underline(`https://github.com/avajs/ava/blob/v${pkg.version}/docs/recipes/babel.md`)} for allowed values.`);
 	}
 
 	return {

--- a/lib/reporters/improper-usage-messages.js
+++ b/lib/reporters/improper-usage-messages.js
@@ -1,5 +1,6 @@
 'use strict';
 const chalk = require('../chalk').get();
+const pkg = require('../../package.json');
 
 exports.forError = error => {
 	if (!error.improperUsage) {
@@ -14,7 +15,7 @@ exports.forError = error => {
 
 Visit the following URL for more details:
 
-  ${chalk.blue.underline('https://github.com/avajs/ava#throwsfunctionpromise-error-message')}`;
+  ${chalk.blue.underline(`https://github.com/avajs/ava/blob/v${pkg.version}/readme.md#throwsthrower-expected-message`)}`;
 	}
 
 	if (assertion === 'snapshot') {

--- a/test/cli.js
+++ b/test/cli.js
@@ -10,6 +10,7 @@ const touch = require('touch');
 const uniqueTempDir = require('unique-temp-dir');
 const execa = require('execa');
 const stripAnsi = require('strip-ansi');
+const pkg = require('../package.json');
 
 const cliPath = path.join(__dirname, '../cli.js');
 
@@ -79,7 +80,7 @@ for (const which of [
 
 			let expectedOutput = '\n';
 			expectedOutput += figures.cross + ' Unexpected Babel configuration for AVA.';
-			expectedOutput += ' See https://github.com/avajs/ava/blob/master/docs/recipes/babel.md for allowed values.';
+			expectedOutput += ` See https://github.com/avajs/ava/blob/v${pkg.version}/docs/recipes/babel.md for allowed values.`;
 			expectedOutput += '\n';
 
 			t.is(stderr, expectedOutput);

--- a/test/helper/report.js
+++ b/test/helper/report.js
@@ -5,6 +5,7 @@ const path = require('path');
 const globby = require('globby');
 const proxyquire = require('proxyquire');
 const replaceString = require('replace-string');
+const pkg = require('../../package.json');
 
 let _Api = null;
 const createApi = options => {
@@ -72,7 +73,8 @@ exports.sanitizers = {
 			return str;
 		}
 		return str === 'stdout\n' || str === 'stderr\n' ? '' : str;
-	}
+	},
+	version: str => replaceString(str, `v${pkg.version}`, 'v1.0.0-beta.5.1')
 };
 
 const run = (type, reporter) => {

--- a/test/reporters/mini.js
+++ b/test/reporters/mini.js
@@ -15,7 +15,7 @@ const run = type => t => {
 
 	const tty = new TTYStream({
 		columns: 200,
-		sanitizers: [report.sanitizers.cwd, report.sanitizers.posix, report.sanitizers.unreliableProcessIO]
+		sanitizers: [report.sanitizers.cwd, report.sanitizers.posix, report.sanitizers.unreliableProcessIO, report.sanitizers.version]
 	});
 	const reporter = new MiniReporter({
 		spinner: {

--- a/test/reporters/mini.regular.log
+++ b/test/reporters/mini.regular.log
@@ -207,7 +207,7 @@ stderr
 
   Visit the following URL for more details:
 
-    [34m[4mhttps://github.com/avajs/ava#throwsfunctionpromise-error-message[24m[39m
+    [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:35:9)[39m
   [90mt (test.js:37:11)[39m
@@ -236,7 +236,7 @@ stderr
 
   Visit the following URL for more details:
 
-    [34m[4mhttps://github.com/avajs/ava#throwsfunctionpromise-error-message[24m[39m
+    [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:42:9)[39m
   [90mt (test.js:44:14)[39m

--- a/test/reporters/verbose.js
+++ b/test/reporters/verbose.js
@@ -15,7 +15,7 @@ const run = type => t => {
 
 	const tty = new TTYStream({
 		columns: 200,
-		sanitizers: [report.sanitizers.cwd, report.sanitizers.posix, report.sanitizers.slow, report.sanitizers.unreliableProcessIO]
+		sanitizers: [report.sanitizers.cwd, report.sanitizers.posix, report.sanitizers.slow, report.sanitizers.unreliableProcessIO, report.sanitizers.version]
 	});
 	const reporter = new VerboseReporter({
 		reportStream: tty,

--- a/test/reporters/verbose.regular.log
+++ b/test/reporters/verbose.regular.log
@@ -179,7 +179,7 @@ stderr
 
   Visit the following URL for more details:
 
-    [34m[4mhttps://github.com/avajs/ava#throwsfunctionpromise-error-message[24m[39m
+    [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:35:9)[39m
   [90mt (test.js:37:11)[39m
@@ -208,7 +208,7 @@ stderr
 
   Visit the following URL for more details:
 
-    [34m[4mhttps://github.com/avajs/ava#throwsfunctionpromise-error-message[24m[39m
+    [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:42:9)[39m
   [90mt (test.js:44:14)[39m


### PR DESCRIPTION
Prevents the documentation links that AVA returns from going out of date.

Closes #1757.