### PR TITLE
Copy flow's promise then() interface into PromiseLike

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -1,8 +1,13 @@
 // @flow
 export interface PromiseLike<R> {
+	then(onFulfill: null | void, onReject: null | void): Promise<R>;
+	then<U>(
+		onFulfill: null | void,
+		onReject: (error: any) => Promise<U> | U
+	): Promise<R | U>;
 	then<U>(
 		onFulfill: (value: R) => Promise<U> | U,
-		onReject?: (error: any) => Promise<U> | U
+		onReject: null | void | ((error: any) => Promise<U> | U)
 	): Promise<U>;
 }
 


### PR DESCRIPTION
This allows Flow promise types to be compatible with what AVA is expecting

https://github.com/facebook/flow/blob/c88262be2be0b94b04bfaaf5e52570856d0b87e3/lib/core.js#L589-L597

These should no longer require extra typing:

```js
await t.throws(() => promise);
await t.throws(promise);
```

PS: This PR was made by @jamiebuilds from my computer. "HI!" – Jamie

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
