### PR TITLE
[Docs] Remove deprecated variable from VS Code debug recipe

### DIFF
--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -15,7 +15,7 @@ Add following to the `configurations` object:
 	"type": "node",
 	"request": "launch",
 	"name": "Run AVA test",
-	"program": "${workspaceRoot}/node_modules/ava/profile.js",
+	"program": "${workspaceFolder}/node_modules/ava/profile.js",
 	"args": [
 	  "${file}"
 	],
@@ -46,7 +46,7 @@ By default AVA runs tests concurrently. This may complicate debugging. Add a con
 	"type": "node",
 	"request": "launch",
 	"name": "Run AVA test serially",
-	"program": "${workspaceRoot}/node_modules/ava/profile.js",
+	"program": "${workspaceFolder}/node_modules/ava/profile.js",
 	"args": [
 	  "${file}",
 	  "--serial"


### PR DESCRIPTION
Fixes #2023

This PR changes the lines containing the deprecated variable into the new equivalent one.

## Brief recap:
In "Debugging tests with Visual Studio Code" recipe the {workspaceRoot} variable has been deprecated since version 1.17 in favor of {workspaceFolder}.
