### PR TITLE
Simplify macro types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -413,7 +413,7 @@ export type Macro<Args extends any[], Context = {}> = UntitledMacro<Args, Contex
 	title?: (providedTitle: string | undefined, ...args: Args) => string;
 }
 
-type EitherMacro<Args extends any[], Context> = Macro<Args, Context> | UntitledMacro<Args, Context>;
+export type EitherMacro<Args extends any[], Context> = Macro<Args, Context> | UntitledMacro<Args, Context>;
 
 /** Alias for a single macro, or an array of macros. */
 export type OneOrMoreMacros<Args extends any[], Context> = EitherMacro<Args, Context> | [EitherMacro<Args, Context>, ...EitherMacro<Args, Context>[]];
@@ -425,7 +425,7 @@ export type CbMacro<Args extends any[], Context = {}> = UntitledCbMacro<Args, Co
 	title?: (providedTitle: string | undefined, ...args: Args) => string;
 }
 
-type EitherCbMacro<Args extends any[], Context> = CbMacro<Args, Context> | UntitledCbMacro<Args, Context>;
+export type EitherCbMacro<Args extends any[], Context> = CbMacro<Args, Context> | UntitledCbMacro<Args, Context>;
 
 /** Alias for a single macro, or an array of macros, used for tests & hooks declared with the `.cb` modifier. */
 export type OneOrMoreCbMacros<Args extends any[], Context> = EitherCbMacro<Args, Context> | [EitherCbMacro<Args, Context>, ...EitherCbMacro<Args, Context>[]];

--- a/index.d.ts
+++ b/index.d.ts
@@ -419,8 +419,7 @@ export type OneOrMoreMacros<Args extends any[], Context> = _Macro<Args, Context>
 
 export type UntitledCbMacro<Args extends any[], Context = {}> = (t: CbExecutionContext<Context>, ...args: Args) => ImplementationResult
 /** A reusable test or hook implementation, for tests & hooks declared with the `.cb` modifier. */
-export interface CbMacro<Args extends any[], Context = {}> {
-	(t: CbExecutionContext<Context>, ...args: Args): ImplementationResult;
+export type CbMacro<Args extends any[], Context = {}> = UntitledCbMacro<Args, Context> & {
 	title?: (providedTitle: string | undefined, ...args: Args) => string;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -404,6 +404,7 @@ export type CbImplementation<Context = {}> = (t: CbExecutionContext<Context>) =>
 
 /** A reusable test or hook implementation. */
 export type UntitledMacro<Args extends any[], Context = {}> = (t: ExecutionContext<Context>, ...args: Args) => ImplementationResult;
+
 /** A reusable test or hook implementation. */
 export type Macro<Args extends any[], Context = {}> = UntitledMacro<Args, Context> & {
 	/**
@@ -420,6 +421,7 @@ export type OneOrMoreMacros<Args extends any[], Context> = EitherMacro<Args, Con
 
 /** A reusable test or hook implementation, for tests & hooks declared with the `.cb` modifier. */
 export type UntitledCbMacro<Args extends any[], Context = {}> = (t: CbExecutionContext<Context>, ...args: Args) => ImplementationResult
+
 /** A reusable test or hook implementation, for tests & hooks declared with the `.cb` modifier. */
 export type CbMacro<Args extends any[], Context = {}> = UntitledCbMacro<Args, Context> & {
 	title?: (providedTitle: string | undefined, ...args: Args) => string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -402,10 +402,9 @@ export type ImplementationResult = PromiseLike<void> | ObservableLike | void;
 export type Implementation<Context = {}> = (t: ExecutionContext<Context>) => ImplementationResult;
 export type CbImplementation<Context = {}> = (t: CbExecutionContext<Context>) => ImplementationResult;
 
+export type UntitledMacro<Args extends any[], Context = {}> = (t: ExecutionContext<Context>, ...args: Args) => ImplementationResult;
 /** A reusable test or hook implementation. */
-export interface Macro<Args extends any[], Context = {}> {
-	(t: ExecutionContext<Context>, ...args: Args): ImplementationResult;
-
+export type Macro<Args extends any[], Context = {}> = UntitledMacro<Args, Context> & {
 	/**
 	 * Implement this function to generate a test (or hook) title whenever this macro is used. `providedTitle` contains
 	 * the title provided when the test or hook was declared. Also receives the remaining test arguments.
@@ -413,56 +412,32 @@ export interface Macro<Args extends any[], Context = {}> {
 	title?: (providedTitle: string | undefined, ...args: Args) => string;
 }
 
-/** Alias for a single macro, or an array of macros. */
-export type OneOrMoreMacros<Args extends any[], Context> = Macro<Args, Context> | [Macro<Args, Context>, ...Macro<Args, Context>[]];
+type _Macro<Args extends any[], Context> = Macro<Args, Context> | UntitledMacro<Args, Context>;
 
+/** Alias for a single macro, or an array of macros. */
+export type OneOrMoreMacros<Args extends any[], Context> = _Macro<Args, Context> | [_Macro<Args, Context>, ..._Macro<Args, Context>[]];
+
+export type UntitledCbMacro<Args extends any[], Context = {}> = (t: CbExecutionContext<Context>, ...args: Args) => ImplementationResult
 /** A reusable test or hook implementation, for tests & hooks declared with the `.cb` modifier. */
 export interface CbMacro<Args extends any[], Context = {}> {
 	(t: CbExecutionContext<Context>, ...args: Args): ImplementationResult;
 	title?: (providedTitle: string | undefined, ...args: Args) => string;
 }
 
+type _CbMacro<Args extends any[], Context> = CbMacro<Args, Context> | UntitledCbMacro<Args, Context>;
+
 /** Alias for a single macro, or an array of macros, used for tests & hooks declared with the `.cb` modifier. */
-export type OneOrMoreCbMacros<Args extends any[], Context> = CbMacro<Args, Context> | [CbMacro<Args, Context>, ...CbMacro<Args, Context>[]];
-
-/** Infers the types of the additional arguments the macro implementations should be called with. */
-export type InferArgs<OneOrMore> =
-	OneOrMore extends Macro<infer Args, any> ? Args :
-	OneOrMore extends Macro<infer Args, any>[] ? Args :
-	OneOrMore extends CbMacro<infer Args, any> ? Args :
-	OneOrMore extends CbMacro<infer Args, any>[] ? Args :
-	never;
-
-export type TitleOrMacro<Context> = string | OneOrMoreMacros<any, Context>
-
-export type MacroOrFirstArg<TitleOrMacro, Context> =
-	TitleOrMacro extends string ? OneOrMoreMacros<any, Context> :
-	TitleOrMacro extends OneOrMoreMacros<any, Context> ? InferArgs<TitleOrMacro>[0] :
-	never
-
-export type TitleOrCbMacro<Context> = string | OneOrMoreCbMacros<any, Context>
-
-export type CbMacroOrFirstArg<TitleOrMacro, Context> =
-	TitleOrMacro extends string ? OneOrMoreCbMacros<any, Context> :
-	TitleOrMacro extends OneOrMoreCbMacros<any, Context> ? InferArgs<TitleOrMacro>[0] :
-	never
-
-export type RestArgs<TitleOrMacro, MacroOrFirstArg, Context> =
-	MacroOrFirstArg extends OneOrMoreMacros<any, Context> ? InferArgs<MacroOrFirstArg> :
-	MacroOrFirstArg extends OneOrMoreCbMacros<any, Context> ? InferArgs<MacroOrFirstArg> :
-	TitleOrMacro extends OneOrMoreMacros<any, Context> ? Tail<InferArgs<TitleOrMacro>> :
-	TitleOrMacro extends OneOrMoreCbMacros<any, Context> ? Tail<InferArgs<TitleOrMacro>> :
-	never
+export type OneOrMoreCbMacros<Args extends any[], Context> = _CbMacro<Args, Context> | [_CbMacro<Args, Context>, ..._CbMacro<Args, Context>[]];
 
 export interface TestInterface<Context = {}> {
 	/** Declare a concurrent test. */
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Declare a concurrent test that uses one or more macros. Additional arguments are passed to the macro. */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void
 
 	/** Declare a concurrent test that uses one or more macros. The macro is responsible for generating a unique test title. */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a hook that is run once, after all tests have passed. */
 	after: AfterInterface<Context>;
@@ -499,10 +474,10 @@ export interface AfterInterface<Context = {}> {
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Declare a hook that is run once, after all tests have passed. Additional arguments are passed to the macro. */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a hook that is run once, after all tests have passed. */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a hook that is run once, after all tests are done. */
 	always: AlwaysInterface<Context>;
@@ -521,10 +496,10 @@ export interface AlwaysInterface<Context = {}> {
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Declare a hook that is run once, after all tests are done. Additional arguments are passed to the macro. */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a hook that is run once, after all tests are done. */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a hook that must call `t.end()` when it's done. */
 	cb: HookCbInterface<Context>;
@@ -540,10 +515,10 @@ export interface BeforeInterface<Context = {}> {
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Declare a hook that is run once, before all tests. Additional arguments are passed to the macro. */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a hook that is run once, before all tests. */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a hook that must call `t.end()` when it's done. */
 	cb: HookCbInterface<Context>;
@@ -559,13 +534,13 @@ export interface CbInterface<Context = {}> {
 	 * Declare a concurrent test that uses one or more macros. The macros must call `t.end()` when they're done.
 	 * Additional arguments are passed to the macro.
 	 */
-	<ToM extends TitleOrCbMacro<Context>, MoA extends CbMacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	/**
 	 * Declare a concurrent test that uses one or more macros. The macros must call `t.end()` when they're done.
 	 * The macro is responsible for generating a unique test title.
 	 */
-	(macro: OneOrMoreCbMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a test that is expected to fail. */
 	failing: CbFailingInterface<Context>;
@@ -582,13 +557,13 @@ export interface CbFailingInterface<Context = {}> {
 	 * Declare a test that uses one or more macros. The macros must call `t.end()` when they're done.
 	 * Additional arguments are passed to the macro. The test is expected to fail.
 	 */
-	<ToM extends TitleOrCbMacro<Context>, MoA extends CbMacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	/**
 	 * Declare a test that uses one or more macros. The macros must call `t.end()` when they're done.
 	 * The test is expected to fail.
 	 */
-	(macro: OneOrMoreCbMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	only: CbOnlyInterface<Context>;
 	skip: CbSkipInterface<Context>;
@@ -604,13 +579,13 @@ export interface CbOnlyInterface<Context = {}> {
 	 * Declare a test that uses one or more macros. The macros must call `t.end()` when they're done.
 	 * Additional arguments are passed to the macro. Only this test and others declared with `.only()` are run.
 	 */
-	<ToM extends TitleOrCbMacro<Context>, MoA extends CbMacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	/**
 	 * Declare a test that uses one or more macros. The macros must call `t.end()` when they're done.
 	 * Additional arguments are passed to the macro. Only this test and others declared with `.only()` are run.
 	 */
-	(macro: OneOrMoreCbMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 }
 
 export interface CbSkipInterface<Context = {}> {
@@ -618,10 +593,10 @@ export interface CbSkipInterface<Context = {}> {
 	(title: string, implementation: CbImplementation<Context>): void;
 
 	/** Skip this test. */
-	<ToM extends TitleOrCbMacro<Context>, MoA extends CbMacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	/** Skip this test. */
-	(macro: OneOrMoreCbMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 }
 
 export interface FailingInterface<Context = {}> {
@@ -632,13 +607,13 @@ export interface FailingInterface<Context = {}> {
 	 * Declare a concurrent test that uses one or more macros. Additional arguments are passed to the macro.
 	 * The test is expected to fail.
 	 */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/**
 	 * Declare a concurrent test that uses one or more macros. The macro is responsible for generating a unique test title.
 	 * The test is expected to fail.
 	 */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	only: OnlyInterface<Context>;
 	skip: SkipInterface<Context>;
@@ -655,12 +630,12 @@ export interface HookCbInterface<Context = {}> {
 	 * Declare a hook that uses one or more macros. The macros must call `t.end()` when they're done.
 	 * Additional arguments are passed to the macro.
 	 */
-	<ToM extends TitleOrCbMacro<Context>, MoA extends CbMacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	/**
 	 * Declare a hook that uses one or more macros. The macros must call `t.end()` when they're done.
 	 */
-	(macro: OneOrMoreCbMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	skip: HookCbSkipInterface<Context>;
 }
@@ -673,10 +648,10 @@ export interface HookCbSkipInterface<Context = {}> {
 	(title: string, implementation: CbImplementation<Context>): void;
 
 	/** Skip this hook. */
-	<ToM extends TitleOrCbMacro<Context>, MoA extends CbMacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 
 	/** Skip this hook. */
-	(macro: OneOrMoreCbMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreCbMacros<T, Context>, ...rest: T): void;
 }
 
 export interface HookSkipInterface<Context = {}> {
@@ -687,10 +662,10 @@ export interface HookSkipInterface<Context = {}> {
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Skip this hook. */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Skip this hook. */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 }
 
 export interface OnlyInterface<Context = {}> {
@@ -701,13 +676,13 @@ export interface OnlyInterface<Context = {}> {
 	 * Declare a test that uses one or more macros. Additional arguments are passed to the macro.
 	 * Only this test and others declared with `.only()` are run.
 	 */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/**
 	 * Declare a test that uses one or more macros. The macro is responsible for generating a unique test title.
 	 * Only this test and others declared with `.only()` are run.
 	 */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 }
 
 export interface SerialInterface<Context = {}> {
@@ -715,12 +690,12 @@ export interface SerialInterface<Context = {}> {
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Declare a serial test that uses one or more macros. Additional arguments are passed to the macro. */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/**
 	 * Declare a serial test that uses one or more macros. The macro is responsible for generating a unique test title.
 	 */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Declare a serial hook that is run once, after all tests have passed. */
 	after: AfterInterface<Context>;
@@ -750,10 +725,10 @@ export interface SkipInterface<Context = {}> {
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Skip this test. */
-	<ToM extends TitleOrMacro<Context>, MoA extends MacroOrFirstArg<ToM, Context>>(titleOrMacro: ToM, macroOrArg: MoA, ...rest: RestArgs<ToM, MoA, Context>): void;
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Skip this test. */
-	(macro: OneOrMoreMacros<[], Context>): void
+	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 }
 
 export interface TodoDeclaration {
@@ -804,33 +779,3 @@ export const todo: TodoDeclaration;
 
 /** Meta data associated with the current process. */
 export const meta: MetaInterface;
-
-/*
-Tail type from <https://github.com/tycho01/typical/blob/25f11ed92c960aab1ebbf47fd6ead9e0ae51d947/src/array/Tail.ts>.
-
-MIT License
-
-Copyright (c) 2017 Thomas Crockett
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
-
-/** Get all but the first element of a tuple. */
-export type Tail<T extends any[]> =
-	((...args: T) => any) extends ((head: any, ...tail: infer R) => any) ? R : never;

--- a/index.d.ts
+++ b/index.d.ts
@@ -402,6 +402,7 @@ export type ImplementationResult = PromiseLike<void> | ObservableLike | void;
 export type Implementation<Context = {}> = (t: ExecutionContext<Context>) => ImplementationResult;
 export type CbImplementation<Context = {}> = (t: CbExecutionContext<Context>) => ImplementationResult;
 
+/** A reusable test or hook implementation. */
 export type UntitledMacro<Args extends any[], Context = {}> = (t: ExecutionContext<Context>, ...args: Args) => ImplementationResult;
 /** A reusable test or hook implementation. */
 export type Macro<Args extends any[], Context = {}> = UntitledMacro<Args, Context> & {
@@ -417,6 +418,7 @@ type _Macro<Args extends any[], Context> = Macro<Args, Context> | UntitledMacro<
 /** Alias for a single macro, or an array of macros. */
 export type OneOrMoreMacros<Args extends any[], Context> = _Macro<Args, Context> | [_Macro<Args, Context>, ..._Macro<Args, Context>[]];
 
+/** A reusable test or hook implementation, for tests & hooks declared with the `.cb` modifier. */
 export type UntitledCbMacro<Args extends any[], Context = {}> = (t: CbExecutionContext<Context>, ...args: Args) => ImplementationResult
 /** A reusable test or hook implementation, for tests & hooks declared with the `.cb` modifier. */
 export type CbMacro<Args extends any[], Context = {}> = UntitledCbMacro<Args, Context> & {

--- a/index.d.ts
+++ b/index.d.ts
@@ -413,10 +413,10 @@ export type Macro<Args extends any[], Context = {}> = UntitledMacro<Args, Contex
 	title?: (providedTitle: string | undefined, ...args: Args) => string;
 }
 
-type _Macro<Args extends any[], Context> = Macro<Args, Context> | UntitledMacro<Args, Context>;
+type EitherMacro<Args extends any[], Context> = Macro<Args, Context> | UntitledMacro<Args, Context>;
 
 /** Alias for a single macro, or an array of macros. */
-export type OneOrMoreMacros<Args extends any[], Context> = _Macro<Args, Context> | [_Macro<Args, Context>, ..._Macro<Args, Context>[]];
+export type OneOrMoreMacros<Args extends any[], Context> = EitherMacro<Args, Context> | [EitherMacro<Args, Context>, ...EitherMacro<Args, Context>[]];
 
 /** A reusable test or hook implementation, for tests & hooks declared with the `.cb` modifier. */
 export type UntitledCbMacro<Args extends any[], Context = {}> = (t: CbExecutionContext<Context>, ...args: Args) => ImplementationResult
@@ -425,10 +425,10 @@ export type CbMacro<Args extends any[], Context = {}> = UntitledCbMacro<Args, Co
 	title?: (providedTitle: string | undefined, ...args: Args) => string;
 }
 
-type _CbMacro<Args extends any[], Context> = CbMacro<Args, Context> | UntitledCbMacro<Args, Context>;
+type EitherCbMacro<Args extends any[], Context> = CbMacro<Args, Context> | UntitledCbMacro<Args, Context>;
 
 /** Alias for a single macro, or an array of macros, used for tests & hooks declared with the `.cb` modifier. */
-export type OneOrMoreCbMacros<Args extends any[], Context> = _CbMacro<Args, Context> | [_CbMacro<Args, Context>, ..._CbMacro<Args, Context>[]];
+export type OneOrMoreCbMacros<Args extends any[], Context> = EitherCbMacro<Args, Context> | [EitherCbMacro<Args, Context>, ...EitherCbMacro<Args, Context>[]];
 
 export interface TestInterface<Context = {}> {
 	/** Declare a concurrent test. */

--- a/test/ts-types/macros.ts
+++ b/test/ts-types/macros.ts
@@ -62,3 +62,14 @@ import test, {ExecutionContext, Macro} from '../..';
 		t.is(input.length, expected)
 	}, 'bar', 3)
 }
+
+// Completely infer parameters
+{
+	test('has length 3', (t, input, expected) => {
+		t.is(input.length, expected);
+	}, 'foo', 3);
+
+	test((t, input, expected) => {
+		t.is(input.length, expected)
+	}, 'foo', 3);
+}


### PR DESCRIPTION
I have noticed that with the types before the proposed change (current types), the following type checks (but it should not). I'm not sure if version of typescript matters here or not, but I'm using 3.3.4000. However, if the title is removed from the test definition, it will fail as it should and even with proper error.
```ts
const hasLength: Macro<[string, number]> = (t, input, expected) => {
	t.is(input.length, expected);
};

test('bar has length 3', [hasLength], 2, 3); // should fail
//                                    ^ Wrong type
test([hasLength], 2, 3);
//                ^ error TS2345: Argument of type '2' is not assignable to parameter of type 'string'.
```

----

The change removes all of the crafty and clever type stuff in favor of simpler solution. Additionally, this change introduces the distinction between Title Macro and Untitled macro. Such distinction helps with the inference of parameter types, when we are passing macro inline without any types specified.

Essentially, in the following example we do not need to explicitly type parameters `t`, `input` and `expected`. Previously, in this case we had to explicitly specify types on parameters of test function.
```ts
test('has length 3', (t, input, expected) => {
	t.is(input.length, expected);
}, 'foo', 3);
```

However, this PR has a flaw that it does not give the user a very useful type error, when it fails. Consider the following case.
```ts
const hasLength: Macro<[string, number]> = (t, input, expected) => {
	t.is(input.length, expected);
};

test('bar has length 3', hasLength, 3, 'bar'); // useless error
//   ^ error TS2345: Argument of type '"bar has length 3"' is not assignable to parameter of type 'OneOrMoreMacros<[Macro<[string, number], {}>, number, string], {}>'.

test(hasLength, 3, 'bar'); // useful error
//              ^ error TS2345: Argument of type '3' is not assignable to parameter of type 'string'.
```
In this case, when title is provided, it is not obvious what the error means. However, if we swap around lines 436 and 439 in the changed file, then the errors swap around - the function call with the title has a useful error message and the one without the title has a useless one! This is exactly the kind of error and useless message that the original change was intended to address. However, it was not very well done.

Maybe the best approach would be to keep types simple and prefer unreadable error over no error at all. Also, if the case where title is provided is more frequently used over the macro without the title case, then we can reorder those two lines, so that there is more readable error for the more used scenario, with the sacrifice that the less used case will receive less readable error.

----

P.S. These types turned out to be very complicated and tedious to work with - ordering changes the error message completely, having "optional" title messes things up for TypeScript. Clearly the best type annotation would be something along the lines of `<T extends any[]>(title?: string, macro: Macro<T, Context>, ...rest: T): void;`, which merges the existence or non-existence of title into one definition, but this is not supported. 

Maybe we should consider asking for help from people familiar with these types of issues.


<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
