### PR TITLE
Insert a trailing newline when appending new snapshot entries

### DIFF
--- a/lib/snapshot-manager.js
+++ b/lib/snapshot-manager.js
@@ -151,6 +151,8 @@ function appendReportEntries(existingReport, entries) {
 	buffers.unshift(prepend);
 	byteLength += prepend.byteLength;
 
+	buffers.push(REPORT_TRAILING_NEWLINE);
+	byteLength += REPORT_TRAILING_NEWLINE.byteLength;
 	return Buffer.concat(buffers, byteLength);
 }
 


### PR DESCRIPTION
I reckon this fixes a regression introduced in https://github.com/avajs/ava/pull/1852.
