### PR TITLE
Fix ObservableLike interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export interface ObservableLike {
     next: (value: any) => void,
     error?: (error: any) => void,
     complete?: () => void,
-  ): ObservableSubscription;
+  ): Subscription;
 }
 
 export type Constructor = (new (...args: Array<any>) => any);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,20 @@
+export interface Subscription {
+  unsubscribe(): void;
+}
+
+export interface Observer {
+  next?: (value: any) => void;
+  error?: (error: any) => void;
+  complete?: () => void;
+}
+
 export interface ObservableLike {
-	subscribe(observer: (value: any) => void): void;
+	subscribe(observer: Observer): Subscription;
+	subscribe(
+    next: (value: any) => void,
+    error?: (error: any) => void,
+    complete?: () => void,
+  ): ObservableSubscription;
 }
 
 export type Constructor = (new (...args: Array<any>) => any);

--- a/index.js.flow
+++ b/index.js.flow
@@ -22,7 +22,7 @@ export interface ObservableLike {
     next: (value: any) => void,
     error?: (error: any) => void,
     complete?: () => void,
-  ): ObservableSubscription;
+  ): Subscription;
 }
 
 export type Constructor = Class<{constructor(...args: Array<any>): any}>;

--- a/index.js.flow
+++ b/index.js.flow
@@ -6,8 +6,23 @@ export interface PromiseLike<R> {
 	): Promise<U>;
 }
 
+export interface Subscription {
+  unsubscribe(): void;
+}
+
+export interface Observer {
+  +next?: (value: any) => void;
+  +error?: (error: any) => void;
+  +complete?: () => void;
+}
+
 export interface ObservableLike {
-	subscribe(observer: (value: any) => void): void;
+	subscribe(observer: Observer): Subscription;
+	subscribe(
+    next: (value: any) => void,
+    error?: (error: any) => void,
+    complete?: () => void,
+  ): ObservableSubscription;
 }
 
 export type Constructor = Class<{constructor(...args: Array<any>): any}>;


### PR DESCRIPTION
`subscribe` method of `ObservableLike` is incompatible with ES Observable `subscribe` method: https://github.com/tc39/proposal-observable#observable

I fix it in this PR. Before, I forced to annotate `test` callbacks like:

```js
test('Subject', (t): any => {
  ...
```