### PR TITLE
Providing useful feedback when using t.throws() with async functions

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -331,7 +331,7 @@ function wrapAssertions(callbacks) {
 					return;
 				}
 			} catch (_) {}
-			
+
 			try {
 				expectations = validateExpectations('throws', expectations, arguments.length);
 			} catch (error) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -333,7 +333,9 @@ function wrapAssertions(callbacks) {
 			try {
 				retval = fn();
 				if (isPromise(retval)) {
-					retval.catch(noop);
+					try {
+						retval.catch(noop);
+					} catch (_) {}
 					fail(this, new AssertionError({
 						assertion: 'throws',
 						message: 'Function threw asynchronously. Use `t.throwsAsync()` instead'

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -321,6 +321,17 @@ function wrapAssertions(callbacks) {
 			}
 
 			try {
+				if (isPromise(fn().catch(_ => {}))) {
+					fail(this, new AssertionError({
+						assertion: 'throws',
+						improperUsage: true,
+						message: '`t.throws()` cannot be called with an asynchronous function. Use `t.throwsAsync()` instead',
+						values: [formatWithLabel('Called with:', fn)]
+					}));
+					return;
+				}
+			} catch (_) {}
+			try {
 				expectations = validateExpectations('throws', expectations, arguments.length);
 			} catch (error) {
 				fail(this, error);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -331,6 +331,7 @@ function wrapAssertions(callbacks) {
 					return;
 				}
 			} catch (_) {}
+			
 			try {
 				expectations = validateExpectations('throws', expectations, arguments.length);
 			} catch (error) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -321,18 +321,6 @@ function wrapAssertions(callbacks) {
 			}
 
 			try {
-				if (isPromise(fn().catch(_ => {}))) {
-					fail(this, new AssertionError({
-						assertion: 'throws',
-						improperUsage: true,
-						message: '`t.throws()` cannot be called with an asynchronous function. Use `t.throwsAsync()` instead',
-						values: [formatWithLabel('Called with:', fn)]
-					}));
-					return;
-				}
-			} catch (_) {}
-
-			try {
 				expectations = validateExpectations('throws', expectations, arguments.length);
 			} catch (error) {
 				fail(this, error);
@@ -344,6 +332,14 @@ function wrapAssertions(callbacks) {
 			let threw = false;
 			try {
 				retval = fn();
+				if (isPromise(retval)) {
+					retval.catch(noop);
+					fail(this, new AssertionError({
+						assertion: 'throws',
+						message: 'Function threw asynchronously. Use `t.throwsAsync()` instead'
+					}));
+					return;
+				}
 			} catch (error) {
 				actual = error;
 				threw = true;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -338,7 +338,8 @@ function wrapAssertions(callbacks) {
 					} catch (_) {}
 					fail(this, new AssertionError({
 						assertion: 'throws',
-						message: 'Function threw asynchronously. Use `t.throwsAsync()` instead'
+						message,
+						values: [formatWithLabel('Function returned a promise. Use `t.throwsAsync()` instead:', retval)]
 					}));
 					return;
 				}

--- a/test/assert.js
+++ b/test/assert.js
@@ -713,6 +713,20 @@ test('.throws()', gather(t => {
 		values: [{label: 'Function returned:', formatted: /undefined/}]
 	});
 
+	// Fails because the function throws asynchronously
+	failsWith(t, async () => {
+		await assertions.throws(async () => {
+			try {
+				await assert(false);
+			} catch (error) {
+				throw new Error(error);
+			}
+		});
+	}, {
+		assertion: 'throws',
+		message: 'Function threw asynchronously. Use `t.throwsAsync()` instead'
+	});
+
 	// Fails because thrown exception is not an error
 	failsWith(t, () => {
 		assertions.throws(() => {

--- a/test/assert.js
+++ b/test/assert.js
@@ -713,16 +713,13 @@ test('.throws()', gather(t => {
 		values: [{label: 'Function returned:', formatted: /undefined/}]
 	});
 
-	// Fails because the function throws asynchronously
+	// Fails because the function returned a promise.
 	failsWith(t, () => {
-		assertions.throws(() => {
-			return new Promise(() => {
-				throw new Error('error');
-			});
-		});
+		assertions.throws(() => Promise.resolve());
 	}, {
 		assertion: 'throws',
-		message: 'Function threw asynchronously. Use `t.throwsAsync()` instead'
+		message: '',
+		values: [{label: 'Function returned a promise. Use `t.throwsAsync()` instead:', formatted: /Promise/}]
 	});
 
 	// Fails because thrown exception is not an error

--- a/test/assert.js
+++ b/test/assert.js
@@ -714,8 +714,8 @@ test('.throws()', gather(t => {
 	});
 
 	// Fails because the function throws asynchronously
-	failsWith(t, async () => {
-		await assertions.throws(async () => {
+	failsWith(t, () => {
+		assertions.throws(async () => {
 			try {
 				await assert(false);
 			} catch (error) {

--- a/test/assert.js
+++ b/test/assert.js
@@ -715,12 +715,10 @@ test('.throws()', gather(t => {
 
 	// Fails because the function throws asynchronously
 	failsWith(t, () => {
-		assertions.throws(async () => {
-			try {
-				await assert(false);
-			} catch (error) {
-				throw new Error(error);
-			}
+		assertions.throws(() => {
+			return new Promise(() => {
+				throw new Error('error');
+			});
 		});
 	}, {
 		assertion: 'throws',


### PR DESCRIPTION
This is for #1932.

Here's the overview of what the lines do:
- Checks if the `fn` argument to `t.throws()` returns a promise and adds a no-op `.catch()` handler to the return value prevent ava from logging an unhandled rejection
- If it returns a promise, calls `fail()` with the message "`t.throws()` cannot be called with an asynchronous function. Use `t.throwsAsync()` instead"
- Wraps all this in a try-catch statement in order to add the `.catch()` handler in the conditional

I used the test case from #1931:
```
import test from 'ava';

test('test', async (t) => {
  await t.throws(async () => {
    throw new Error();
  });
});
```

The output running npm test is:
```
   15: test('test', async (t) => {     
   16:     await t.throws(async () => {
   17:         throw new Error();      

  `t.throws()` cannot be called with an asynchronous function. Use `t.throwsAsync()` instead

  Called with:

  AsyncFunction []
```
I'd be happy to do this a different way if anyone has suggestions.