### PR TITLE
Remove test export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -801,8 +801,6 @@ declare const test: TestInterface;
 /** Call to declare a test, or chain to declare hooks or test modifiers */
 export default test;
 
-export {test};
-
 /** Call to declare a hook that is run once, after all tests have passed, or chain to declare modifiers. */
 export const after: AfterInterface;
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -774,9 +774,6 @@ export interface TodoDeclaration {
 /** Call to declare a test, or chain to declare hooks or test modifiers */
 declare export default TestInterface<>;
 
-/** Call to declare a test, or chain to declare hooks or test modifiers */
-declare export var test: TestInterface<>;
-
 /** Call to declare a hook that is run after each passing test, or chain to declare modifiers. */
 declare export var after: AfterInterface<>;
 

--- a/lib/worker/main.js
+++ b/lib/worker/main.js
@@ -16,6 +16,5 @@ const makeCjsExport = () => {
 // unavoidable.
 module.exports = Object.assign(makeCjsExport(), {
 	__esModule: true,
-	default: runner.chain,
-	test: runner.chain
+	default: runner.chain
 });


### PR DESCRIPTION
Fixes #1862. The `test()` method is already available as the default export.
