### PR TITLE
Improve Babel and Vue recipes

### DIFF
--- a/docs/recipes/babel.md
+++ b/docs/recipes/babel.md
@@ -208,3 +208,15 @@ Note that loading `@babel/register` in every worker process has a non-trivial pe
 
 
 [Babel options]: https://babeljs.io/docs/en/options
+
+## Use webpack aliases in babel-transpiled files
+
+You'll need to install `babel-plugin-webpack-alias-7` as a devDependency. Then you can add the plugin to your babel config, likely under either `ava.babel.testOptions` or `babel.env.test`.
+
+```json
+{
+	"plugins": [
+		[ "babel-plugin-webpack-alias-7", { "config": "./configs/webpack.config.test.js" } ]
+	]
+}
+```

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -5,10 +5,15 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/do
 ## Dependencies
 
 - [Require extension hooks](https://github.com/jackmellis/require-extension-hooks):
-	- `npm i --save-dev require-extension-hooks require-extension-hooks-vue require-extension-hooks-babel`
+	- babel v7: `npm i --save-dev require-extension-hooks require-extension-hooks-vue require-extension-hooks-babel@beta`
+	- babel v6: `npm i --save-dev require-extension-hooks require-extension-hooks-vue require-extension-hooks-babel`
 
 - [browser-env](browser-testing.md)
 	- `npm i --save-dev browser-env`
+
+- Optional: [babel-plugin-webpack-alias-7](https://github.com/shortminds/babel-plugin-webpack-alias-7) if you want to use [webpack aliases](https://webpack.js.org/configuration/resolve/#resolve-alias) or use them in your source files
+	- babel v7: `npm i --save-dev babel-plugin-webpack-alias-7`
+	- babel v6: `npm i --save-dev babel-plugin-webpack-alias`
 
 ## Setup
 
@@ -40,8 +45,10 @@ Vue.config.productionTip = false;
 // Setup vue files to be processed by `require-extension-hooks-vue`
 hooks('vue').plugin('vue').push();
 // Setup vue and js files to be processed by `require-extension-hooks-babel`
-hooks(['vue', 'js']).plugin('babel').push();
+hooks(['vue', 'js']).exclude(({filename}) => filename.includes('node_modules')).plugin('babel').push();
 ```
+
+**Note:** If you are using _babel-plugin-webpack-alias_ (either babel version), you must also exclude your webpack file - e.g. `filename.includes('node_modules') || filename.includes('webpack.config.test.js')`
 
 You can find more information about setting up Babel with AVA in the [Babel recipe](babel.md).
 


### PR DESCRIPTION
Related: #1011 

- Improves the Vue recipe by updating it with Babel v7 support. Adds exclusion of `node_modules` to `require-extension-hooks` which seems to provide a significant speedup. Also adds a note about webpack-aliases here, since this is likely a common use-case (but has one 'gotcha' involved).
- Adds webpack-aliases to the Babel recipe

