### PR TITLE
Support babel.config.js

### DIFF
--- a/lib/babel-pipeline.js
+++ b/lib/babel-pipeline.js
@@ -38,7 +38,7 @@ function validate(conf) {
 		return null;
 	}
 
-	const defaultOptions = {babelrc: true};
+	const defaultOptions = {babelrc: true, configFile: true};
 
 	if (conf === undefined) {
 		return {testOptions: defaultOptions};
@@ -102,7 +102,7 @@ function wantsStage4(userOptions, projectDir) {
 	});
 }
 
-function hashPartialTestConfig({babelrc, options: {plugins, presets}}, projectDir, pluginAndPresetHashes) {
+function hashPartialTestConfig({babelrc, config, options: {plugins, presets}}, projectDir, pluginAndPresetHashes) {
 	const inputs = [];
 	if (babelrc) {
 		inputs.push(babelrc);
@@ -114,7 +114,9 @@ function hashPartialTestConfig({babelrc, options: {plugins, presets}}, projectDi
 			inputs.push(stripBomBuf(fs.readFileSync(babelrc)));
 		}
 	}
-	// TODO: If present, hash config contents
+	if (config) {
+		inputs.push(config, stripBomBuf(fs.readFileSync(config)));
+	}
 
 	for (const {file: {resolved: filename}} of [...plugins, ...presets]) {
 		if (pluginAndPresetHashes.has(filename)) {

--- a/test/api.js
+++ b/test/api.js
@@ -872,6 +872,105 @@ test('babel.testOptions.babelrc (when true) picks up .babelrc.js files', t => {
 		});
 });
 
+test('babel.testOptions.configFile effectively defaults to true', t => {
+	t.plan(3);
+
+	const api = apiCreator({
+		projectDir: path.join(__dirname, 'fixture/babel-config')
+	});
+
+	api.on('run', plan => {
+		plan.status.on('stateChange', evt => {
+			if (evt.type === 'test-passed') {
+				t.ok((evt.title === 'foo') || (evt.title === 'repeated test: foo'));
+			}
+		});
+	});
+
+	return api.run()
+		.then(runStatus => {
+			t.is(runStatus.stats.passedTests, 2);
+		});
+});
+
+test('babel.testOptions.configFile can explicitly be true', t => {
+	t.plan(3);
+
+	const api = apiCreator({
+		babelConfig: {
+			testOptions: {configFile: true}
+		},
+		cacheEnabled: false,
+		projectDir: path.join(__dirname, 'fixture/babel-config')
+	});
+
+	api.on('run', plan => {
+		plan.status.on('stateChange', evt => {
+			if (evt.type === 'test-passed') {
+				t.ok(evt.title === 'foo' || evt.title === 'repeated test: foo');
+			}
+		});
+	});
+
+	return api.run()
+		.then(runStatus => {
+			t.is(runStatus.stats.passedTests, 2);
+		});
+});
+
+test('babel.testOptions.configFile can explicitly be false', t => {
+	t.plan(2);
+
+	const api = apiCreator({
+		babelConfig: {
+			testOptions: {configFile: false}
+		},
+		cacheEnabled: false,
+		projectDir: path.join(__dirname, 'fixture/babel-config')
+	});
+
+	api.on('run', plan => {
+		plan.status.on('stateChange', evt => {
+			if (evt.type === 'test-passed') {
+				t.is(evt.title, 'foo');
+			}
+		});
+	});
+
+	return api.run()
+		.then(runStatus => {
+			t.is(runStatus.stats.passedTests, 1);
+		});
+});
+
+test('babel.testOptions merges plugins with babel.config.js', t => {
+	t.plan(3);
+
+	const api = apiCreator({
+		babelConfig: {
+			testOptions: {
+				babelrc: true,
+				plugins: [testCapitalizerPlugin]
+			}
+		},
+		cacheEnabled: false,
+		projectDir: path.join(__dirname, 'fixture/babel-config')
+	});
+
+	api.on('run', plan => {
+		plan.status.on('stateChange', evt => {
+			if (evt.type === 'test-passed') {
+				t.ok(evt.title === 'FOO' || evt.title === 'repeated test: foo');
+			}
+		});
+	});
+
+	return api.run()
+		.then(runStatus => {
+			t.is(runStatus.stats.passedTests, 2);
+		});
+});
+
 test('babel.testOptions can disable ava/stage-4', t => {
 	t.plan(1);
 
@@ -909,6 +1008,34 @@ test('babel.testOptions with extends still merges plugins with .babelrc', t => {
 		},
 		cacheEnabled: false,
 		projectDir: path.join(__dirname, 'fixture/babelrc')
+	});
+
+	api.on('run', plan => {
+		plan.status.on('stateChange', evt => {
+			if (evt.type === 'test-passed') {
+				t.ok(evt.title === 'BAR' || evt.title === 'repeated test: bar');
+			}
+		});
+	});
+
+	return api.run()
+		.then(runStatus => {
+			t.is(runStatus.stats.passedTests, 2);
+		});
+});
+
+test('babel.testOptions with extends still merges plugins with babel.config.js', t => {
+	t.plan(3);
+
+	const api = apiCreator({
+		babelConfig: {
+			testOptions: {
+				plugins: [testCapitalizerPlugin],
+				extends: path.join(__dirname, 'fixture/babel-config/.alt-babelrc')
+			}
+		},
+		cacheEnabled: false,
+		projectDir: path.join(__dirname, 'fixture/babel-config')
 	});
 
 	api.on('run', plan => {

--- a/test/fixture/babel-config/.alt-babelrc
+++ b/test/fixture/babel-config/.alt-babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../babel-plugin-foo-to-bar"]
+}

--- a/test/fixture/babel-config/babel.config.js
+++ b/test/fixture/babel-config/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	presets: ['@ava/stage-4'],
+	env: {
+		development: {
+			plugins: ['../babel-plugin-test-capitalizer']
+		},
+		test: {
+			plugins: ['../babel-plugin-test-doubler']
+		}
+	}
+};

--- a/test/fixture/babel-config/package.json
+++ b/test/fixture/babel-config/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "application-name",
+  "version": "0.0.1"
+}

--- a/test/fixture/babel-config/test.js
+++ b/test/fixture/babel-config/test.js
@@ -1,0 +1,11 @@
+import test from '../../..';
+
+const one = {one: 1};
+const two = {two: 2};
+
+test('foo', t => {
+	// Using object rest/spread to ensure it transpiles on Node.js 6, since this
+	// is a Node.js 8 feature
+	const actual = {...one, ...two};
+	t.deepEqual(actual, {one: 1, two: 2});
+});


### PR DESCRIPTION
This adds support for `babel.config.js` files but does not address the documentation. It'll be good to get at least a release out so people can test.

See #1816.

PR against #1954, will rebase before merging.