### PR TITLE
Move api.js into lib/

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -14,12 +14,12 @@ const arrify = require('arrify');
 const makeDir = require('make-dir');
 const ms = require('ms');
 const chunkd = require('chunkd');
-const babelPipeline = require('./lib/babel-pipeline');
-const Emittery = require('./lib/emittery');
-const RunStatus = require('./lib/run-status');
-const AvaFiles = require('./lib/ava-files');
-const fork = require('./lib/fork');
-const serializeError = require('./lib/serialize-error');
+const babelPipeline = require('./babel-pipeline');
+const Emittery = require('./emittery');
+const RunStatus = require('./run-status');
+const AvaFiles = require('./ava-files');
+const fork = require('./fork');
+const serializeError = require('./serialize-error');
 
 function resolveModules(modules) {
 	return arrify(modules).map(name => {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -156,7 +156,7 @@ exports.run = () => { // eslint-disable-line complexity
 	}
 
 	const ciParallelVars = require('ci-parallel-vars');
-	const Api = require('../api');
+	const Api = require('./api');
 	const VerboseReporter = require('./reporters/verbose');
 	const MiniReporter = require('./reporters/mini');
 	const TapReporter = require('./reporters/tap');

--- a/test/api.js
+++ b/test/api.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const del = require('del');
 const {test} = require('tap');
-const Api = require('../api');
+const Api = require('../lib/api');
 const babelPipeline = require('../lib/babel-pipeline');
 
 const testCapitalizerPlugin = require.resolve('./fixture/babel-plugin-test-capitalizer');

--- a/test/helper/report.js
+++ b/test/helper/report.js
@@ -10,8 +10,8 @@ const pkg = require('../../package.json');
 let _Api = null;
 const createApi = options => {
 	if (!_Api) {
-		_Api = proxyquire('../../api', {
-			'./lib/fork': proxyquire('../../lib/fork', {
+		_Api = proxyquire('../../lib/api', {
+			'./fork': proxyquire('../../lib/fork', {
 				child_process: Object.assign({}, childProcess, { // eslint-disable-line camelcase
 					fork(filename, argv, options) {
 						return childProcess.fork(path.join(__dirname, 'report-worker.js'), argv, options);


### PR DESCRIPTION
Originally the goal may have been for this to be accessible
programmatically, but it's unclear whether we'd ever end up supporting
that. For now moving it into the lib/ directory better communicates it's
internal.
