### PR TITLE
Fix unbound reference to clearTimeout

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -278,7 +278,7 @@ class Test {
 	}
 
 	clearTimeout() {
-		clearTimeout(this.timeoutTimer);
+		nowAndTimers.clearTimeout(this.timeoutTimer);
 		this.timeoutTimer = null;
 	}
 


### PR DESCRIPTION
Test code should be able to stuck the global clearTimeout() without breaking AVA.

This fixes a regression from #2015 (v1.2.0).