### PR TITLE
Fix sample test in TypeScript recipe

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -49,7 +49,7 @@ Create a `test.ts` file.
 ```ts
 import test from 'ava';
 
-const fn = () => Promise.resolve('foo');
+const fn = () => 'foo';
 
 test('fn() returns foo', t => {
 	t.is(fn(), 'foo');

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -51,7 +51,7 @@ import test from 'ava';
 
 const fn = async () => Promise.resolve('foo');
 
-test(async t => {
+test('receive foo asynchronously', async t => {
 	t.is(await fn(), 'foo');
 });
 ```

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -49,10 +49,10 @@ Create a `test.ts` file.
 ```ts
 import test from 'ava';
 
-const fn = async () => Promise.resolve('foo');
+const fn = () => Promise.resolve('foo');
 
-test('receive foo asynchronously', async t => {
-	t.is(await fn(), 'foo');
+test('fn() returns foo', t => {
+	t.is(fn(), 'foo');
 });
 ```
 


### PR DESCRIPTION
The getting started example contains a minor defect.  Ava requires a label, but the example given does not have one.

```
test(async t => {
	t.is(await fn(), 'foo');
});
```

Result:

```
$ npx ava ./src/test/testset.ts

  Uncaught exception in src\test\testset.ts

  (censored)\src\test\testset.ts:12

   11:
   12: test(async t => {
   13:   t.is(await fn(), 'foo');

  TypeError: Tests must have a title

  Object.<anonymous> (src/test/testset.ts:12:5)
  Module.m._compile (node_modules/ts-node/src/index.ts:439:23)
  Object.require.extensions.(anonymous function) [as .ts] (node_modules/ts-node/src/index.ts:442:12)
```

Proposed replacement:

```
test('receive foo asynchronously', async t => {
	t.is(await fn(), 'foo');
});
```
