### PR TITLE
Remove observable support in t.throws() and t.notThrows()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -161,17 +161,11 @@ export interface NotThrowsAssertion {
 	/** Assert that the function does not throw. */
 	(fn: () => never, message?: string): void;
 
-	/** Assert that the function returns an observable that does not error. You must await the result. */
-	(fn: () => ObservableLike, message?: string): Promise<void>;
-
 	/** Assert that the function returns a promise that does not reject. You must await the result. */
 	(fn: () => PromiseLike<any>, message?: string): Promise<void>;
 
 	/** Assert that the function does not throw. */
 	(fn: () => any, message?: string): void;
-
-	/** Assert that the observable does not error. You must await the result. */
-	(observable: ObservableLike, message?: string): Promise<void>;
 
 	/** Assert that the promise does not reject. You must await the result. */
 	(promise: PromiseLike<any>, message?: string): Promise<void>;
@@ -249,37 +243,6 @@ export interface ThrowsAssertion {
 	(fn: () => never, expectations: ThrowsExpectation, message?: string): any;
 
 	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result.
-	 */
-	(fn: () => ObservableLike, expectations?: null, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must be an instance of the given constructor.
-	 */
-	(fn: () => ObservableLike, constructor: Constructor, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must have a message that matches the regular
-	 * expression.
-	 */
-	(fn: () => ObservableLike, regex: RegExp, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must have a message equal to `errorMessage`.
-	 */
-	(fn: () => ObservableLike, errorMessage: string, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must satisfy all expectations.
-	 */
-	(fn: () => ObservableLike, expectations: ThrowsExpectation, message?: string): Promise<any>;
-
-	/**
 	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
 	 * If so, returns the rejection reason. You must await the result.
 	 */
@@ -340,36 +303,6 @@ export interface ThrowsAssertion {
 	 * The error must satisfy all expectations.
 	 */
 	(fn: () => any, expectations: ThrowsExpectation, message?: string): any;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result.
-	 */
-	(promise: ObservableLike, expectations?: null, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must be an instance of the given constructor.
-	 */
-	(promise: ObservableLike, constructor: Constructor, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must have a message that matches the regular expression.
-	 */
-	(promise: ObservableLike, regex: RegExp, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must have a message equal to `errorMessage`.
-	 */
-	(promise: ObservableLike, errorMessage: string, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must satisfy all expectations.
-	 */
-	(promise: ObservableLike, expectations: ThrowsExpectation, message?: string): Promise<any>;
 
 	/**
 	 * Assert that the promise rejects with [an error](https://www.npmjs.com/package/is-error). If so, returns the

--- a/index.js.flow
+++ b/index.js.flow
@@ -166,17 +166,11 @@ export interface NotRegexAssertion {
 }
 
 export interface NotThrowsAssertion {
-	/** Assert that the function returns an observable that does not error. You must await the result. */
-	(fn: () => ObservableLike, message?: string): Promise<void>;
-
 	/** Assert that the function returns a promise that does not reject. You must await the result. */
 	(fn: () => PromiseLike<any>, message?: string): Promise<void>;
 
 	/** Assert that the function does not throw. */
 	(fn: () => any, message?: string): void;
-
-	/** Assert that the observable does not error. You must await the result. */
-	(observable: ObservableLike, message?: string): Promise<void>;
 
 	/** Assert that the promise does not reject. You must await the result. */
 	(promise: PromiseLike<any>, message?: string): Promise<void>;
@@ -224,37 +218,6 @@ export interface SnapshotAssertion {
 }
 
 export interface ThrowsAssertion {
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result.
-	 */
-	(fn: () => ObservableLike, expectations?: null, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must be an instance of the given constructor.
-	 */
-	(fn: () => ObservableLike, constructor: Constructor, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must have a message that matches the regular
-	 * expression.
-	 */
-	(fn: () => ObservableLike, regex: RegExp, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must have a message equal to `errorMessage`.
-	 */
-	(fn: () => ObservableLike, errorMessage: string, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns an observable that errors with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the error value. You must await the result. The error must satisfy all expectations.
-	 */
-	(fn: () => ObservableLike, expectations: ThrowsExpectation, message?: string): Promise<any>;
-
 	/**
 	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
 	 * If so, returns the rejection reason. You must await the result.
@@ -316,36 +279,6 @@ export interface ThrowsAssertion {
 	 * The error must satisfy all expectations.
 	 */
 	(fn: () => any, expectations: ThrowsExpectation, message?: string): any;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result.
-	 */
-	(promise: ObservableLike, expectations?: null, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must be an instance of the given constructor.
-	 */
-	(promise: ObservableLike, constructor: Constructor, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must have a message that matches the regular expression.
-	 */
-	(promise: ObservableLike, regex: RegExp, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must have a message equal to `errorMessage`.
-	 */
-	(promise: ObservableLike, errorMessage: string, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the observable errors with [an error](https://www.npmjs.com/package/is-error). If so, returns the error
-	 * value. You must await the result. The error must satisfy all expectations.
-	 */
-	(promise: ObservableLike, expectations: ThrowsExpectation, message?: string): Promise<any>;
 
 	/**
 	 * Assert that the promise rejects with [an error](https://www.npmjs.com/package/is-error). If so, returns the

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,8 +1,6 @@
 'use strict';
 const concordance = require('concordance');
-const observableToPromise = require('observable-to-promise');
 const isError = require('is-error');
-const isObservable = require('is-observable');
 const isPromise = require('is-promise');
 const concordanceOptions = require('./concordance-options').default;
 const concordanceDiffOptions = require('./concordance-options').diff;
@@ -160,11 +158,11 @@ function wrapAssertions(callbacks) {
 		},
 
 		throws(thrower, expected, message) { // eslint-disable-line complexity
-			if (typeof thrower !== 'function' && !isPromise(thrower) && !isObservable(thrower)) {
+			if (typeof thrower !== 'function' && !isPromise(thrower)) {
 				fail(this, new AssertionError({
 					assertion: 'throws',
 					improperUsage: true,
-					message: '`t.throws()` must be called with a function, observable or promise',
+					message: '`t.throws()` must be called with a function or promise',
 					values: [formatWithLabel('Called with:', thrower)]
 				}));
 				return;
@@ -240,7 +238,7 @@ function wrapAssertions(callbacks) {
 			}
 
 			// Note: this function *must* throw exceptions, since it can be used
-			// as part of a pending assertion for observables and promises.
+			// as part of a pending assertion for promises.
 			const assertExpected = (actual, prefix, stack) => {
 				if (!isError(actual)) {
 					throw new AssertionError({
@@ -324,26 +322,6 @@ function wrapAssertions(callbacks) {
 				}
 			};
 
-			const handleObservable = (observable, wasReturned) => {
-				// Record stack before it gets lost in the promise chain.
-				const stack = getStack();
-				const intermediate = observableToPromise(observable).then(value => {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [formatWithLabel(`${wasReturned ? 'Returned observable' : 'Observable'} completed with:`, value)]
-					});
-				}, reason => {
-					assertExpected(reason, `${wasReturned ? 'Returned observable' : 'Observable'} errored with`, stack);
-					return reason;
-				});
-
-				pending(this, intermediate);
-				// Don't reject the returned promise, even if the assertion fails.
-				return intermediate.catch(noop);
-			};
-
 			const handlePromise = (promise, wasReturned) => {
 				// Record stack before it gets lost in the promise chain.
 				const stack = getStack();
@@ -368,10 +346,6 @@ function wrapAssertions(callbacks) {
 				return handlePromise(thrower, false);
 			}
 
-			if (isObservable(thrower)) {
-				return handleObservable(thrower, false);
-			}
-
 			let retval;
 			let actual;
 			let threw = false;
@@ -385,10 +359,6 @@ function wrapAssertions(callbacks) {
 			if (!threw) {
 				if (isPromise(retval)) {
 					return handlePromise(retval, true);
-				}
-
-				if (isObservable(retval)) {
-					return handleObservable(retval, true);
 				}
 
 				fail(this, new AssertionError({
@@ -410,31 +380,15 @@ function wrapAssertions(callbacks) {
 		},
 
 		notThrows(nonThrower, message) {
-			if (typeof nonThrower !== 'function' && !isPromise(nonThrower) && !isObservable(nonThrower)) {
+			if (typeof nonThrower !== 'function' && !isPromise(nonThrower)) {
 				fail(this, new AssertionError({
 					assertion: 'notThrows',
 					improperUsage: true,
-					message: '`t.notThrows()` must be called with a function, observable or promise',
+					message: '`t.notThrows()` must be called with a function or promise',
 					values: [formatWithLabel('Called with:', nonThrower)]
 				}));
 				return;
 			}
-
-			const handleObservable = (observable, wasReturned) => {
-				// Record stack before it gets lost in the promise chain.
-				const stack = getStack();
-				const intermediate = observableToPromise(observable).then(noop, reason => {
-					throw new AssertionError({
-						assertion: 'notThrows',
-						message,
-						stack,
-						values: [formatWithLabel(`${wasReturned ? 'Returned observable' : 'Observable'} errored with:`, reason)]
-					});
-				});
-				pending(this, intermediate);
-				// Don't reject the returned promise, even if the assertion fails.
-				return intermediate.catch(noop);
-			};
 
 			const handlePromise = (promise, wasReturned) => {
 				// Record stack before it gets lost in the promise chain.
@@ -456,10 +410,6 @@ function wrapAssertions(callbacks) {
 				return handlePromise(nonThrower, false);
 			}
 
-			if (isObservable(nonThrower)) {
-				return handleObservable(nonThrower, false);
-			}
-
 			let retval;
 			try {
 				retval = nonThrower();
@@ -474,10 +424,6 @@ function wrapAssertions(callbacks) {
 
 			if (isPromise(retval)) {
 				return handlePromise(retval, true);
-			}
-
-			if (isObservable(retval)) {
-				return handleObservable(retval, true);
 			}
 
 			pass(this);

--- a/readme.md
+++ b/readme.md
@@ -946,7 +946,7 @@ Assert that `value` is not deeply equal to `expected`. The inverse of `.deepEqua
 
 ### `.throws(thrower, [expected, [message]])`
 
-Assert that an error is thrown. `thrower` can be a function which should throw, or return a promise that should reject, or an observable that should error. Alternatively a promise or observable can be passed directly.
+Assert that an error is thrown. `thrower` can be a function which should throw, or return a promise that should reject. Alternatively a promise can be passed directly.
 
 The thrown value *must* be an error. It is returned so you can run more assertions against it.
 
@@ -985,7 +985,7 @@ test('rejects', async t => {
 });
 ```
 
-When testing an observable or promise you must wait for the assertion to complete:
+When testing a promise you must wait for the assertion to complete:
 
 ```js
 test('rejects', async t => {
@@ -1005,9 +1005,9 @@ test('throws', async t => {
 
 ### `.notThrows(nonThrower, [message])`
 
-Assert that no error is thrown. `thrower` can be a function which shouldn't throw, or return a promise that should resolve, or an observable that should complete. Alternatively a promise or an observable can be passed directly.
+Assert that no error is thrown. `thrower` can be a function which shouldn't throw, or return a promise that should resolve. Alternatively a promise can be passed directly.
 
-Like the `.throws()` assertion, when testing a promise or an observable you must wait for the assertion to complete:
+Like the `.throws()` assertion, when testing a promise you must wait for the assertion to complete:
 
 ```js
 test('resolves', async t => {

--- a/test/assert.js
+++ b/test/assert.js
@@ -7,7 +7,6 @@ const stripAnsi = require('strip-ansi');
 const React = require('react');
 const renderer = require('react-test-renderer');
 const test = require('tap').test;
-const Observable = require('zen-observable');
 const assert = require('../lib/assert');
 const snapshotManager = require('../lib/snapshot-manager');
 const Test = require('../lib/test');
@@ -876,49 +875,6 @@ test('.throws()', gather(t => {
 			{label: 'Expected message to match:', formatted: /\/def\//}
 		]
 	});
-
-	const complete = arg => Observable.of(arg);
-	const error = err => new Observable(observer => observer.error(err));
-
-	// Fails because the observable completed, not errored.
-	eventuallyFailsWith(t, () => assertions.throws(complete('foo')), {
-		assertion: 'throws',
-		message: '',
-		values: [{label: 'Observable completed with:', formatted: /'foo'/}]
-	});
-
-	// Fails because the observable completed with an Error
-	eventuallyFailsWith(t, () => assertions.throws(complete(new Error())), {
-		assertion: 'throws',
-		message: '',
-		values: [{label: 'Observable completed with:', formatted: /Error/}]
-	});
-
-	// Fails because the function returned a observable that completed, not rejected.
-	eventuallyFailsWith(t, () => assertions.throws(() => complete('foo')), {
-		assertion: 'throws',
-		message: '',
-		values: [{label: 'Returned observable completed with:', formatted: /'foo'/}]
-	});
-
-	// Passes because the observable errored with an error.
-	eventuallyPasses(t, () => assertions.throws(error(new Error())));
-
-	// Passes because the function returned an observable errored with an error.
-	eventuallyPasses(t, () => assertions.throws(() => error(new Error())));
-
-	// Passes because the error's message matches the regex
-	eventuallyPasses(t, () => assertions.throws(error(new Error('abc')), /abc/));
-
-	// Fails because the error's message does not match the regex
-	eventuallyFailsWith(t, () => assertions.throws(error(new Error('abc')), /def/), {
-		assertion: 'throws',
-		message: '',
-		values: [
-			{label: 'Observable errored with unexpected exception:', formatted: /Error/},
-			{label: 'Expected message to match:', formatted: /\/def\//}
-		]
-	});
 }));
 
 test('.throws() returns the thrown error', t => {
@@ -952,23 +908,12 @@ test('.throws() returns the rejection reason of a promise returned by the functi
 	});
 });
 
-test('.throws() returns the error of an observable returned by the function', t => {
-	const expected = new Error();
-
-	return assertions.throws(() => {
-		return new Observable(observer => observer.error(expected));
-	}).then(actual => {
-		t.is(actual, expected);
-		t.end();
-	});
-});
-
 test('.throws() fails if passed a bad value', t => {
 	failsWith(t, () => {
 		assertions.throws('not a function');
 	}, {
 		assertion: 'throws',
-		message: '`t.throws()` must be called with a function, observable or promise',
+		message: '`t.throws()` must be called with a function or promise',
 		values: [{label: 'Called with:', formatted: /not a function/}]
 	});
 
@@ -1091,29 +1036,6 @@ test('.notThrows()', gather(t => {
 		message: '',
 		values: [{label: 'Returned promise rejected with:', formatted: /Error/}]
 	});
-
-	const complete = arg => Observable.of(arg);
-	const error = err => new Observable(observer => observer.error(err));
-
-	// Passes because the observable completed
-	eventuallyPasses(t, () => assertions.notThrows(complete()));
-
-	// Fails because the observable errored
-	eventuallyFailsWith(t, () => assertions.notThrows(error(new Error())), {
-		assertion: 'notThrows',
-		message: '',
-		values: [{label: 'Observable errored with:', formatted: /Error/}]
-	});
-
-	// Passes because the function returned a completed observable
-	eventuallyPasses(t, () => assertions.notThrows(() => complete()));
-
-	// Fails because the function returned an errored observable
-	eventuallyFailsWith(t, () => assertions.notThrows(() => error(new Error())), {
-		assertion: 'notThrows',
-		message: '',
-		values: [{label: 'Returned observable errored with:', formatted: /Error/}]
-	});
 }));
 
 test('.notThrows() returns undefined for a fulfilled promise', t => {
@@ -1130,20 +1052,12 @@ test('.notThrows() returns undefined for a fulfilled promise returned by the fun
 	});
 });
 
-test('.notThrows() returns undefined for an observable returned by the function', t => {
-	return assertions.notThrows(() => {
-		return Observable.of(Symbol(''));
-	}).then(actual => {
-		t.is(actual, undefined);
-	});
-});
-
 test('.notThrows() fails if passed a bad value', t => {
 	failsWith(t, () => {
 		assertions.notThrows('not a function');
 	}, {
 		assertion: 'notThrows',
-		message: '`t.notThrows()` must be called with a function, observable or promise',
+		message: '`t.notThrows()` must be called with a function or promise',
 		values: [{label: 'Called with:', formatted: /not a function/}]
 	});
 


### PR DESCRIPTION
See discussion in #1794. It feels out of place compared to promises and requires many overloads in the type definitions.
