### PR TITLE
Add support for `code` in `expected` t.throws() and t.throwsAsync() t…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,8 @@ export type Constructor = (new (...args: Array<any>) => any);
 
 /** Specify one or more expectations the thrown error must satisfy. */
 export type ThrowsExpectation = {
-	/** The thrown error must have a code that equals the given string. */
-	code?: string;
+	/** The thrown error must have a code that equals the given string or number. */
+	code?: string | number;
 
 	/** The thrown error must be an instance of this constructor. */
 	instanceOf?: Constructor;

--- a/index.js.flow
+++ b/index.js.flow
@@ -19,8 +19,8 @@ export type Constructor = Class<{constructor(...args: Array<any>): any}>;
 
 /** Specify one or more expectations the thrown error must satisfy. */
 export type ThrowsExpectation = {
-	/** The thrown error must have a code that equals the given string. */
-	code?: string;
+	/** The thrown error must have a code that equals the given string or number. */
+	code?: string | number;
 
 	/** The thrown error must be an instance of this constructor. */
 	instanceOf?: Constructor;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -106,10 +106,10 @@ function validateExpectations(assertion, expectations, numArgs) { // eslint-disa
 			});
 		}
 
-		if (hasOwnProperty(expectations, 'code') && typeof expectations.code !== 'string') {
+		if (hasOwnProperty(expectations, 'code') && typeof expectations.code !== 'string' && typeof expectations.code !== 'number') {
 			throw new AssertionError({
 				assertion,
-				message: `The \`code\` property of the second argument to \`t.${assertion}()\` must be a string`,
+				message: `The \`code\` property of the second argument to \`t.${assertion}()\` must be a string or number`,
 				values: [formatWithLabel('Called with:', expectations)]
 			});
 		}

--- a/test/assert.js
+++ b/test/assert.js
@@ -827,6 +827,15 @@ test('.throws()', gather(t => {
 		}, {code: 'ERR_TEST'});
 	});
 
+	// Passes because the correct error is thrown.
+	passes(t, () => {
+		assertions.throws(() => {
+			const err = new TypeError(); // eslint-disable-line unicorn/error-message
+			err.code = 42;
+			throw err;
+		}, {code: 42});
+	});
+
 	// Fails because the thrown value is not the right one
 	fails(t, () => {
 		assertions.throws(() => {
@@ -980,11 +989,11 @@ test('.throws() fails if passed a bad expectation', t => {
 	});
 
 	failsWith(t, () => {
-		assertions.throws(() => {}, {code: 42});
+		assertions.throws(() => {}, {code: {}});
 	}, {
 		assertion: 'throws',
-		message: 'The `code` property of the second argument to `t.throws()` must be a string',
-		values: [{label: 'Called with:', formatted: /code: 42/}]
+		message: 'The `code` property of the second argument to `t.throws()` must be a string or number',
+		values: [{label: 'Called with:', formatted: /code: {}/}]
 	});
 
 	failsWith(t, () => {
@@ -1048,11 +1057,11 @@ test('.throwsAsync() fails if passed a bad expectation', t => {
 	});
 
 	failsWith(t, () => {
-		assertions.throwsAsync(() => {}, {code: 42});
+		assertions.throwsAsync(() => {}, {code: {}});
 	}, {
 		assertion: 'throwsAsync',
-		message: 'The `code` property of the second argument to `t.throwsAsync()` must be a string',
-		values: [{label: 'Called with:', formatted: /code: 42/}]
+		message: 'The `code` property of the second argument to `t.throwsAsync()` must be a string or number',
+		values: [{label: 'Called with:', formatted: /code: {}/}]
 	});
 
 	failsWith(t, () => {


### PR DESCRIPTION
Fixes https://github.com/avajs/ava/issues/1901

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
