### PR TITLE
Change babel-register to @babel/register

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1167,7 +1167,7 @@ Usually, serial tests create temp directories in the current test directory and 
 
 You can't use [`istanbul`](https://github.com/gotwarlost/istanbul) for code coverage as AVA [spawns the test files](#process-isolation). You can use [`nyc`](https://github.com/bcoe/nyc) instead, which is basically `istanbul` with support for subprocesses.
 
-As of version `5.0.0` it uses source maps to report coverage for your actual code, regardless of transpilation. Make sure that the code you're testing includes an inline source map or references a source map file. If you use `babel-register` you can set the `sourceMaps` option in your Babel config to `inline`.
+As of version `5.0.0` it uses source maps to report coverage for your actual code, regardless of transpilation. Make sure that the code you're testing includes an inline source map or references a source map file. If you use `@babel/register` you can set the `sourceMaps` option in your Babel config to `inline`.
 
 ### Common pitfalls
 


### PR DESCRIPTION
I created this PR because:
> This documentation covers the 1.0 beta releases, **which use Babel 7.**
