### PR TITLE
Tweak reporter integration tests so they pass on Node.js 12-pre

### DIFF
--- a/test/fixture/report/regular/unhandled-rejection.js
+++ b/test/fixture/report/regular/unhandled-rejection.js
@@ -1,9 +1,11 @@
 import test from '../../../..';
 
-test('passes', t => {
+const passes = t => {
 	Promise.reject(new Error('Can\'t catch me'));
 	t.pass();
-});
+};
+
+test('passes', passes);
 
 test('unhandled non-error rejection', t => {
 	const err = null;

--- a/test/helper/report.js
+++ b/test/helper/report.js
@@ -68,6 +68,7 @@ exports.sanitizers = {
 	lineEndings: str => replaceString(str, '\r\n', '\n'),
 	posix: str => replaceString(str, '\\', '/'),
 	slow: str => str.replace(/(slow.+?)\(\d+m?s\)/g, '$1 (000ms)'),
+	timeout: str => replaceString(str, 'Timeout._onTimeout', 'Timeout.setTimeout'),
 	// At least in Appveyor with Node.js 6, IPC can overtake stdout/stderr. This
 	// causes the reporter to emit in a different order, resulting in a test
 	// failure. "Fix" by not asserting on the stdout/stderr reporting at all.

--- a/test/reporters/mini.regular.log
+++ b/test/reporters/mini.regular.log
@@ -445,7 +445,7 @@ stderr
 
   [90m~/test/fixture/report/regular/unhandled-rejection.js:4[39m
 
-   [90m3:[39m test('passes', t => {                          
+   [90m3:[39m const passes = t => {                          
   [41m 4:   Promise.reject(new Error('Can/'t catch me'));[49m
    [90m5:[39m   t.pass();                                    
 

--- a/test/reporters/tap.js
+++ b/test/reporters/tap.js
@@ -15,7 +15,7 @@ const run = (type, sanitizers = []) => t => {
 
 	const tty = new TTYStream({
 		columns: 200,
-		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix, report.sanitizers.unreliableProcessIO]
+		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix, report.sanitizers.timeout, report.sanitizers.unreliableProcessIO]
 	});
 	const reporter = new TapReporter({
 		reportStream: tty,

--- a/test/reporters/tap.regular.log
+++ b/test/reporters/tap.regular.log
@@ -22,7 +22,7 @@ not ok 5 - Error: Can't catch me
   ---
     name: Error
     message: Can't catch me
-    at: 't (unhandled-rejection.js:4:17)'
+    at: 'passes (unhandled-rejection.js:4:17)'
   ...
 ---tty-stream-chunk-separator
 # unhandled-rejection

--- a/test/reporters/verbose.regular.log
+++ b/test/reporters/verbose.regular.log
@@ -22,7 +22,7 @@
 
   [90m~/test/fixture/report/regular/unhandled-rejection.js:4[39m
 
-   [90m3:[39m test('passes', t => {                          
+   [90m3:[39m const passes = t => {                          
   [41m 4:   Promise.reject(new Error('Can/'t catch me'));[49m
    [90m5:[39m   t.pass();                                    
 


### PR DESCRIPTION
This should fix failures in https://github.com/nodejs/citgm.