### PR TITLE
Move promise-handling code to t.throwsAsync and t.notThrowsAsync

### DIFF
--- a/docs/recipes/flow.md
+++ b/docs/recipes/flow.md
@@ -66,20 +66,3 @@ test('an actual test', t => {
 ```
 
 Note that, despite the type cast above, when executing `t.context` is an empty object unless it's assigned.
-
-## Using `t.throws()` and `t.notThrows()`
-
-The `t.throws()` and `t.noThrows()` assertions can be called with a function that returns an observable or a promise. You may have to explicitly type functions:
-
-```ts
-import test from 'ava';
-
-test('just throws', async t => {
-	const expected = new Error();
-	const err = t.throws((): void => { throw expected; });
-	t.is(err, expected);
-
-	const err2 = await t.throws((): Promise<*> => Promise.reject(expected));
-	t.is(err2, expected);
-});
-```

--- a/docs/recipes/when-to-use-plan.md
+++ b/docs/recipes/when-to-use-plan.md
@@ -62,11 +62,11 @@ test('rejects with foo', t => {
 ```
 
 Here, the use of `t.plan()` seeks to ensure that the code inside the `catch` block is executed.
-Instead, you should take advantage of `t.throws` and `async`/`await`, as this leads to flatter code that is easier to reason about:
+Instead, you should take advantage of `t.throwsAsync` and `async`/`await`, as this leads to flatter code that is easier to reason about:
 
 ```js
 test('rejects with foo', async t => {
-	const reason = await t.throws(shouldRejectWithFoo());
+	const reason = await t.throwsAsync(shouldRejectWithFoo());
 	t.is(reason.message, 'Hello');
 	t.is(reason.foo, 'bar');
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,6 +62,9 @@ export interface Assertions {
 	/** Assert that the function does not throw. */
 	notThrows: NotThrowsAssertion;
 
+	/** Assert that the async function does not throw, or that the promise does not reject. Must be awaited. */
+	notThrowsAsync: NotThrowsAsyncAssertion;
+
 	/** Count a passing assertion. */
 	pass: PassAssertion;
 
@@ -79,6 +82,12 @@ export interface Assertions {
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
 	 */
 	throws: ThrowsAssertion;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error), or the promise rejects
+	 * with one. If so, returns a promise for the error value, which must be awaited.
+	 */
+	throwsAsync: ThrowsAsyncAssertion;
 
 	/** Assert that `actual` is strictly true. */
 	true: TrueAssertion;
@@ -159,13 +168,15 @@ export interface NotRegexAssertion {
 
 export interface NotThrowsAssertion {
 	/** Assert that the function does not throw. */
-	(fn: () => never, message?: string): void;
-
-	/** Assert that the function returns a promise that does not reject. You must await the result. */
-	(fn: () => PromiseLike<any>, message?: string): Promise<void>;
-
-	/** Assert that the function does not throw. */
 	(fn: () => any, message?: string): void;
+
+	/** Skip this assertion. */
+	skip(fn: () => any, message?: string): void;
+}
+
+export interface NotThrowsAsyncAssertion {
+	/** Assert that the async function does not throw. You must await the result. */
+	(fn: () => PromiseLike<any>, message?: string): Promise<void>;
 
 	/** Assert that the promise does not reject. You must await the result. */
 	(promise: PromiseLike<any>, message?: string): Promise<void>;
@@ -216,68 +227,6 @@ export interface ThrowsAssertion {
 	/**
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
 	 */
-	(fn: () => never, expectations?: null, message?: string): any;
-
-	/**
-	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
-	 * The error must be an instance of the given constructor.
-	 */
-	(fn: () => never, constructor: Constructor, message?: string): any;
-
-	/**
-	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
-	 * The error must have a message that matches the regular expression.
-	 */
-	(fn: () => never, regex: RegExp, message?: string): any;
-
-	/**
-	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
-	 * The error must have a message equal to `errorMessage`.
-	 */
-	(fn: () => never, errorMessage: string, message?: string): any;
-
-	/**
-	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
-	 * The error must satisfy all expectations.
-	 */
-	(fn: () => never, expectations: ThrowsExpectation, message?: string): any;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result.
-	 */
-	(fn: () => PromiseLike<any>, expectations?: null, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must be an instance of the given
-	 * constructor.
-	 */
-	(fn: () => PromiseLike<any>, constructor: Constructor, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must have a message that matches the
-	 * regular expression.
-	 */
-	(fn: () => PromiseLike<any>, regex: RegExp, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must have a message equal to
-	 * `errorMessage`.
-	 */
-	(fn: () => PromiseLike<any>, errorMessage: string, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must satisfy all expectations.
-	 */
-	(fn: () => PromiseLike<any>, expectations: ThrowsExpectation, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
-	 */
 	(fn: () => any, expectations?: null, message?: string): any;
 
 	/**
@@ -303,6 +252,41 @@ export interface ThrowsAssertion {
 	 * The error must satisfy all expectations.
 	 */
 	(fn: () => any, expectations: ThrowsExpectation, message?: string): any;
+
+	/** Skip this assertion. */
+	skip(fn: () => any, expectations?: any, message?: string): void;
+}
+
+export interface ThrowsAsyncAssertion {
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result.
+	 */
+	(fn: () => PromiseLike<any>, expectations?: null, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must be an instance of the given constructor.
+	 */
+	(fn: () => PromiseLike<any>, constructor: Constructor, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must have a message that matches the regular expression.
+	 */
+	(fn: () => PromiseLike<any>, regex: RegExp, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must have a message equal to `errorMessage`.
+	 */
+	(fn: () => PromiseLike<any>, errorMessage: string, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must satisfy all expectations.
+	 */
+	(fn: () => PromiseLike<any>, expectations: ThrowsExpectation, message?: string): Promise<any>;
 
 	/**
 	 * Assert that the promise rejects with [an error](https://www.npmjs.com/package/is-error). If so, returns the

--- a/index.js.flow
+++ b/index.js.flow
@@ -75,6 +75,9 @@ export interface Assertions {
 	/** Assert that the function does not throw. */
 	notThrows: NotThrowsAssertion;
 
+	/** Assert that the async function does not throw, or that the promise does not reject. Must be awaited. */
+	notThrowsAsync: NotThrowsAsyncAssertion;
+
 	/** Count a passing assertion. */
 	pass: PassAssertion;
 
@@ -92,6 +95,12 @@ export interface Assertions {
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
 	 */
 	throws: ThrowsAssertion;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error), or the promise rejects
+	 * with one. If so, returns a promise for the error value, which must be awaited.
+	 */
+	throwsAsync: ThrowsAsyncAssertion;
 
 	/** Assert that `actual` is strictly true. */
 	true: TrueAssertion;
@@ -171,11 +180,16 @@ export interface NotRegexAssertion {
 }
 
 export interface NotThrowsAssertion {
-	/** Assert that the function returns a promise that does not reject. You must await the result. */
-	(fn: () => PromiseLike<any>, message?: string): Promise<void>;
-
 	/** Assert that the function does not throw. */
 	(fn: () => any, message?: string): void;
+
+	/** Skip this assertion. */
+	skip(fn: () => any, message?: string): void;
+}
+
+export interface NotThrowsAsyncAssertion {
+	/** Assert that the async function does not throw. You must await the result. */
+	(fn: () => PromiseLike<any>, message?: string): Promise<void>;
 
 	/** Assert that the promise does not reject. You must await the result. */
 	(promise: PromiseLike<any>, message?: string): Promise<void>;
@@ -224,39 +238,6 @@ export interface SnapshotAssertion {
 
 export interface ThrowsAssertion {
 	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result.
-	 */
-	(fn: () => PromiseLike<any>, expectations?: null, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must be an instance of the given
-	 * constructor.
-	 */
-	(fn: () => PromiseLike<any>, constructor: Constructor, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must have a message that matches the
-	 * regular expression.
-	 */
-	(fn: () => PromiseLike<any>, regex: RegExp, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must have a message equal to
-	 * `errorMessage`.
-	 */
-	(fn: () => PromiseLike<any>, errorMessage: string, message?: string): Promise<any>;
-
-	/**
-	 * Assert that the function returns a promise that rejects with [an error](https://www.npmjs.com/package/is-error).
-	 * If so, returns the rejection reason. You must await the result. The error must satisfy all expectations.
-	 */
-	(fn: () => PromiseLike<any>, expectations: ThrowsExpectation, message?: string): Promise<any>;
-
-	/**
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
 	 */
 	(fn: () => any, expectations?: null, message?: string): any;
@@ -284,6 +265,41 @@ export interface ThrowsAssertion {
 	 * The error must satisfy all expectations.
 	 */
 	(fn: () => any, expectations: ThrowsExpectation, message?: string): any;
+
+	/** Skip this assertion. */
+	skip(fn: () => any, expectations?: any, message?: string): void;
+}
+
+export interface ThrowsAsyncAssertion {
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result.
+	 */
+	(fn: () => PromiseLike<any>, expectations?: null, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must be an instance of the given constructor.
+	 */
+	(fn: () => PromiseLike<any>, constructor: Constructor, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must have a message that matches the regular expression.
+	 */
+	(fn: () => PromiseLike<any>, regex: RegExp, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must have a message equal to `errorMessage`.
+	 */
+	(fn: () => PromiseLike<any>, errorMessage: string, message?: string): Promise<any>;
+
+	/**
+	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
+	 * value. You must await the result. The error must satisfy all expectations.
+	 */
+	(fn: () => PromiseLike<any>, expectations: ThrowsExpectation, message?: string): Promise<any>;
 
 	/**
 	 * Assert that the promise rejects with [an error](https://www.npmjs.com/package/is-error). If so, returns the

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -68,6 +68,158 @@ function getStack() {
 	return obj.stack;
 }
 
+function validateExpectations(assertion, expectations, numArgs) { // eslint-disable-line complexity
+	if (typeof expectations === 'function') {
+		expectations = {instanceOf: expectations};
+	} else if (typeof expectations === 'string' || expectations instanceof RegExp) {
+		expectations = {message: expectations};
+	} else if (numArgs === 1 || expectations === null) {
+		expectations = {};
+	} else if (typeof expectations !== 'object' || Array.isArray(expectations) || Object.keys(expectations).length === 0) {
+		throw new AssertionError({
+			assertion,
+			message: `The second argument to \`t.${assertion}()\` must be a function, string, regular expression, expectation object or \`null\``,
+			values: [formatWithLabel('Called with:', expectations)]
+		});
+	} else {
+		if (hasOwnProperty(expectations, 'instanceOf') && typeof expectations.instanceOf !== 'function') {
+			throw new AssertionError({
+				assertion,
+				message: `The \`instanceOf\` property of the second argument to \`t.${assertion}()\` must be a function`,
+				values: [formatWithLabel('Called with:', expectations)]
+			});
+		}
+
+		if (hasOwnProperty(expectations, 'message') && typeof expectations.message !== 'string' && !(expectations.message instanceof RegExp)) {
+			throw new AssertionError({
+				assertion,
+				message: `The \`message\` property of the second argument to \`t.${assertion}()\` must be a string or regular expression`,
+				values: [formatWithLabel('Called with:', expectations)]
+			});
+		}
+
+		if (hasOwnProperty(expectations, 'name') && typeof expectations.name !== 'string') {
+			throw new AssertionError({
+				assertion,
+				message: `The \`name\` property of the second argument to \`t.${assertion}()\` must be a string`,
+				values: [formatWithLabel('Called with:', expectations)]
+			});
+		}
+
+		if (hasOwnProperty(expectations, 'code') && typeof expectations.code !== 'string') {
+			throw new AssertionError({
+				assertion,
+				message: `The \`code\` property of the second argument to \`t.${assertion}()\` must be a string`,
+				values: [formatWithLabel('Called with:', expectations)]
+			});
+		}
+
+		for (const key of Object.keys(expectations)) {
+			switch (key) {
+				case 'instanceOf':
+				case 'is':
+				case 'message':
+				case 'name':
+				case 'code':
+					continue;
+				default:
+					throw new AssertionError({
+						assertion,
+						message: `The second argument to \`t.${assertion}()\` contains unexpected properties`,
+						values: [formatWithLabel('Called with:', expectations)]
+					});
+			}
+		}
+	}
+
+	return expectations;
+}
+
+// Note: this function *must* throw exceptions, since it can be used
+// as part of a pending assertion for promises.
+function assertExpectations({assertion, actual, expectations, message, prefix, stack}) {
+	if (!isError(actual)) {
+		throw new AssertionError({
+			assertion,
+			message,
+			stack,
+			values: [formatWithLabel(`${prefix} exception that is not an error:`, actual)]
+		});
+	}
+
+	if (hasOwnProperty(expectations, 'is') && actual !== expectations.is) {
+		throw new AssertionError({
+			assertion,
+			message,
+			stack,
+			values: [
+				formatWithLabel(`${prefix} unexpectations exception:`, actual),
+				formatWithLabel('Expected to be strictly equal to:', expectations.is)
+			]
+		});
+	}
+
+	if (expectations.instanceOf && !(actual instanceof expectations.instanceOf)) {
+		throw new AssertionError({
+			assertion,
+			message,
+			stack,
+			values: [
+				formatWithLabel(`${prefix} unexpected exception:`, actual),
+				formatWithLabel('Expected instance of:', expectations.instanceOf)
+			]
+		});
+	}
+
+	if (typeof expectations.name === 'string' && actual.name !== expectations.name) {
+		throw new AssertionError({
+			assertion,
+			message,
+			stack,
+			values: [
+				formatWithLabel(`${prefix} unexpected exception:`, actual),
+				formatWithLabel('Expected name to equal:', expectations.name)
+			]
+		});
+	}
+
+	if (typeof expectations.message === 'string' && actual.message !== expectations.message) {
+		throw new AssertionError({
+			assertion,
+			message,
+			stack,
+			values: [
+				formatWithLabel(`${prefix} unexpected exception:`, actual),
+				formatWithLabel('Expected message to equal:', expectations.message)
+			]
+		});
+	}
+
+	if (expectations.message instanceof RegExp && !expectations.message.test(actual.message)) {
+		throw new AssertionError({
+			assertion,
+			message,
+			stack,
+			values: [
+				formatWithLabel(`${prefix} unexpected exception:`, actual),
+				formatWithLabel('Expected message to match:', expectations.message)
+			]
+		});
+	}
+
+	if (typeof expectations.code === 'string' && actual.code !== expectations.code) {
+		throw new AssertionError({
+			assertion,
+			message,
+			stack,
+			values: [
+				formatWithLabel(`${prefix} unexpected exception:`, actual),
+				formatWithLabel('Expected code to equal:', expectations.code)
+			]
+		});
+	}
+}
+
 function wrapAssertions(callbacks) {
 	const pass = callbacks.pass;
 	const pending = callbacks.pending;
@@ -157,183 +309,95 @@ function wrapAssertions(callbacks) {
 			}
 		},
 
-		throws(thrower, expected, message) { // eslint-disable-line complexity
-			if (typeof thrower !== 'function' && !isPromise(thrower)) {
+		throws(fn, expectations, message) {
+			if (typeof fn !== 'function') {
 				fail(this, new AssertionError({
 					assertion: 'throws',
 					improperUsage: true,
-					message: '`t.throws()` must be called with a function or promise',
-					values: [formatWithLabel('Called with:', thrower)]
+					message: '`t.throws()` must be called with a function',
+					values: [formatWithLabel('Called with:', fn)]
 				}));
 				return;
 			}
 
-			if (typeof expected === 'function') {
-				expected = {instanceOf: expected};
-			} else if (typeof expected === 'string' || expected instanceof RegExp) {
-				expected = {message: expected};
-			} else if (arguments.length === 1 || expected === null) {
-				expected = {};
-			} else if (typeof expected !== 'object' || Array.isArray(expected) || Object.keys(expected).length === 0) {
+			try {
+				expectations = validateExpectations('throws', expectations, arguments.length);
+			} catch (err) {
+				fail(this, err);
+				return;
+			}
+
+			let retval;
+			let actual;
+			let threw = false;
+			try {
+				retval = fn();
+			} catch (err) {
+				actual = err;
+				threw = true;
+			}
+
+			if (!threw) {
 				fail(this, new AssertionError({
 					assertion: 'throws',
-					message: 'The second argument to `t.throws()` must be a function, string, regular expression, expectation object or `null`',
-					values: [formatWithLabel('Called with:', expected)]
+					message,
+					values: [formatWithLabel('Function returned:', retval)]
 				}));
 				return;
-			} else {
-				if (hasOwnProperty(expected, 'instanceOf') && typeof expected.instanceOf !== 'function') {
-					fail(this, new AssertionError({
-						assertion: 'throws',
-						message: 'The `instanceOf` property of the second argument to `t.throws()` must be a function',
-						values: [formatWithLabel('Called with:', expected)]
-					}));
-					return;
-				}
-
-				if (hasOwnProperty(expected, 'message') && typeof expected.message !== 'string' && !(expected.message instanceof RegExp)) {
-					fail(this, new AssertionError({
-						assertion: 'throws',
-						message: 'The `message` property of the second argument to `t.throws()` must be a string or regular expression',
-						values: [formatWithLabel('Called with:', expected)]
-					}));
-					return;
-				}
-
-				if (hasOwnProperty(expected, 'name') && typeof expected.name !== 'string') {
-					fail(this, new AssertionError({
-						assertion: 'throws',
-						message: 'The `name` property of the second argument to `t.throws()` must be a string',
-						values: [formatWithLabel('Called with:', expected)]
-					}));
-					return;
-				}
-
-				if (hasOwnProperty(expected, 'code') && typeof expected.code !== 'string') {
-					fail(this, new AssertionError({
-						assertion: 'throws',
-						message: 'The `code` property of the second argument to `t.throws()` must be a string',
-						values: [formatWithLabel('Called with:', expected)]
-					}));
-					return;
-				}
-
-				for (const key of Object.keys(expected)) {
-					switch (key) {
-						case 'instanceOf':
-						case 'is':
-						case 'message':
-						case 'name':
-						case 'code':
-							continue;
-						default:
-							fail(this, new AssertionError({
-								assertion: 'throws',
-								message: 'The second argument to `t.throws()` contains unexpected properties',
-								values: [formatWithLabel('Called with:', expected)]
-							}));
-							return;
-					}
-				}
 			}
 
-			// Note: this function *must* throw exceptions, since it can be used
-			// as part of a pending assertion for promises.
-			const assertExpected = (actual, prefix, stack) => {
-				if (!isError(actual)) {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [formatWithLabel(`${prefix} exception that is not an error:`, actual)]
-					});
-				}
+			try {
+				assertExpectations({
+					assertion: 'throws',
+					actual,
+					expectations,
+					message,
+					prefix: 'Function threw'
+				});
+				pass(this);
+				return actual;
+			} catch (err) {
+				fail(this, err);
+			}
+		},
 
-				if (hasOwnProperty(expected, 'is') && actual !== expected.is) {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [
-							formatWithLabel(`${prefix} unexpected exception:`, actual),
-							formatWithLabel('Expected to be strictly equal to:', expected.is)
-						]
-					});
-				}
+		throwsAsync(thrower, expectations, message) {
+			if (typeof thrower !== 'function' && !isPromise(thrower)) {
+				fail(this, new AssertionError({
+					assertion: 'throwsAsync',
+					improperUsage: true,
+					message: '`t.throwsAsync()` must be called with a function or promise',
+					values: [formatWithLabel('Called with:', thrower)]
+				}));
+				return Promise.resolve();
+			}
 
-				if (expected.instanceOf && !(actual instanceof expected.instanceOf)) {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [
-							formatWithLabel(`${prefix} unexpected exception:`, actual),
-							formatWithLabel('Expected instance of:', expected.instanceOf)
-						]
-					});
-				}
-
-				if (typeof expected.name === 'string' && actual.name !== expected.name) {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [
-							formatWithLabel(`${prefix} unexpected exception:`, actual),
-							formatWithLabel('Expected name to equal:', expected.name)
-						]
-					});
-				}
-
-				if (typeof expected.message === 'string' && actual.message !== expected.message) {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [
-							formatWithLabel(`${prefix} unexpected exception:`, actual),
-							formatWithLabel('Expected message to equal:', expected.message)
-						]
-					});
-				}
-
-				if (expected.message instanceof RegExp && !expected.message.test(actual.message)) {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [
-							formatWithLabel(`${prefix} unexpected exception:`, actual),
-							formatWithLabel('Expected message to match:', expected.message)
-						]
-					});
-				}
-
-				if (typeof expected.code === 'string' && actual.code !== expected.code) {
-					throw new AssertionError({
-						assertion: 'throws',
-						message,
-						stack,
-						values: [
-							formatWithLabel(`${prefix} unexpected exception:`, actual),
-							formatWithLabel('Expected code to equal:', expected.code)
-						]
-					});
-				}
-			};
+			try {
+				expectations = validateExpectations('throwsAsync', expectations, arguments.length);
+			} catch (err) {
+				fail(this, err);
+				return Promise.resolve();
+			}
 
 			const handlePromise = (promise, wasReturned) => {
 				// Record stack before it gets lost in the promise chain.
 				const stack = getStack();
 				const intermediate = promise.then(value => {
 					throw new AssertionError({
-						assertion: 'throws',
+						assertion: 'throwsAsync',
 						message,
 						stack,
 						values: [formatWithLabel(`${wasReturned ? 'Returned promise' : 'Promise'} resolved with:`, value)]
 					});
 				}, reason => {
-					assertExpected(reason, `${wasReturned ? 'Returned promise' : 'Promise'} rejected with`, stack);
+					assertExpectations({
+						assertion: 'throwsAsync',
+						actual: reason,
+						expectations,
+						message,
+						prefix: `${wasReturned ? 'Returned promise' : 'Promise'} rejected with`,
+						stack
+					});
 					return reason;
 				});
 
@@ -356,38 +420,61 @@ function wrapAssertions(callbacks) {
 				threw = true;
 			}
 
-			if (!threw) {
-				if (isPromise(retval)) {
-					return handlePromise(retval, true);
-				}
-
+			if (threw) {
 				fail(this, new AssertionError({
-					assertion: 'throws',
+					assertion: 'throwsAsync',
 					message,
-					values: [formatWithLabel('Function returned:', retval)]
+					values: [formatWithLabel('Function threw synchronously. Use `t.throws()` instead:', actual)]
 				}));
+				return Promise.resolve();
+			}
 
+			if (isPromise(retval)) {
+				return handlePromise(retval, true);
+			}
+
+			fail(this, new AssertionError({
+				assertion: 'throwsAsync',
+				message,
+				values: [formatWithLabel('Function returned:', retval)]
+			}));
+			return Promise.resolve();
+		},
+
+		notThrows(fn, message) {
+			if (typeof fn !== 'function') {
+				fail(this, new AssertionError({
+					assertion: 'notThrows',
+					improperUsage: true,
+					message: '`t.notThrows()` must be called with a function',
+					values: [formatWithLabel('Called with:', fn)]
+				}));
 				return;
 			}
 
 			try {
-				assertExpected(actual, 'Function threw');
-				pass(this);
-				return actual;
+				fn();
 			} catch (err) {
-				fail(this, err);
-			}
-		},
-
-		notThrows(nonThrower, message) {
-			if (typeof nonThrower !== 'function' && !isPromise(nonThrower)) {
 				fail(this, new AssertionError({
 					assertion: 'notThrows',
-					improperUsage: true,
-					message: '`t.notThrows()` must be called with a function or promise',
-					values: [formatWithLabel('Called with:', nonThrower)]
+					message,
+					values: [formatWithLabel('Function threw:', err)]
 				}));
 				return;
+			}
+
+			pass(this);
+		},
+
+		notThrowsAsync(nonThrower, message) {
+			if (typeof nonThrower !== 'function' && !isPromise(nonThrower)) {
+				fail(this, new AssertionError({
+					assertion: 'notThrowsAsync',
+					improperUsage: true,
+					message: '`t.notThrowsAsync()` must be called with a function or promise',
+					values: [formatWithLabel('Called with:', nonThrower)]
+				}));
+				return Promise.resolve();
 			}
 
 			const handlePromise = (promise, wasReturned) => {
@@ -395,7 +482,7 @@ function wrapAssertions(callbacks) {
 				const stack = getStack();
 				const intermediate = promise.then(noop, reason => {
 					throw new AssertionError({
-						assertion: 'notThrows',
+						assertion: 'notThrowsAsync',
 						message,
 						stack,
 						values: [formatWithLabel(`${wasReturned ? 'Returned promise' : 'Promise'} rejected with:`, reason)]
@@ -415,18 +502,23 @@ function wrapAssertions(callbacks) {
 				retval = nonThrower();
 			} catch (err) {
 				fail(this, new AssertionError({
-					assertion: 'notThrows',
+					assertion: 'notThrowsAsync',
 					message,
-					values: [formatWithLabel(`Function threw:`, err)]
+					values: [formatWithLabel('Function threw:', err)]
 				}));
-				return;
+				return Promise.resolve();
 			}
 
-			if (isPromise(retval)) {
-				return handlePromise(retval, true);
+			if (!isPromise(retval)) {
+				fail(this, new AssertionError({
+					assertion: 'notThrowsAsync',
+					message,
+					values: [formatWithLabel('Function did not return a promise. Use `t.notThrows()` instead:', retval)]
+				}));
+				return Promise.resolve();
 			}
 
-			pass(this);
+			return handlePromise(retval, true);
 		},
 
 		snapshot(expected, optionsOrMessage, message) {

--- a/readme.md
+++ b/readme.md
@@ -937,11 +937,9 @@ Assert that `value` is deeply equal to `expected`. See [Concordance](https://git
 
 Assert that `value` is not deeply equal to `expected`. The inverse of `.deepEqual()`.
 
-### `.throws(thrower, [expected, [message]])`
+### `.throws(fn, [expected, [message]])`
 
-Assert that an error is thrown. `thrower` can be a function which should throw, or return a promise that should reject. Alternatively a promise can be passed directly.
-
-The thrown value *must* be an error. It is returned so you can run more assertions against it.
+Assert that an error is thrown. `fn` must be a function which should throw. The thrown value *must* be an error. It is returned so you can run more assertions against it.
 
 `expected` can be a constructor, in which case the thrown error must be an instance of the constructor. It can be a string, which is compared against the thrown error's message, or a regular expression which is matched against this message. You can also specify a matcher object with one or more of the following properties:
 
@@ -969,42 +967,54 @@ test('throws', t => {
 });
 ```
 
-```js
-const promise = Promise.reject(new TypeError('🦄'));
+### `.throwsAsync(thrower, [expected, [message]])`
 
-test('rejects', async t => {
-	const error = await t.throws(promise);
-	t.is(error.message, '🦄');
-});
-```
+Assert that an error is thrown. `thrower` can be an async function which should throw, or a promise that should reject. This assertion must be awaited.
 
-When testing a promise you must wait for the assertion to complete:
+The thrown value *must* be an error. It is returned so you can run more assertions against it.
 
-```js
-test('rejects', async t => {
-	await t.throws(promise);
-});
-```
+`expected` can be a constructor, in which case the thrown error must be an instance of the constructor. It can be a string, which is compared against the thrown error's message, or a regular expression which is matched against this message. You can also specify a matcher object with one or more of the following properties:
 
-When testing an asynchronous function you must also wait for the assertion to complete:
+* `instanceOf`: a constructor, the thrown error must be an instance of
+* `is`: the thrown error must be strictly equal to `expected.is`
+* `message`: either a string, which is compared against the thrown error's message, or a regular expression, which is matched against this message
+* `name`: the expected `.name` value of the thrown error
+* `code`: the expected `.code` value of the thrown error
+
+`expected` does not need to be specified. If you don't need it but do want to set an assertion message you have to specify `null`.
+
+Example:
 
 ```js
 test('throws', async t => {
-	await t.throws(async () => {
+	await t.throwsAsync(async () => {
 		throw new TypeError('🦄');
 	}, {instanceOf: TypeError, message: '🦄'});
 });
 ```
 
-### `.notThrows(nonThrower, [message])`
+```js
+const promise = Promise.reject(new TypeError('🦄'));
 
-Assert that no error is thrown. `thrower` can be a function which shouldn't throw, or return a promise that should resolve. Alternatively a promise can be passed directly.
+test('rejects', async t => {
+	const error = await t.throwsAsync(promise);
+	t.is(error.message, '🦄');
+});
+```
 
-Like the `.throws()` assertion, when testing a promise you must wait for the assertion to complete:
+### `.notThrows(fn, [message])`
+
+Assert that no error is thrown. `fn` must be a function which shouldn't throw.
+
+### `.notThrowsAsync(nonThrower, [message])`
+
+Assert that no error is thrown. `nonThrower` can be an async function which shouldn't throw, or a promise that should resolve.
+
+Like the `.throwsAsync()` assertion, you must wait for the assertion to complete:
 
 ```js
 test('resolves', async t => {
-	await t.notThrows(promise);
+	await t.notThrowsAsync(promise);
 });
 ```
 

--- a/test/flow-types/regression-1148.js.flow
+++ b/test/flow-types/regression-1148.js.flow
@@ -1,18 +1,16 @@
 // @flow
 import test from '../../index.js.flow';
 
-test('test', t => {
-	t.throws((): void => { throw new Error(); });
-	t.throws(Promise.reject(new Error()));
+test('test', async t => {
+	t.throws(() => { throw new Error(); });
+	await t.throwsAsync(Promise.reject(new Error()));
 
-	t.notThrows((): void => { return; });
-	t.notThrows(Promise.resolve('Success'));
+	t.notThrows(() => { return; });
+	await t.notThrowsAsync(Promise.resolve('Success'));
 
-	const error = t.throws((): void => { throw new Error(); });
+	const error = t.throws(() => { throw new Error(); });
 	const message: string = error.message;
 
-	const promise = t.throws(Promise.reject(new Error()));
-	promise.then(error => {
-		const message: string = error.message;
-	});
+	const errorAsync = await t.throwsAsync(Promise.reject(new Error()));
+	const messageAsync: string = errorAsync.message;
 });

--- a/test/test.js
+++ b/test/test.js
@@ -374,7 +374,7 @@ test('fails with the first assertError', t => {
 
 test('failing pending assertion causes test to fail, not promise rejection', t => {
 	return ava(a => {
-		return a.throws(Promise.resolve()).then(() => {
+		return a.throwsAsync(Promise.resolve()).then(() => {
 			throw new Error('Should be ignored');
 		});
 	}).run().then(result => {
@@ -471,8 +471,8 @@ test('throws and notThrows work with promises', t => {
 	const instance = ava(a => {
 		a.plan(2);
 		return Promise.all([
-			a.throws(delay.reject(10, new Error('foo')), 'foo'),
-			a.notThrows(delay(20).then(() => {
+			a.throwsAsync(delay.reject(10, new Error('foo')), 'foo'),
+			a.notThrowsAsync(delay(20).then(() => {
 				asyncCalled = true;
 			}))
 		]);
@@ -513,8 +513,8 @@ test('multiple resolving and rejecting promises passed to t.throws/t.notThrows',
 		const promises = [];
 		for (let i = 0; i < 3; i++) {
 			promises.push(
-				a.throws(delay.reject(10, new Error('foo')), 'foo'),
-				a.notThrows(delay(10), 'foo')
+				a.throwsAsync(delay.reject(10, new Error('foo')), 'foo'),
+				a.notThrowsAsync(delay(10), 'foo')
 			);
 		}
 		return Promise.all(promises);
@@ -528,7 +528,7 @@ test('multiple resolving and rejecting promises passed to t.throws/t.notThrows',
 
 test('fails if test ends while there are pending assertions', t => {
 	return ava(a => {
-		a.throws(Promise.reject(new Error()));
+		a.throwsAsync(Promise.reject(new Error()));
 	}).run().then(result => {
 		t.is(result.passed, false);
 		t.is(result.error.name, 'Error');
@@ -538,7 +538,7 @@ test('fails if test ends while there are pending assertions', t => {
 
 test('fails if callback test ends while there are pending assertions', t => {
 	return ava.cb(a => {
-		a.throws(Promise.reject(new Error()));
+		a.throwsAsync(Promise.reject(new Error()));
 		a.end();
 	}).run().then(result => {
 		t.is(result.passed, false);
@@ -549,7 +549,7 @@ test('fails if callback test ends while there are pending assertions', t => {
 
 test('fails if async test ends while there are pending assertions', t => {
 	return ava(a => {
-		a.throws(Promise.reject(new Error()));
+		a.throwsAsync(Promise.reject(new Error()));
 		return Promise.resolve();
 	}).run().then(result => {
 		t.is(result.passed, false);
@@ -580,7 +580,7 @@ test('no crash when adding assertions after the test has ended', t => {
 	ava(a => {
 		a.pass();
 		setImmediate(() => {
-			t.doesNotThrow(() => a.notThrows(Promise.resolve()));
+			t.doesNotThrow(() => a.notThrowsAsync(Promise.resolve()));
 		});
 	}).run();
 });
@@ -651,23 +651,23 @@ test('failing tests must not return a fulfilled promise', t => {
 test('failing tests pass when returning a rejected promise', t => {
 	return ava.failing(a => {
 		a.plan(1);
-		return a.notThrows(delay(10), 'foo').then(() => Promise.reject());
+		return a.notThrowsAsync(delay(10), 'foo').then(() => Promise.reject());
 	}).run().then(result => {
 		t.is(result.passed, true);
 	});
 });
 
-test('failing tests pass with `t.throws(nonThrowingPromise)`', t => {
+test('failing tests pass with `t.throwsAsync(nonThrowingPromise)`', t => {
 	return ava.failing(a => {
-		return a.throws(Promise.resolve(10));
+		return a.throwsAsync(Promise.resolve(10));
 	}).run().then(result => {
 		t.is(result.passed, true);
 	});
 });
 
-test('failing tests fail with `t.notThrows(throws)`', t => {
+test('failing tests fail with `t.notThrowsAsync(throws)`', t => {
 	return ava.failing(a => {
-		return a.notThrows(Promise.resolve('foo'));
+		return a.notThrowsAsync(Promise.resolve('foo'));
 	}).run().then(result => {
 		t.is(result.passed, false);
 		t.is(result.error.message, failingTestHint);


### PR DESCRIPTION
See #1794.

---

`t.throws()` and `t.notThrows()` no longer take async functions or promises. Instead, use `await t.throwsAsync()` and `await t.notThrowsAsync()`. The async assertions fail if the function throws synchronously.

Updated tests, documentation and type definitions.