### PR TITLE
added Test stats to execution context

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -115,7 +115,7 @@ class ExecutionContext {
 	set context(context) {
 		testMap.get(this).contextRef.set(context);
 	}
-	
+
 	_throwsArgStart(assertion, file, line) {
 		testMap.get(this).trackThrows({assertion, file, line});
 	}

--- a/lib/test.js
+++ b/lib/test.js
@@ -57,6 +57,19 @@ function timeout(ms) {
 	this.timeout(ms);
 }
 
+function stats() {
+	return {
+		assertCount: this.assertCount,
+		assertError: this.assertError,
+		calledEnd: this.calledEnd,
+		duration: this.duration,
+		finishing: this.finishing,
+		pendingAssertionCount: this.pendingAssertionCount,
+		planCount: this.planCount,
+		startedAt: this.startedAt
+	};
+}
+
 const testMap = new WeakMap();
 class ExecutionContext {
 	constructor(test) {
@@ -76,7 +89,8 @@ class ExecutionContext {
 		}, {
 			log: {value: log.bind(test)},
 			plan: {value: boundPlan},
-			timeout: {value: timeout.bind(test)}
+			timeout: {value: timeout.bind(test)},
+			stats: {value: stats.bind(test)}
 		}));
 
 		this.snapshot.skip = () => {
@@ -101,7 +115,7 @@ class ExecutionContext {
 	set context(context) {
 		testMap.get(this).contextRef.set(context);
 	}
-
+	
 	_throwsArgStart(assertion, file, line) {
 		testMap.get(this).trackThrows({assertion, file, line});
 	}


### PR DESCRIPTION
#1485 
#1692 

I would like to propose this pull request. I built a framework on top of AVA that allows you to execute individual steps within a Test. However I wanted to have more control in order to stop steps from executing when previous steps have failed and to give debug feedback about which steps have executed and which have not. In order to do this I had to hack Object.bind to get to the Test object, however this patch would expose the necessary information that tests can use to inspect the current state of testing.

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
