### PR TITLE
Change serialization of Error summary due to #1995

### DIFF
--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -107,7 +107,7 @@ function trySerializeError(err, shouldBeautifyStack) {
 		} else {
 			// Skip the source line header inserted by `esm`:
 			// <https://github.com/standard-things/esm/wiki/improved-errors>
-			const start = lines.indexOf(lines.find(line => !/:\d+$/.test(line)));
+			const start = lines.findIndex(line => !/:\d+$/.test(line));
 			retval.summary = '';
 			for (let index = start; index < lines.length; index++) {
 				if (lines[index].startsWith('    at')) {

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -110,7 +110,7 @@ function trySerializeError(err, shouldBeautifyStack) {
 			const start = lines.indexOf(lines.find(line => !/:\d+$/.test(line)));
 			retval.summary = '';
 			for (let index = start; index < lines.length; index++) {
-				retval.summary += index + 1 !== lines.length ? lines[index] + '\n' : lines[index];
+				retval.summary += index + 1 === lines.length ? lines[index] : lines[index] + '\n';
 			}
 		}
 	}

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -107,7 +107,11 @@ function trySerializeError(err, shouldBeautifyStack) {
 		} else {
 			// Skip the source line header inserted by `esm`:
 			// <https://github.com/standard-things/esm/wiki/improved-errors>
-			retval.summary = lines.find(line => !/:\d+$/.test(line));
+			const start = lines.indexOf(lines.find(line => !/:\d+$/.test(line)));
+			retval.summary = '';
+			for (let index = start; index < lines.length; index++) {
+				retval.summary += index + 1 !== lines.length ? lines[index] + '\n' : lines[index];
+			}
 		}
 	}
 

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -110,7 +110,12 @@ function trySerializeError(err, shouldBeautifyStack) {
 			const start = lines.indexOf(lines.find(line => !/:\d+$/.test(line)));
 			retval.summary = '';
 			for (let index = start; index < lines.length; index++) {
-				retval.summary += index + 1 === lines.length ? lines[index] : lines[index] + '\n';
+				if (lines[index].startsWith('    at')) {
+					break;
+				}
+				const next = index + 1;
+				const end = next === lines.length || lines[next].startsWith('    at');
+				retval.summary += end ? lines[index] : lines[index] + '\n';
 			}
 		}
 	}

--- a/test/serialize-error.js
+++ b/test/serialize-error.js
@@ -29,7 +29,7 @@ test('serialize standard props', t => {
 	t.is(serializedError.name, 'Error');
 	t.is(serializedError.stack, beautifyStack(error.stack));
 	t.is(serializedError.message, 'Hello');
-	t.is(serializedError.summary, 'Error: Hello');
+	t.is(serializedError.summary, error.stack);
 	t.is(typeof serializedError.source.isDependency, 'boolean');
 	t.is(typeof serializedError.source.isWithinProject, 'boolean');
 	t.is(typeof serializedError.source.file, 'string');
@@ -180,10 +180,10 @@ test('creates multiline summaries for syntax errors', t => {
 test('skips esm enhancement lines when finding the summary', t => {
 	const error = new Error();
 	Object.defineProperty(error, 'stack', {
-		value: 'file://file.js:1\nHello'
+		value: 'file://file.js:1\nFirst line\nSecond line'
 	});
 	const serializedError = serialize(error);
-	t.is(serializedError.summary, 'Hello');
+	t.is(serializedError.summary, 'First line\nSecond line');
 	t.end();
 });
 

--- a/test/serialize-error.js
+++ b/test/serialize-error.js
@@ -29,7 +29,7 @@ test('serialize standard props', t => {
 	t.is(serializedError.name, 'Error');
 	t.is(serializedError.stack, beautifyStack(error.stack));
 	t.is(serializedError.message, 'Hello');
-	t.is(serializedError.summary, error.stack);
+	t.is(serializedError.summary, 'Error: Hello');
 	t.is(typeof serializedError.source.isDependency, 'boolean');
 	t.is(typeof serializedError.source.isWithinProject, 'boolean');
 	t.is(typeof serializedError.source.file, 'string');


### PR DESCRIPTION
1. Fixes #1995
2. Add `lines[index].startsWith('    at')` for fixing tests from `test/reports/*.js`
3. Change `skips esm enhancement lines when finding the summary` test in `test/serialize-error.js` for checking my changes
4. Firstly, I change `serialize standard props` test in in `test/serialize-error.js` 
from:
`t.is(serializedError.summary, 'Error: Hello');`
to:
`t.is(serializedError.summary, error.stack)`;
But after adding fix for `test/reports/*.js` I return it to initial 
`t.is(serializedError.summary, 'Error: Hello');` and it also pass