### PR TITLE
Use source-mapped file to build snapshots

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,4 @@
 'use strict';
-const path = require('path');
 const matcher = require('matcher');
 const ContextRef = require('./context-ref');
 const createChain = require('./create-chain');
@@ -167,10 +166,7 @@ class Runner extends Emittery {
 			this.snapshots = snapshotManager.load({
 				file: this.file,
 				fixedLocation: this.snapshotDir,
-				name: path.basename(this.file),
 				projectDir: this.projectDir,
-				relFile: path.relative(this.projectDir, this.file),
-				testDir: path.dirname(this.file),
 				updating: this.updateSnapshots
 			});
 			this.emit('dependency', this.snapshots.snapPath);

--- a/lib/snapshot-manager.js
+++ b/lib/snapshot-manager.js
@@ -357,14 +357,14 @@ class Manager {
 	}
 }
 
-function determineSnapshotDir(options) {
-	const testDir = determineSourceMappedDir(options);
-	if (options.fixedLocation) {
-		const relativeTestLocation = path.relative(options.projectDir, testDir);
-		return path.join(options.fixedLocation, relativeTestLocation);
+function determineSnapshotDir({file, fixedLocation, projectDir, testDir}) {
+	testDir = determineSourceMappedDir(file, testDir);
+	if (fixedLocation) {
+		const relativeTestLocation = path.relative(projectDir, testDir);
+		return path.join(fixedLocation, relativeTestLocation);
 	}
 
-	const parts = new Set(path.relative(options.projectDir, testDir).split(path.sep));
+	const parts = new Set(path.relative(projectDir, testDir).split(path.sep));
 	if (parts.has('__tests__')) {
 		return path.join(testDir, '__snapshots__');
 	}
@@ -375,29 +375,29 @@ function determineSnapshotDir(options) {
 	return testDir;
 }
 
-function determineSourceMappedDir(options) {
-	const source = tryRead(options.file).toString();
-	const converter = convertSourceMap.fromSource(source) || convertSourceMap.fromMapFileSource(source, options.testDir);
+function determineSourceMappedDir(file, testDir) {
+	const source = tryRead(file).toString();
+	const converter = convertSourceMap.fromSource(source) || convertSourceMap.fromMapFileSource(source, testDir);
 	if (converter) {
 		const map = converter.toObject();
 		const firstSource = `${map.sourceRoot || ''}${map.sources[0]}`;
-		const sourceFile = path.resolve(options.testDir, firstSource);
+		const sourceFile = path.resolve(testDir, firstSource);
 		return path.dirname(sourceFile);
 	}
 
-	return options.testDir;
+	return testDir;
 }
 
-function load(options) {
-	const dir = determineSnapshotDir(options);
-	const reportFile = `${options.name}.md`;
-	const snapFile = `${options.name}.snap`;
+function load({file, fixedLocation, name, projectDir, relFile, testDir, updating}) {
+	const dir = determineSnapshotDir({file, fixedLocation, projectDir, testDir});
+	const reportFile = `${name}.md`;
+	const snapFile = `${name}.snap`;
 	const snapPath = path.join(dir, snapFile);
 
-	let appendOnly = !options.updating;
+	let appendOnly = !updating;
 	let snapshotsByHash;
 
-	if (!options.updating) {
+	if (!updating) {
 		const buffer = tryRead(snapPath);
 		if (buffer) {
 			snapshotsByHash = decodeSnapshots(buffer, snapPath);
@@ -409,7 +409,7 @@ function load(options) {
 	return new Manager({
 		appendOnly,
 		dir,
-		relFile: options.relFile,
+		relFile,
 		reportFile,
 		snapFile,
 		snapPath,

--- a/lib/snapshot-manager.js
+++ b/lib/snapshot-manager.js
@@ -357,8 +357,8 @@ class Manager {
 	}
 }
 
-function determineSnapshotDir({file, fixedLocation, projectDir, testDir}) {
-	testDir = determineSourceMappedDir(file, testDir);
+function determineSnapshotDir({file, fixedLocation, projectDir}) {
+	const testDir = path.dirname(file);
 	if (fixedLocation) {
 		const relativeTestLocation = path.relative(projectDir, testDir);
 		return path.join(fixedLocation, relativeTestLocation);
@@ -375,21 +375,29 @@ function determineSnapshotDir({file, fixedLocation, projectDir, testDir}) {
 	return testDir;
 }
 
-function determineSourceMappedDir(file, testDir) {
-	const source = tryRead(file).toString();
+function resolveSourceFile(file) {
+	const testDir = path.dirname(file);
+	const buffer = tryRead(file);
+	if (!buffer) {
+		return file; // Assume the file is stubbed in our test suite.
+	}
+
+	const source = buffer.toString();
 	const converter = convertSourceMap.fromSource(source) || convertSourceMap.fromMapFileSource(source, testDir);
 	if (converter) {
 		const map = converter.toObject();
 		const firstSource = `${map.sourceRoot || ''}${map.sources[0]}`;
-		const sourceFile = path.resolve(testDir, firstSource);
-		return path.dirname(sourceFile);
+		return path.resolve(testDir, firstSource);
 	}
 
-	return testDir;
+	return file;
 }
 
-function load({file, fixedLocation, name, projectDir, relFile, testDir, updating}) {
-	const dir = determineSnapshotDir({file, fixedLocation, projectDir, testDir});
+function load({file, fixedLocation, projectDir, updating}) {
+	const sourceFile = resolveSourceFile(file);
+	const dir = determineSnapshotDir({file: sourceFile, fixedLocation, projectDir});
+	const relFile = path.relative(projectDir, sourceFile);
+	const name = path.basename(relFile);
 	const reportFile = `${name}.md`;
 	const snapFile = `${name}.snap`;
 	const snapPath = path.join(dir, snapFile);

--- a/test/assert.js
+++ b/test/assert.js
@@ -1227,12 +1227,9 @@ test('.snapshot()', t => {
 
 	const projectDir = path.join(__dirname, 'fixture');
 	const manager = snapshotManager.load({
-		file: __filename,
-		name: 'assert.js',
+		file: path.join(projectDir, 'assert.js'),
 		projectDir,
-		relFile: 'test/assert.js',
 		fixedLocation: null,
-		testDir: projectDir,
 		updating
 	});
 	const setup = title => {

--- a/test/integration/snapshots.js
+++ b/test/integration/snapshots.js
@@ -129,7 +129,7 @@ test('legacy snapshot files are reported to the console', t => {
 	});
 });
 
-test('snapshots infer their location from sourcemaps', t => {
+test('snapshots infer their location and name from sourcemaps', t => {
 	t.plan(8);
 	const relativeFixtureDir = path.join('fixture/snapshots/test-sourcemaps');
 	const snapDirStructure = [
@@ -141,8 +141,8 @@ test('snapshots infer their location from sourcemaps', t => {
 		.map(snapRelativeDir => {
 			const snapPath = path.join(__dirname, '..', relativeFixtureDir, snapRelativeDir);
 			return [
-				path.join(snapPath, 'test.js.md'),
-				path.join(snapPath, 'test.js.snap')
+				path.join(snapPath, 'test.ts.md'),
+				path.join(snapPath, 'test.ts.snap')
 			];
 		})
 		.reduce((a, b) => a.concat(b), []);

--- a/test/test.js
+++ b/test/test.js
@@ -723,12 +723,9 @@ test('assertions are bound', t => {
 test('snapshot assertion can be skipped', t => {
 	const projectDir = path.join(__dirname, 'fixture');
 	const manager = snapshotManager.load({
-		file: __filename,
-		name: 'assert.js',
+		file: path.join(projectDir, 'assert.js'),
 		projectDir,
-		relFile: 'test/assert.js',
 		fixedLocation: null,
-		testDir: projectDir,
 		updating: false
 	});
 


### PR DESCRIPTION
* Use the filename of the source file to build the snapshot filename
* Put the relative path of the actual source file in the Markdown snapshot

This is great for TypeScript projects where AVA is applied to pre-build files. The snapshots will be named `file.ts.snap`, and the relative path will be correct, rather than pointing at the output directory.

---

This is a breaking change, since AVA will now write new snapshot files, without removing the previous ones. It may not catch bugs introduced at the same time as the project is updated to the new AVA version.