### PR TITLE
Fix typo in endpoint-testing-with-mongoose

### DIFF
--- a/docs/recipes/endpoint-testing-with-mongoose.md
+++ b/docs/recipes/endpoint-testing-with-mongoose.md
@@ -8,7 +8,7 @@ This recipe shows you how to test your endpoints with AVA and Mongoose, assuming
 
 This recipe uses the following libraries:
 
-1. [`mongod-memory-server`](https://github.com/nodkz/mongodb-memory-server) (A MongoDB in-memory Server)
+1. [`mongodb-memory-server`](https://github.com/nodkz/mongodb-memory-server) (A MongoDB in-memory Server)
 2. [SuperTest](https://github.com/visionmedia/supertest) (An endpoint testing library)
 3. [Mongoose](http://mongoosejs.com)
 


### PR DESCRIPTION
fix small typo in setup list mongod-memory-server -> mongodb-memory-server

copied and tried to install it, which of cause failed, so might safe others ;-)

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
