### PR TITLE
Update 07-test-timeouts.md

### DIFF
--- a/docs/07-test-timeouts.md
+++ b/docs/07-test-timeouts.md
@@ -22,3 +22,4 @@ test('foo', t => {
 	// Write your assertions here
 });
 ```
+Important: There is _no default timeout_ in AVA!

--- a/docs/07-test-timeouts.md
+++ b/docs/07-test-timeouts.md
@@ -4,9 +4,9 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/do
 
 Timeouts in AVA behave differently than in other test frameworks. AVA resets a timer after each test, forcing tests to quit if no new test results were received within the specified timeout. This can be used to handle stalled tests.
 
-You can configure timeouts using the `--timeout` [command line option](./05-command-line.md), or in the [configuration](./06-configuration.md).
+*There is no default timeout.*
 
-You can set timeouts in a human-readable way:
+You can configure timeouts using the `--timeout` [command line option](./05-command-line.md), or in the [configuration](./06-configuration.md). They can be set in a human-readable way:
 
 ```console
 npx ava --timeout=10s # 10 seconds
@@ -22,4 +22,3 @@ test('foo', t => {
 	// Write your assertions here
 });
 ```
-Important: There is _no default timeout_ in AVA!


### PR DESCRIPTION
Add sentence that there is no default timeout in AVA.
