### PR TITLE
Split the two ways of writing the pronunciation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,7 @@ In contrast AVA is highly opinionated and runs tests concurrently, with a separa
 
 ### How is the name written and pronounced?
 
-AVA, not Ava or ava. Pronounced [`/ˈeɪvə/`](media/pronunciation.m4a?raw=true): Ay (f**a**ce, m**a**de) v (**v**ie, ha**v**e) a (comm**a**, **a**go)
+AVA, not Ava or ava. Pronounced [`/ˈeɪvə/`](media/pronunciation.m4a?raw=true): Ay (f**a**ce, m**a**de) V (**v**ie, ha**v**e) A (comm**a**, **a**go)
 
 ### What is the header background?
 

--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,7 @@ In contrast AVA is highly opinionated and runs tests concurrently, with a separa
 
 ### How is the name written and pronounced?
 
-AVA, not Ava or ava. Pronounced [/ˈeɪvə/ ay-və](media/pronunciation.m4a?raw=true).
+AVA, not Ava or ava. Pronounced [`/ˈeɪvə/`](media/pronunciation.m4a?raw=true): Ay (f**a**ce, m**a**de) v (**v**ie, ha**v**e) a (comm**a**, **a**go)
 
 ### What is the header background?
 


### PR DESCRIPTION
This purposefully splits the two ways of writing and don't use the schwa (inverted e) in the alternative non-IPA writing. The reason I'm proposing this change is because I had an employee ask me about "why is there something after that second `/`? Do I have to say ava twice?

In our case downloading and listening to the file made it clear, but I think writing it out in IPA and writing it out without any IPA-characters makes it unambiguous and removes the need to download the audio file (which is not very accessible).

