### PR TITLE
Bump source-map-support and update tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1077,9 +1077,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -9186,9 +9186,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.8.tgz",
+      "integrity": "sha512-WqAEWPdb78u25RfKzOF0swBpY0dKrNdjc4GvLwm7ScX/o9bj8Eh/YL8mcMhBHYDGl87UkkSXDOFnW4G7GhWhGg==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
 		"require-precompiled": "^0.1.0",
 		"resolve-cwd": "^2.0.0",
 		"slash": "^2.0.0",
-		"source-map-support": "^0.5.6",
+		"source-map-support": "^0.5.8",
 		"stack-utils": "^1.0.1",
 		"strip-ansi": "^4.0.0",
 		"strip-bom-buf": "^1.0.0",

--- a/test/integration/stack-traces.js
+++ b/test/integration/stack-traces.js
@@ -13,9 +13,9 @@ test('enabling long stack traces will provide detailed debug information', t => 
 test('`AssertionError` should capture infinity stack trace', t => {
 	execCli('infinity-stack-trace.js', (err, stdout) => {
 		t.ok(err);
-		t.match(stdout, /c \(.+?infinity-stack-trace\.js:6:20\)/);
-		t.match(stdout, /b \(.+?infinity-stack-trace\.js:7:18\)/);
-		t.match(stdout, /a \(.+?infinity-stack-trace\.js:8:18\)/);
+		t.match(stdout, /c \(.+?infinity-stack-trace\.js:7:18\)/);
+		t.match(stdout, /b \(.+?infinity-stack-trace\.js:8:18\)/);
+		t.match(stdout, /a \(.+?infinity-stack-trace\.js:10:2\)/);
 		t.end();
 	});
 });

--- a/test/reporters/mini.regular.log
+++ b/test/reporters/mini.regular.log
@@ -210,7 +210,7 @@ stderr
     [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:35:9)[39m
-  [90mt (test.js:37:11)[39m
+  [90mfn (test.js:37:11)[39m
 
 
 
@@ -239,7 +239,7 @@ stderr
     [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:42:9)[39m
-  [90mt (test.js:44:14)[39m
+  [90mfn (test.js:44:14)[39m
 
 
 

--- a/test/reporters/tap.failfast.log
+++ b/test/reporters/tap.failfast.log
@@ -6,7 +6,7 @@ not ok 1 - a [90m[2m›[22m[39m fails
     name: AssertionError
     message: Test failed via `t.fail()`
     assertion: fail
-    at: 't (a.js:3:22)'
+    at: 'fail (a.js:3:22)'
   ...
 ---tty-stream-chunk-separator
 

--- a/test/reporters/tap.failfast2.log
+++ b/test/reporters/tap.failfast2.log
@@ -6,7 +6,7 @@ not ok 1 - a [90m[2m›[22m[39m fails
     name: AssertionError
     message: Test failed via `t.fail()`
     assertion: fail
-    at: 't (a.js:3:22)'
+    at: 'fail (a.js:3:22)'
   ...
 ---tty-stream-chunk-separator
 # 1 test remaining in test/fixture/report/failfast2/a.js

--- a/test/reporters/tap.regular.log
+++ b/test/reporters/tap.regular.log
@@ -5,7 +5,7 @@ not ok 1 - TypeError: _.default.serial.test is not a function
   ---
     name: TypeError
     message: _.default.serial.test is not a function
-    at: 'Object.<anonymous> (bad-test-chain.js:3:13)'
+    at: 'Object.test (bad-test-chain.js:3:13)'
   ...
 ---tty-stream-chunk-separator
 # test/fixture/report/regular/bad-test-chain.js exited with a non-zero exit code: 1
@@ -65,7 +65,7 @@ not ok 13 - test [90m[2m›[22m[39m fails
     name: AssertionError
     message: Test failed via `t.fail()`
     assertion: fail
-    at: 't (test.js:12:22)'
+    at: 'fail (test.js:12:22)'
   ...
 ---tty-stream-chunk-separator
 # test › known failure
@@ -88,7 +88,7 @@ not ok 16 - test [90m[2m›[22m[39m logs
     name: AssertionError
     message: Test failed via `t.fail()`
     assertion: fail
-    at: 't (test.js:21:4)'
+    at: 'fail (test.js:21:4)'
   ...
 ---tty-stream-chunk-separator
 # test › formatted
@@ -100,7 +100,7 @@ not ok 17 - test [90m[2m›[22m[39m formatted
       'Difference:': |-
         - 'foo'
         + 'bar'
-    at: 't (test.js:25:4)'
+    at: 'deepEqual (test.js:25:4)'
   ...
 ---tty-stream-chunk-separator
 # test › power-assert
@@ -111,7 +111,7 @@ not ok 18 - test [90m[2m›[22m[39m power-assert
     operator: '!'
     values:
       'Value is not falsy:': '''bar'''
-    at: 't (test.js:30:4)'
+    at: 'falsy (test.js:30:4)'
   ...
 ---tty-stream-chunk-separator
 # test › bad throws

--- a/test/reporters/verbose.regular.log
+++ b/test/reporters/verbose.regular.log
@@ -182,7 +182,7 @@ stderr
     [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:35:9)[39m
-  [90mt (test.js:37:11)[39m
+  [90mfn (test.js:37:11)[39m
 
 
 
@@ -211,7 +211,7 @@ stderr
     [34m[4mhttps://github.com/avajs/ava/blob/v1.0.0-beta.5.1/readme.md#throwsthrower-expected-message[24m[39m
 
   [90mfn (test.js:42:9)[39m
-  [90mt (test.js:44:14)[39m
+  [90mfn (test.js:44:14)[39m
 
 
 


### PR DESCRIPTION
I think the fixes from https://github.com/evanw/node-source-map-support/pull/220 are causing some test failures on our end. This should fix it.