### PR TITLE
Add `t.timeout()`

### DIFF
--- a/docs/02-execution-context.md
+++ b/docs/02-execution-context.md
@@ -33,3 +33,7 @@ End the test. Only works with `test.cb()`.
 ## `t.log(...values)`
 
 Log values contextually alongside the test result instead of immediately printing them to `stdout`. Behaves somewhat like `console.log`, but without support for placeholder tokens.
+
+## `t.timeout(ms)`
+
+Set a timeout for the test, in milliseconds. The test will fail if this timeout is exceeded. The timeout is reset each time an assertion is made.

--- a/docs/07-test-timeouts.md
+++ b/docs/07-test-timeouts.md
@@ -16,9 +16,9 @@ npx ava --timeout=100 # 100 milliseconds
 
 Timeouts can also be set individually for each test. These timeouts are reset each time an assertion is made.
 
-```javascript
+```js
 test('foo', t => {
 	t.timeout(100); // 100 milliseconds
-	// write your assertions here
+	// Write your assertions here
 });
 ```

--- a/docs/07-test-timeouts.md
+++ b/docs/07-test-timeouts.md
@@ -13,3 +13,12 @@ npx ava --timeout=10s # 10 seconds
 npx ava --timeout=2m # 2 minutes
 npx ava --timeout=100 # 100 milliseconds
 ```
+
+Timeouts can also be set individually for each test. These timeouts are reset each time an assertion is made.
+
+```javascript
+test('foo', t => {
+	t.timeout(100); // 100 milliseconds
+	// write your assertions here
+});
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -348,6 +348,7 @@ export interface ExecutionContext<Context = {}> extends Assertions {
 
 	log: LogFn;
 	plan: PlanFn;
+	timeout: TimeoutFn;
 }
 
 export interface LogFn {
@@ -367,6 +368,14 @@ export interface PlanFn {
 
 	/** Don't plan assertions. */
 	skip(count: number): void;
+}
+
+export interface TimeoutFn {
+	/**
+	 * Set a timeout for the test, in milliseconds. The test will fail if the timeout is exceeded.
+	 * The timeout is reset each time an assertion is made.
+	 */
+	(ms: number): void;
 }
 
 /** The `t` value passed to implementations for tests & hooks declared with the `.cb` modifier. */

--- a/index.js.flow
+++ b/index.js.flow
@@ -361,6 +361,7 @@ export interface ExecutionContext<Context = {}> extends Assertions {
 
 	log: LogFn;
 	plan: PlanFn;
+	timeout: TimeoutFn;
 }
 
 export interface LogFn {
@@ -380,6 +381,14 @@ export interface PlanFn {
 
 	/** Don't plan assertions. */
 	skip(count: number): void;
+}
+
+export interface TimeoutFn {
+	/**
+	 * Set a timeout for the test, in milliseconds. The test will fail if the timeout is exceeded.
+	 * The timeout is reset each time an assertion is made.
+	 */
+	(ms: number): void;
 }
 
 /** The `t` value passed to implementations for tests & hooks declared with the `.cb` modifier. */

--- a/lib/test.js
+++ b/lib/test.js
@@ -266,7 +266,13 @@ class Test {
 	}
 
 	refreshTimeout() {
-		if (this.timeoutTimer) {
+		if (!this.timeoutTimer) {
+			return;
+		}
+
+		if (this.timeoutTimer.refresh) {
+			this.timeoutTimer.refresh();
+		} else {
 			this.timeout(this.timeoutMs);
 		}
 	}

--- a/lib/test.js
+++ b/lib/test.js
@@ -145,6 +145,7 @@ class Test {
 		this.endCallbackFinisher = null;
 		this.finishDueToAttributedError = null;
 		this.finishDueToInactivity = null;
+		this.finishDueToTimeout = null;
 		this.finishing = false;
 		this.pendingAssertionCount = 0;
 		this.pendingThrowsAssertion = null;

--- a/lib/test.js
+++ b/lib/test.js
@@ -53,6 +53,10 @@ function plan(count) {
 	this.plan(count, captureStack(this.plan));
 }
 
+function timeout(ms) {
+	this.timeout(ms);
+}
+
 const testMap = new WeakMap();
 class ExecutionContext {
 	constructor(test) {
@@ -71,7 +75,8 @@ class ExecutionContext {
 			return props;
 		}, {
 			log: {value: log.bind(test)},
-			plan: {value: boundPlan}
+			plan: {value: boundPlan},
+			timeout: {value: timeout.bind(test)}
 		}));
 
 		this.snapshot.skip = () => {
@@ -145,6 +150,8 @@ class Test {
 		this.pendingThrowsAssertion = null;
 		this.planCount = null;
 		this.startedAt = 0;
+		this.timeoutTimer = null;
+		this.timeoutMs = 0;
 	}
 
 	bindEndCallback() {
@@ -189,6 +196,7 @@ class Test {
 		}
 
 		this.assertCount++;
+		this.refreshTimeout();
 	}
 
 	addLog(text) {
@@ -202,9 +210,14 @@ class Test {
 
 		this.assertCount++;
 		this.pendingAssertionCount++;
+		this.refreshTimeout();
+
 		promise
 			.catch(error => this.saveFirstError(error))
-			.then(() => this.pendingAssertionCount--);
+			.then(() => {
+				this.pendingAssertionCount--;
+				this.refreshTimeout();
+			});
 	}
 
 	addFailedAssertion(error) {
@@ -213,6 +226,7 @@ class Test {
 		}
 
 		this.assertCount++;
+		this.refreshTimeout();
 		this.saveFirstError(error);
 	}
 
@@ -232,6 +246,33 @@ class Test {
 		// In case the `planCount` doesn't match `assertCount, we need the stack of
 		// this function to throw with a useful stack.
 		this.planStack = planStack;
+	}
+
+	timeout(ms) {
+		if (this.finishing) {
+			return;
+		}
+
+		this.clearTimeout();
+		this.timeoutMs = ms;
+		this.timeoutTimer = nowAndTimers.setTimeout(() => {
+			this.saveFirstError(new Error('Test timeout exceeded'));
+
+			if (this.finishDueToTimeout) {
+				this.finishDueToTimeout();
+			}
+		}, ms);
+	}
+
+	refreshTimeout() {
+		if (this.timeoutTimer) {
+			this.timeout(this.timeoutMs);
+		}
+	}
+
+	clearTimeout() {
+		clearTimeout(this.timeoutTimer);
+		this.timeoutTimer = null;
 	}
 
 	verifyPlan() {
@@ -370,6 +411,10 @@ class Test {
 					resolve(this.finishPromised());
 				};
 
+				this.finishDueToTimeout = () => {
+					resolve(this.finishPromised());
+				};
+
 				this.finishDueToInactivity = () => {
 					this.saveFirstError(new Error('`t.end()` was never called'));
 					resolve(this.finishPromised());
@@ -380,6 +425,10 @@ class Test {
 		if (promise) {
 			return new Promise(resolve => {
 				this.finishDueToAttributedError = () => {
+					resolve(this.finishPromised());
+				};
+
+				this.finishDueToTimeout = () => {
 					resolve(this.finishPromised());
 				};
 
@@ -415,6 +464,7 @@ class Test {
 			return this.waitForPendingThrowsAssertion();
 		}
 
+		this.clearTimeout();
 		this.verifyPlan();
 		this.verifyAssertions();
 

--- a/test/test.js
+++ b/test/test.js
@@ -764,3 +764,36 @@ test('implementation runs with null scope', t => {
 		t.is(this, null);
 	}).run();
 });
+
+test('timeout with promise', t => {
+	return ava(a => {
+		a.timeout(10);
+		return delay(200);
+	}).run().then(result => {
+		t.is(result.passed, false);
+		t.match(result.error.message, /timeout/);
+	});
+});
+
+test('timeout with cb', t => {
+	return ava.cb(a => {
+		a.timeout(10);
+		setTimeout(() => a.end(), 200);
+	}).run().then(result => {
+		t.is(result.passed, false);
+		t.match(result.error.message, /timeout/);
+	});
+});
+
+test('timeout is refreshed on assert', t => {
+	return ava.cb(a => {
+		a.timeout(10);
+		a.plan(3);
+		setTimeout(() => a.pass(), 5);
+		setTimeout(() => a.pass(), 10);
+		setTimeout(() => a.pass(), 15);
+		setTimeout(() => a.end(), 20);
+	}).run().then(result => {
+		t.is(result.passed, true);
+	});
+});


### PR DESCRIPTION
Fixes #1565 

As suggested in the issue, the timeout is refreshed whenever an assertion is made.
I'm not sure if the typescript or flow definitions need to be updated.