### PR TITLE
fix: allow tests inside of helpers that arent test helpers

### DIFF
--- a/lib/ava-files.js
+++ b/lib/ava-files.js
@@ -76,7 +76,12 @@ function handlePaths(files, extensions, excludePatterns, globOptions) {
 const defaultExcludePatterns = () => [
 	'!**/node_modules/**',
 	'!**/fixtures/**',
-	'!**/helpers/**'
+	'!**/__tests__/**/helpers/**',
+	'!**/test/**/helpers/**',
+	'!**/helpers/!(?(__tests__))/!(?(__tests__))',
+	'!**/helpers/!(?(__tests__))/!(?(__tests__))/!(?(__tests__))',
+	'!**/helpers/!(?(__tests__))/!(?(__tests__))/!(?(__tests__))/!(?(__tests__))',
+	'!**/helpers/!(?(__tests__))/!(?(__tests__))/!(?(__tests__))/!(?(__tests__))/!(?(__tests__))',
 ];
 
 const defaultIncludePatterns = extPattern => [


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
i have non-test things called "helpers" and i wanted to test them. so i crafted this glob. Considering how you're changing things with helpers, idk how useful this PR would be, but here it is anyways. Sorry for the casual PR message, it's the end of the day on a friday :3
