### PR TITLE
docs(recipes): "profile.js --serial ${file}" error

### DIFF
--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -48,8 +48,8 @@ By default AVA runs tests concurrently. This may complicate debugging. Add a con
 	"name": "Run AVA test serially",
 	"program": "${workspaceRoot}/node_modules/ava/profile.js",
 	"args": [
-	  "--serial",
-	  "${file}"
+	  "${file}",
+	  "--serial"
 	],
 	"skipFiles": [
 		"<node_internals>/**/*.js"


### PR DESCRIPTION
`profile.js` expects `${file}` argument before other options like `--serial`. 

As documented it errors:

```bash
profile.js --serial ./test.js

profile.js:69
	throw new Error('Specify a test file');
	^

Error: Specify a test file
...
```

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
