### PR TITLE
Fix profile.js was not able to work without babel

### DIFF
--- a/profile.js
+++ b/profile.js
@@ -75,9 +75,7 @@ const cacheDir = conf.cacheEnabled === false ? uniqueTempDir() : path.join(proje
 const babelConfig = babelPipeline.validate(conf.babel);
 conf.extensions = normalizeExtensions(conf.extensions || [], babelConfig);
 
-const _regexpFullExtensions = new RegExp(
-	`\\.(${conf.extensions.full.map(ext => escapeStringRegexp(ext)).join('|')})$`,
-);
+const _regexpFullExtensions = new RegExp(`\\.(${conf.extensions.full.map(ext => escapeStringRegexp(ext)).join('|')})$`);
 
 const precompileFull = babelPipeline.build(process.cwd(), cacheDir, babelConfig, conf.compileEnhancements === true);
 


### PR DESCRIPTION
Fixes #1819

When we need to debug our code, we launch ava not from cli, but using profile.js.

In this file the `precompileFile` was hardcoded, so files were always transpiled through babel, which was the issue with projects on typescript, where we do not need babel at all.

I took code api.js to choose when to use babelPipeline and when not.

There is some code duplication problem now between `api.js` and `profile.js`, which can not be easily refactored. 