### PR TITLE
Add test.serial.failing.{only|skip} implementations (#1898)

### DIFF
--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -85,6 +85,8 @@ function createChain(fn, defaults) {
 	extendChain(root.serial.cb, 'failing');
 	extendChain(root.serial.cb, 'only', 'exclusive');
 	extendChain(root.serial.cb, 'skip', 'skipped');
+	extendChain(root.serial.failing, 'only', 'exclusive');
+	extendChain(root.serial.failing, 'skip', 'skipped');
 	extendChain(root.serial.cb.failing, 'only', 'exclusive');
 	extendChain(root.serial.cb.failing, 'skip', 'skipped');
 


### PR DESCRIPTION
resolves #1898 

I tested this fix by creating a new npm project, installing AVA, and running this:

`import test from 'ava';

test.serial.failing.skip('foo', t => {
  t.pass();
});

test.serial.failing.only('bar', t => {
  t.pass();
});`

which produced a 'not a function error'. After the changes in create-chain.js, the file works as expected. 