### PR TITLE
Type additional arguments used by macros

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -58,15 +58,27 @@ test(async t => {
 
 ## Using [macros](../01-writing-tests.md#reusing-test-logic-through-macros)
 
+Macros can receive additional arguments. AVA can infer these to ensure you're using the macro correctly:
+
+```ts
+import test, {ExecutionContext} from 'ava';
+
+const hasLength = (t: ExecutionContext, input: string, expected: number) => {
+	t.is(input.length, expected);
+};
+
+test('bar has length 3', hasLength, 'bar', 3);
+```
+
 In order to be able to assign the `title` property to a macro you need to type the function:
 
 ```ts
 import test, {Macro} from 'ava';
 
-const macro: Macro = (t, input: string, expected: number) => {
+const macro: Macro<[string, number]> = (t, input, expected) => {
 	t.is(eval(input), expected);
 };
-macro.title = (providedTitle = '', input: string, expected: number) => `${providedTitle} ${input} = ${expected}`.trim();
+macro.title = (providedTitle = '', input, expected) => `${providedTitle} ${input} = ${expected}`.trim();
 
 test(macro, '2 + 2', 4);
 test(macro, '2 * 3', 6);
@@ -78,7 +90,7 @@ You'll need a different type if you're expecting your macro to be used with a ca
 ```ts
 import test, {CbMacro} from 'ava';
 
-const macro: CbMacro = t => {
+const macro: CbMacro<[]> = t => {
 	t.pass();
 	setTimeout(t.end, 100);
 };
@@ -123,7 +135,7 @@ interface Context {
 
 const test = anyTest as TestInterface<Context>;
 
-const macro: Macro<Context> = (t, expected: string) => {
+const macro: Macro<[string], Context> = (t, expected: string) => {
 	t.is(t.context.foo, expected);
 };
 

--- a/test/ts-types/context.ts
+++ b/test/ts-types/context.ts
@@ -6,7 +6,7 @@ interface Context {
 
 const test = anyTest as TestInterface<Context>;
 
-const macro: Macro<Context> = (t, expected: string) => {
+const macro: Macro<[string], Context> = (t, expected) => {
 	t.is(t.context.foo, expected);
 };
 

--- a/test/ts-types/macros.ts
+++ b/test/ts-types/macros.ts
@@ -1,0 +1,64 @@
+import test, {ExecutionContext, Macro} from '../..';
+
+// Explicitly type as a macro.
+{
+	const hasLength: Macro<[string, number]> = (t, input, expected) => {
+		t.is(input.length, expected);
+	};
+
+	test('bar has length 3', hasLength, 'bar', 3);
+	test('bar has length 3', [hasLength], 'bar', 3);
+}
+
+// Infer macro
+{
+	const hasLength = (t: ExecutionContext, input: string, expected: number) => {
+		t.is(input.length, expected);
+	};
+
+	test('bar has length 3', hasLength, 'bar', 3);
+	test('bar has length 3', [hasLength], 'bar', 3);
+}
+
+// Multiple macros
+{
+	const hasLength = (t: ExecutionContext, input: string, expected: number) => {
+		t.is(input.length, expected);
+	};
+	const hasCodePoints = (t: ExecutionContext, input: string, expected: number) => {
+		t.is(Array.from(input).length, expected);
+	};
+
+	test('bar has length 3', [hasLength, hasCodePoints], 'bar', 3);
+}
+
+// No title
+{
+	const hasLength: Macro<[string, number]> = (t, input, expected) => {
+		t.is(input.length, expected);
+	};
+	const hasCodePoints: Macro<[string, number]> = (t, input, expected) => {
+		t.is(Array.from(input).length, expected);
+	};
+
+	test(hasLength, 'bar', 3);
+	test([hasLength, hasCodePoints], 'bar', 3);
+}
+
+// No arguments
+{
+	const pass: Macro<[]> = t => t.pass()
+	pass.title = () => 'pass'
+	test(pass)
+}
+
+// Inline
+{
+	test('has length 3', (t: ExecutionContext, input: string, expected: number) => {
+		t.is(input.length, expected)
+	}, 'bar', 3)
+
+	test((t: ExecutionContext, input: string, expected: number) => {
+		t.is(input.length, expected)
+	}, 'bar', 3)
+}


### PR DESCRIPTION
This is an attempt at inferring the types of the additional arguments when you use macros.

```typescript
const hasLength: Macro<[string, number]> = (t, expected, length) => {
	t.is(expected.length, length);
};

test('bar has length 3', hasLength, 'bar', 3);

const hasCodePoints: Macro<[string, number]> = (t, expected, length) => {
	t.is(Array.from(expected).length, length);
};
test('bar has length 3', [hasLength, hasCodePoints], 'bar', 3);
```

See `test/ts-types/macro.ts` for more examples.

This all works quite well as long as you provide the correct arguments. However, the feedback when you don't is atrocious. Due to the way we overload the `test()` function TypeScript assumes you're trying to use `test(macro, ...args)` if it can't match `test('title', macro, ...args)`, which means it's complaining that the `'title'` string isn't a macro….

I feel like there should be a way for TypeScript to narrow the overloads based on whether a title is passed. We may need to open an issue for that (though I don't know the correct terms) but even then it'll take a while to ship any improvements.

One solution would be to make the `title` parameter required. We could still accept an empty string, of course. Alternatively we could require a typecast before `test()` can be used without a `title`.

I still need to document the new generics. I should write some negative typechecks as well.

I'm not sure to what extend this is possible in Flow.

@sindresorhus, @SamVerschueren thoughts?