### PR TITLE
Fix the `SkipInterface` in the TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -732,7 +732,7 @@ export interface SkipInterface<Context = {}> {
 	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 
 	/** Skip this test. */
-	<T extends any[]>(title: string, macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
+	<T extends any[]>(macros: OneOrMoreMacros<T, Context>, ...rest: T): void;
 }
 
 export interface TodoDeclaration {

--- a/test/ts-types/macros.ts
+++ b/test/ts-types/macros.ts
@@ -72,4 +72,8 @@ import test, {ExecutionContext, Macro} from '../..';
 	test((t, input, expected) => {
 		t.is(input.length, expected)
 	}, 'foo', 3);
+
+	test.skip((t, input, expected) => {
+		t.is(input.length, expected)
+	}, 'foo', 3);
 }


### PR DESCRIPTION
This fixes a copy/paste mistake in the TS definition preventing us from using the `skip` method with macros and without a title.