### PR TITLE
Delete snapshots files after running tests

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -171,7 +171,7 @@ class AvaFiles {
 
 		// Same defaults as used for Chokidar
 		if (!hasPositivePattern) {
-			mixedPatterns = ['package.json', '**/*.js'].concat(mixedPatterns);
+			mixedPatterns = ['package.json', '**/*.js', '**/*.snap'].concat(mixedPatterns);
 		}
 
 		filePath = matchable(filePath);

--- a/test/ava-files.js
+++ b/test/ava-files.js
@@ -73,6 +73,9 @@ test('sourceMatcher - defaults', t => {
 	isSource('fixtures/foo.js');
 	isSource('helpers/foo.js');
 
+	isSource('snapshots/foo.js.snap');
+	isSource('snapshots/bar.js.snap');
+
 	// TODO: Watcher should probably track any required file that matches the source pattern and has a require extension installed for the given extension.
 	notSource('foo-bar.json');
 	notSource('foo-bar.coffee');


### PR DESCRIPTION
This fixes #1511 by recognizing snapshot (`.snap`) files as source files.

Note that I didn't add an integration test as requested in https://github.com/avajs/ava/pull/1751#pullrequestreview-108522952 since the two assertions I added to the `ava-files.js` unit tests should be enough. If you still think we need an integration test for this, let me know and I'll add one.

// cc @novemberborn