### PR TITLE
Bug fix: t.throws() does not fail when expected code is a number

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -215,7 +215,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		});
 	}
 
-	if ((typeof expectations.code === 'number' || typeof expectations.code === 'string') && actual.code !== expectations.code) {
+	if (actual.code !== expectations.code) {
 		throw new AssertionError({
 			assertion,
 			message,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -215,7 +215,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		});
 	}
 
-	if (typeof expectations.code === 'string' && actual.code !== expectations.code) {
+	if ((typeof expectations.code === 'number' || typeof expectations.code === 'string') && actual.code !== expectations.code) {
 		throw new AssertionError({
 			assertion,
 			message,

--- a/test/assert.js
+++ b/test/assert.js
@@ -858,6 +858,14 @@ test('.throws()', gather(t => {
 			throw err;
 		}, {code: 'ERR_TEST'});
 	});
+
+	fails(t, () => {
+		assertions.throws(() => {
+			const err = new TypeError();
+			err.code = 1;
+			throw err;
+		}, {code: 42});
+	});
 }));
 
 test('.throws() returns the thrown error', t => {


### PR DESCRIPTION
A tiny bug with a tiny fix. Title describes it all.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
