### PR TITLE
Fix snapshot report merging.

### DIFF
--- a/lib/snapshot-manager.js
+++ b/lib/snapshot-manager.js
@@ -82,11 +82,11 @@ function tryRead(file) {
 }
 
 function withoutLineEndings(buffer) {
-	let newLength = buffer.byteLength - 1;
-	while (buffer[newLength] === 0x0A || buffer[newLength] === 0x0D) {
-		newLength--;
+	let checkPosition = buffer.byteLength - 1;
+	while (buffer[checkPosition] === 0x0A || buffer[checkPosition] === 0x0D) {
+		checkPosition--;
 	}
-	return buffer.slice(0, newLength);
+	return buffer.slice(0, checkPosition + 1);
 }
 
 function formatEntry(label, descriptor) {


### PR DESCRIPTION
Rename `newLength` to `checkPosition` to make the function clearer.
At the end of the loop `checkPosition` points to the last index that
does not contain a line ending, so add one to include it.

Fixes #1848 