### PR TITLE
Make the object printing depth configurable

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -107,3 +107,20 @@ export default ({projectDir}) => {
 ```
 
 Note that the final configuration must not be a promise.
+
+## Object printing depth
+
+By default, Ava prints nested objects to a depth of 3. However, when debugging tests it's sometimes useful to print more detail in highly nested objects. This can be done by setting [`util.inspect.defaultOptions.depth`](https://nodejs.org/api/util.html#util_util_inspect_defaultoptions) to the desired depth, before the test is executed:
+
+```js
+import test from 'ava';
+import util from 'util';  // import the "util" module from Node.js
+
+util.inspect.defaultOptions.depth = 5;  // set the depth
+
+...
+
+test("My test", ...);
+```
+
+The minimum object printing depth is 3. If it's set lower than 3, Ava will still print 3 levels of nested objects.

--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -110,17 +110,18 @@ Note that the final configuration must not be a promise.
 
 ## Object printing depth
 
-By default, Ava prints nested objects to a depth of 3. However, when debugging tests it's sometimes useful to print more detail in highly nested objects. This can be done by setting [`util.inspect.defaultOptions.depth`](https://nodejs.org/api/util.html#util_util_inspect_defaultoptions) to the desired depth, before the test is executed:
+By default, AVA prints nested objects to a depth of `3`. However, when debugging tests with deeply nested objects, it can be useful to print with more detail. This can be done by setting [`util.inspect.defaultOptions.depth`](https://nodejs.org/api/util.html#util_util_inspect_defaultoptions) to the desired depth, before the test is executed:
 
 ```js
+import util from 'util';
+
 import test from 'ava';
-import util from 'util';  // import the "util" module from Node.js
 
-util.inspect.defaultOptions.depth = 5;  // set the depth
+util.inspect.defaultOptions.depth = 5;  // Increase AVA's printing depth
 
-...
-
-test("My test", ...);
+test('My test', t => {
+	t.deepEqual(someDeeplyNestedObject, theExpectedValue);
+});
 ```
 
-The minimum object printing depth is 3. If it's set lower than 3, Ava will still print 3 levels of nested objects.
+AVA has a minimum depth of `3`.

--- a/lib/concordance-options.js
+++ b/lib/concordance-options.js
@@ -1,4 +1,5 @@
 'use strict';
+const util = require('util');
 const ansiStyles = require('ansi-styles');
 const stripAnsi = require('strip-ansi');
 const cloneDeepWith = require('lodash.clonedeepwith');
@@ -124,6 +125,6 @@ const plainTheme = cloneDeepWith(colorTheme, value => {
 });
 
 const theme = chalk.enabled ? colorTheme : plainTheme;
-exports.default = {maxDepth: 3, plugins, theme};
+exports.default = {maxDepth: util.inspect.defaultOptions.depth, plugins, theme};
 exports.diff = {maxDepth: 1, plugins, theme};
 exports.snapshotManager = {plugins, theme: plainTheme};

--- a/lib/concordance-options.js
+++ b/lib/concordance-options.js
@@ -125,6 +125,15 @@ const plainTheme = cloneDeepWith(colorTheme, value => {
 });
 
 const theme = chalk.enabled ? colorTheme : plainTheme;
-exports.default = {maxDepth: util.inspect.defaultOptions.depth, plugins, theme};
+
+exports.default = {
+	// Use Node's object inspection depth, clamped to a minimum of 3
+	get maxDepth() {
+		return Math.max(3, util.inspect.defaultOptions.depth);
+	},
+	plugins,
+	theme
+};
+
 exports.diff = {maxDepth: 1, plugins, theme};
 exports.snapshotManager = {plugins, theme: plainTheme};


### PR DESCRIPTION
When printing objects or exceptions, Ava restricts the depth of the printed objects to 3 levels. Some libraries that like to throw exceptions with deeply nested data in them (e.g. Axios) would benefit from increasing the printing depth when debugging failing tests, but unfortunately this depth is hardcoded in Ava and it's not possible to change it by the user.

I would propose instead to tie this depth to [`util.inspect.defaultOptions.depth`](https://nodejs.org/api/util.html#util_util_inspect_defaultoptions), which is a setting that NodeJS uses to control the depth of printing for `console.log()` and similar. Most NodeJS developers who have had to debug deeply nested objects by printing them with `console.log()` are already familiar with this setting, so it would come natural to use the same setting to control Ava's printing depth.

There are other ways this could be implemented, of course, for example by exposing this option as a command line argument or through some Ava-specific environment variable, but I think tying it to NodeJS's printing depth is the most practical solution. This way a NodeJS developer could kill two birds with one stone, by setting both the NodeJS and Ava printing depth in one go, rather than hunting for Ava-specific docs separately.
