### PR TITLE
Update TypeScript recipe to allow ESM

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -8,7 +8,7 @@ This guide assumes you've already set up TypeScript for your project. Note that 
 
 ## Configuring AVA to compile TypeScript files on the fly
 
-You can configure AVA to recognize TypeScript files. Then, with `ts-node` installed, you can compile them on the fly.
+You can configure AVA to recognize TypeScript files. Then, with `ts-node` installed, you can compile them on the fly. Also you will need to install `esm` to add support for `import` & `export`.
 
 **`package.json`:**
 
@@ -20,7 +20,8 @@ You can configure AVA to recognize TypeScript files. Then, with `ts-node` instal
 			"ts"
 		],
 		"require": [
-			"ts-node/register"
+			"ts-node/register",
+			"esm"
 		]
 	}
 }

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -8,7 +8,7 @@ This guide assumes you've already set up TypeScript for your project. Note that 
 
 ## Configuring AVA to compile TypeScript files on the fly
 
-You can configure AVA to recognize TypeScript files. Then, with `ts-node` installed, you can compile them on the fly. Also you will need to install `esm` to add support for `import` & `export`.
+You can configure AVA to recognize TypeScript files. Then, with `ts-node` installed, you can compile them on the fly.
 
 **`package.json`:**
 
@@ -20,14 +20,30 @@ You can configure AVA to recognize TypeScript files. Then, with `ts-node` instal
 			"ts"
 		],
 		"require": [
-			"ts-node/register",
-			"esm"
+			"ts-node/register"
 		]
 	}
 }
 ```
 
 It's worth noting that with this configuration tests will fail if there are TypeScript build errors. If you want to test while ignoring these errors you can use `ts-node/register/transpile-only` instead of `ts-node/register`.
+
+If you are using `"module": "esnext"` in your `tsconfig.json` file, you also will need to install `esm@3.2.20` to add support for `import` & `export`. After install add `esm` to the `require` section.
+**Warning:** versions 3.2.21 and 3.2.22 have reported issues: https://github.com/standard-things/esm/issues/782
+
+**`package.json`:**
+
+```json
+{
+	"ava": {
+		...
+		"require": [
+			...
+			"esm"
+		]
+	}
+}
+```
 
 ## Compiling TypeScript files before running AVA
 


### PR DESCRIPTION
Added `esm` module to require parameter to avoid `SyntaxError: Unexpected identifier` error when using ECMAScript module loader(`import` or `export`).

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
