### PR TITLE
Remove the moot `typings` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
 		"xo": "^0.24.0",
 		"zen-observable": "^0.8.13"
 	},
-	"typings": "index.d.ts",
 	"xo": {
 		"ignores": [
 			"media/**",


### PR DESCRIPTION
It's not needed as TypeScript infers the file just like Node.js does for `index.js`.