### PR TITLE
Fix detection of existing syntax plugins

### DIFF
--- a/lib/babel-pipeline.js
+++ b/lib/babel-pipeline.js
@@ -60,7 +60,7 @@ function validate(conf) {
 // more reliable.
 function makeValueChecker(ref) {
 	const expected = require(ref);
-	return ({value}) => value === expected;
+	return ({value}) => value === expected || value === expected.default;
 }
 
 // Resolved paths are used to create the config item, rather than the plugin

--- a/test/fixture/babel/with-explicit-syntax-plugins/async-generators/package.json
+++ b/test/fixture/babel/with-explicit-syntax-plugins/async-generators/package.json
@@ -1,0 +1,10 @@
+{
+	"ava": {
+		"cache": false
+	},
+	"babel": {
+		"plugins": [
+			"@babel/plugin-syntax-async-generators"
+		]
+	}
+}

--- a/test/fixture/babel/with-explicit-syntax-plugins/async-generators/test.js
+++ b/test/fixture/babel/with-explicit-syntax-plugins/async-generators/test.js
@@ -1,0 +1,3 @@
+import test from '../../../../..';
+
+test('pass', t => t.pass());

--- a/test/fixture/babel/with-explicit-syntax-plugins/object-rest-spread/package.json
+++ b/test/fixture/babel/with-explicit-syntax-plugins/object-rest-spread/package.json
@@ -1,0 +1,10 @@
+{
+	"ava": {
+		"cache": false
+	},
+	"babel": {
+		"plugins": [
+			"@babel/plugin-syntax-object-rest-spread"
+		]
+	}
+}

--- a/test/fixture/babel/with-explicit-syntax-plugins/object-rest-spread/test.js
+++ b/test/fixture/babel/with-explicit-syntax-plugins/object-rest-spread/test.js
@@ -1,0 +1,3 @@
+import test from '../../../../..';
+
+test('pass', t => t.pass());

--- a/test/fixture/babel/with-explicit-syntax-plugins/optional-catch-binding/package.json
+++ b/test/fixture/babel/with-explicit-syntax-plugins/optional-catch-binding/package.json
@@ -1,0 +1,10 @@
+{
+	"ava": {
+		"cache": false
+	},
+	"babel": {
+		"plugins": [
+			"@babel/plugin-syntax-optional-catch-binding"
+		]
+	}
+}

--- a/test/fixture/babel/with-explicit-syntax-plugins/optional-catch-binding/test.js
+++ b/test/fixture/babel/with-explicit-syntax-plugins/optional-catch-binding/test.js
@@ -1,0 +1,3 @@
+import test from '../../../../..';
+
+test('pass', t => t.pass());

--- a/test/integration/babel.js
+++ b/test/integration/babel.js
@@ -46,3 +46,12 @@ test('includes relative paths in source map', t => {
 		t.end();
 	});
 });
+
+for (const plugin of ['async-generators', 'object-rest-spread', 'optional-catch-binding']) {
+	test(`avoids applying '@babel/plugin-syntax-${plugin}' if already in config`, t => {
+		execCli([], {dirname: `fixture/babel/with-explicit-syntax-plugins/${plugin}`}, err => {
+			t.ifError(err);
+			t.end();
+		});
+	});
+}


### PR DESCRIPTION
AVA needs to add syntax plugins for stage-4 features, however it
shouldn't do so if the user has already specified them. This fixes the
detection of existing plugins by also comparing a `default` export of
the plugin package.

Fixes #1828.