### PR TITLE
Handle esm's error "improvements"

### DIFF
--- a/lib/beautify-stack.js
+++ b/lib/beautify-stack.js
@@ -68,5 +68,8 @@ module.exports = stack => {
 
 	return stackUtils.clean(stack)
 		// Remove the trailing newline inserted by the `stack-utils` module
-		.trim();
+		.trim()
+		// Remove remaining file:// prefixes, inserted by `esm`, that are not
+		// cleaned up by `stack-utils`
+		.split('\n').map(line => line.replace(/\(file:\/\/([^/].+:\d+:\d+)\)$/, '($1)')).join('\n');
 };

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -101,7 +101,9 @@ function trySerializeError(err, shouldBeautifyStack) {
 			}
 			retval.summary = retval.summary.trim();
 		} else {
-			retval.summary = lines[0];
+			// Skip the source line header inserted by `esm`:
+			// <https://github.com/standard-things/esm/wiki/improved-errors>
+			retval.summary = lines.find(line => !/:\d+$/.test(line));
 		}
 	}
 


### PR DESCRIPTION
`esm` changes error stacks in a way that AVA is not expecting. This adds a few workarounds, though admittedly all the packages we're using and workarounds we're applying are making a bit of a mess.

See https://github.com/standard-things/esm/wiki/improved-errors for `esm`'s behavior.
