### PR TITLE
Provide getColorDepth() shim for fake TTYs

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -39,6 +39,7 @@ module.exports = (file, opts, execArgv) => {
 		file,
 		baseDir: process.cwd(),
 		tty: process.stdout.isTTY ? {
+			colorDepth: process.stdout.getColorDepth ? process.stdout.getColorDepth() : undefined,
 			columns: process.stdout.columns || 80,
 			rows: process.stdout.rows
 		} : false

--- a/lib/worker/fake-tty.js
+++ b/lib/worker/fake-tty.js
@@ -5,6 +5,10 @@ const options = require('./options').get();
 if (options.tty) {
 	Object.assign(process.stdout, {isTTY: true}, options.tty);
 
+	if (options.tty.colorDepth !== undefined) {
+		process.stdout.getColorDepth = () => options.tty.colorDepth;
+	}
+
 	const isatty = tty.isatty;
 	tty.isatty = function (fd) {
 		if (fd === 1 || fd === process.stdout) {

--- a/test/fixture/node-assertions/assert-failure.js
+++ b/test/fixture/node-assertions/assert-failure.js
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import test from '../../..';
+
+test('test', () => {
+	assert(false);
+});

--- a/test/fixture/tty/color-disabled.js
+++ b/test/fixture/tty/color-disabled.js
@@ -1,0 +1,6 @@
+import test from '../../..';
+
+test('stdout does not support color', t => {
+	t.true(process.stdout.isTTY);
+	t.is(process.stdout.getColorDepth(), 1);
+});

--- a/test/fixture/tty/color-enabled.js
+++ b/test/fixture/tty/color-enabled.js
@@ -1,0 +1,8 @@
+import test from '../../..';
+
+test('stdout supports color', t => {
+	t.true(process.stdout.isTTY);
+	const colorDepth = process.stdout.getColorDepth();
+	t.is(typeof colorDepth, 'number');
+	t.true(colorDepth > 1);
+});

--- a/test/fixture/tty/get-color-depth-missing.js
+++ b/test/fixture/tty/get-color-depth-missing.js
@@ -1,0 +1,6 @@
+import test from '../../..';
+
+test('stdout does not implement getColorDepth', t => {
+	t.true(process.stdout.isTTY);
+	t.is(process.stdout.getColorDepth, undefined);
+});

--- a/test/fixture/tty/is-not-tty.js
+++ b/test/fixture/tty/is-not-tty.js
@@ -1,0 +1,8 @@
+import test from '../../..';
+
+test('stdout is not a TTY', t => {
+	t.falsy(process.stdout.isTTY);
+	t.falsy(process.stdout.getColorDepth);
+	t.falsy(process.stdout.columns);
+	t.falsy(process.stdout.rows);
+});

--- a/test/fixture/tty/is-tty.js
+++ b/test/fixture/tty/is-tty.js
@@ -1,0 +1,7 @@
+import test from '../../..';
+
+test('stdout is a TTY', t => {
+	t.true(process.stdout.isTTY);
+	t.is(typeof process.stdout.columns, 'number');
+	t.is(typeof process.stdout.rows, 'number');
+});

--- a/test/helper/cli.js
+++ b/test/helper/cli.js
@@ -4,6 +4,7 @@ const childProcess = require('child_process');
 const getStream = require('get-stream');
 
 const cliPath = path.join(__dirname, '../../cli.js');
+const ttySimulator = path.join(__dirname, 'simulate-tty.js');
 
 function execCli(args, opts, cb) {
 	let dirname;
@@ -23,7 +24,9 @@ function execCli(args, opts, cb) {
 	let stderr;
 
 	const processPromise = new Promise(resolve => {
-		child = childProcess.spawn(process.execPath, [cliPath].concat(args), {
+		// Spawning a child with piped IO means that the CLI will never see a TTY.
+		// Inserting a shim here allows us to fake a TTY.
+		child = childProcess.spawn(process.execPath, ['-r', ttySimulator, cliPath].concat(args), {
 			cwd: dirname,
 			env: Object.assign({CI: '1'}, env), // Force CI to ensure the correct reporter is selected
 			// env,

--- a/test/helper/simulate-tty.js
+++ b/test/helper/simulate-tty.js
@@ -1,0 +1,17 @@
+'use strict';
+// The execCli helper spawns tests in a child process. This means that stdout is
+// a pipe and not a TTY device. Setting isTTY to true more accurately reflects
+// typical testing conditions and tricks AVA into using its fake TTY logic.
+if (process.env.AVA_SIMULATE_TTY) {
+	process.stdout.isTTY = true;
+	process.stdout.columns = 80;
+	process.stdout.rows = 24;
+
+	const colorDepth = process.env.AVA_TTY_COLOR_DEPTH ?
+		parseInt(process.env.AVA_TTY_COLOR_DEPTH, 10) :
+		undefined;
+
+	if (colorDepth) {
+		process.stdout.getColorDepth = () => colorDepth;
+	}
+}

--- a/test/integration/node-assertions.js
+++ b/test/integration/node-assertions.js
@@ -1,0 +1,28 @@
+'use strict';
+const test = require('tap').test;
+const {execCli} = require('../helper/cli');
+
+// The AssertionError constructor in Node 10 depends on the TTY interface
+test('node assertion failures are reported to the console when running in a terminal', t => {
+	const options = {
+		dirname: 'fixture/node-assertions',
+		env: {
+			AVA_SIMULATE_TTY: true,
+			AVA_TTY_COLOR_DEPTH: 8
+		}
+	};
+
+	execCli('assert-failure.js', options, (err, stdout) => {
+		t.ok(err);
+		t.match(stdout, /AssertionError/);
+		t.end();
+	});
+});
+
+test('node assertion failures are reported to the console when not running in a terminal', t => {
+	execCli('assert-failure.js', {dirname: 'fixture/node-assertions'}, (err, stdout) => {
+		t.ok(err);
+		t.match(stdout, /AssertionError/);
+		t.end();
+	});
+});

--- a/test/integration/tty.js
+++ b/test/integration/tty.js
@@ -1,0 +1,64 @@
+'use strict';
+const test = require('tap').test;
+const {execCli} = require('../helper/cli');
+
+test('test workers do not get a TTY when ava is not run with a TTY', t => {
+	execCli('is-not-tty.js', {dirname: 'fixture/tty'}, err => {
+		t.ifError(err);
+		t.end();
+	});
+});
+
+test('test workers get a TTY when ava is run with a TTY', t => {
+	const options = {
+		dirname: 'fixture/tty',
+		env: {AVA_SIMULATE_TTY: true}
+	};
+
+	execCli('is-tty.js', options, err => {
+		t.ifError(err);
+		t.end();
+	});
+});
+
+test('test worker TTYs do not support getColorDepth by default', t => {
+	const options = {
+		dirname: 'fixture/tty',
+		env: {AVA_SIMULATE_TTY: true}
+	};
+
+	execCli('get-color-depth-missing.js', options, err => {
+		t.ifError(err);
+		t.end();
+	});
+});
+
+test('test worker TTYs do not support color if the parent TTY does not', t => {
+	const options = {
+		dirname: 'fixture/tty',
+		env: {
+			AVA_SIMULATE_TTY: true,
+			AVA_TTY_COLOR_DEPTH: 1
+		}
+	};
+
+	execCli('color-disabled.js', options, err => {
+		t.ifError(err);
+		t.end();
+	});
+});
+
+test('test worker TTYs inherit color support from the parent TTY', t => {
+	const options = {
+		dirname: 'fixture/tty',
+		env: {
+			AVA_SIMULATE_TTY: true,
+			AVA_TTY_COLOR_DEPTH: 8
+		}
+	};
+
+	execCli('color-enabled.js', options, err => {
+		t.ifError(err);
+		t.end();
+	});
+});


### PR DESCRIPTION
The AssertionError constructor in Node 10 depends on the TTY
interface. More specifically, if isTTY is true on stdout then
getColorDepth() must also be available. Ava provides a shim for
isTTY in the test workers but does not provide a getColorDepth()
implementation. This leads to unexpected failures when code under
test is using Node's built-in assert module.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
