### PR TITLE
Ignore node_modules/* in example

### DIFF
--- a/docs/recipes/babel.md
+++ b/docs/recipes/babel.md
@@ -173,7 +173,7 @@ You'll need to install `@babel/register` yourself.
 // test/_register.js:
 require('@babel/register')({
 	// These patterns are relative to the project directory (where the `package.json` file lives):
-	ignore: ['test/*', 'node_modules/*']
+	ignore: ['node_modules/*', 'test/*']
 });
 ```
 

--- a/docs/recipes/babel.md
+++ b/docs/recipes/babel.md
@@ -173,7 +173,7 @@ You'll need to install `@babel/register` yourself.
 // test/_register.js:
 require('@babel/register')({
 	// These patterns are relative to the project directory (where the `package.json` file lives):
-	ignore: ['test/*']
+	ignore: ['test/*', 'node_modules/*']
 });
 ```
 


### PR DESCRIPTION
If someone were to blindly copy & paste the example (as I did), things go bad when node spawns too many processes trying to compile files under `node_modules`.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
