### PR TITLE
Update esm package detection

### DIFF
--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -111,7 +111,8 @@ ipc.options.then(options => {
 			const required = require(mod);
 
 			try {
-				if (required[Symbol.for('esm\u200D:package')]) {
+				if (required[Symbol.for('esm:package')] ||
+						required[Symbol.for('esm\u200D:package')]) {
 					require = required(module); // eslint-disable-line no-global-assign
 				}
 			} catch (_) {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2675,9 +2675,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.1.3.tgz",
-      "integrity": "sha512-W5DKpMvvvtdn4Wzwl9scBUlsdiy4sXALG5oKIrCgnalg6db6vAztKVHWfOW4R8TlFvXlZDjipXSTrqhJDHpdRg=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.4.tgz",
+      "integrity": "sha512-wOuWtQCkkwD1WKQN/k3RsyGSSN+AmiUzdKftn8vaC+uV9JesYmQlODJxgXaaRz0LaaFIlUxZaUu5NPiUAjKAAA=="
     },
     "espower-location-detector": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"empower-core": "^1.2.0",
 		"equal-length": "^1.0.0",
 		"escape-string-regexp": "^1.0.5",
-		"esm": "^3.1.3",
+		"esm": "^3.2.4",
 		"figures": "^2.0.0",
 		"find-up": "^3.0.0",
 		"get-port": "^4.1.0",


### PR DESCRIPTION
This PR updates ava's `esm` detection to use a simplified symbol value.