### PR TITLE
Store an error object in AssertionError rather than a stack trace

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -53,26 +53,14 @@ class AssertionError extends Error {
 		// Reserved for power-assert statements
 		this.statements = [];
 
-		if (opts.stack) {
-			this.stack = opts.stack;
-		} else {
-			const limitBefore = Error.stackTraceLimit;
-			Error.stackTraceLimit = Infinity;
-			Error.captureStackTrace(this);
-			Error.stackTraceLimit = limitBefore;
-		}
+        if (opts.savedError && isError(opts.savedError)) {
+            this.savedError = opts.savedError;
+        } else {
+            this.savedError = new Error();
+        }
 	}
 }
 exports.AssertionError = AssertionError;
-
-function getStack() {
-	const limitBefore = Error.stackTraceLimit;
-	Error.stackTraceLimit = Infinity;
-	const obj = {};
-	Error.captureStackTrace(obj, getStack);
-	Error.stackTraceLimit = limitBefore;
-	return obj.stack;
-}
 
 function validateExpectations(assertion, expectations, numArgs) { // eslint-disable-line complexity
 	if (typeof expectations === 'function') {
@@ -143,12 +131,12 @@ function validateExpectations(assertion, expectations, numArgs) { // eslint-disa
 
 // Note: this function *must* throw exceptions, since it can be used
 // as part of a pending assertion for promises.
-function assertExpectations({assertion, actual, expectations, message, prefix, stack}) {
+function assertExpectations({assertion, actual, expectations, message, prefix, savedError}) {
 	if (!isError(actual)) {
 		throw new AssertionError({
 			assertion,
 			message,
-			stack,
+			savedError,
 			values: [formatWithLabel(`${prefix} exception that is not an error:`, actual)]
 		});
 	}
@@ -159,7 +147,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		throw new AssertionError({
 			assertion,
 			message,
-			stack,
+			savedError,
 			actualStack,
 			values: [
 				formatWithLabel(`${prefix} unexpected exception:`, actual),
@@ -172,7 +160,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		throw new AssertionError({
 			assertion,
 			message,
-			stack,
+			savedError,
 			actualStack,
 			values: [
 				formatWithLabel(`${prefix} unexpected exception:`, actual),
@@ -185,7 +173,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		throw new AssertionError({
 			assertion,
 			message,
-			stack,
+			savedError,
 			actualStack,
 			values: [
 				formatWithLabel(`${prefix} unexpected exception:`, actual),
@@ -198,7 +186,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		throw new AssertionError({
 			assertion,
 			message,
-			stack,
+			savedError,
 			actualStack,
 			values: [
 				formatWithLabel(`${prefix} unexpected exception:`, actual),
@@ -211,7 +199,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		throw new AssertionError({
 			assertion,
 			message,
-			stack,
+			savedError,
 			actualStack,
 			values: [
 				formatWithLabel(`${prefix} unexpected exception:`, actual),
@@ -224,7 +212,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		throw new AssertionError({
 			assertion,
 			message,
-			stack,
+			savedError,
 			actualStack,
 			values: [
 				formatWithLabel(`${prefix} unexpected exception:`, actual),
@@ -480,14 +468,14 @@ class Assertions {
 			}
 
 			const handlePromise = (promise, wasReturned) => {
-				// Record stack before it gets lost in the promise chain.
-				const stack = getStack();
+				// Create an error object to record the stack before it gets lost in the promise chain.
+				const savedError = new Error();
 				// Handle "promise like" objects by casting to a real Promise.
 				const intermediate = Promise.resolve(promise).then(value => { // eslint-disable-line promise/prefer-await-to-then
 					throw new AssertionError({
 						assertion: 'throwsAsync',
 						message,
-						stack,
+						savedError,
 						values: [formatWithLabel(`${wasReturned ? 'Returned promise' : 'Promise'} resolved with:`, value)]
 					});
 				}, reason => {
@@ -497,7 +485,7 @@ class Assertions {
 						expectations,
 						message,
 						prefix: `${wasReturned ? 'Returned promise' : 'Promise'} rejected with`,
-						stack
+						savedError
 					});
 					return reason;
 				});
@@ -587,14 +575,14 @@ class Assertions {
 			}
 
 			const handlePromise = (promise, wasReturned) => {
-				// Record stack before it gets lost in the promise chain.
-				const stack = getStack();
+				// Create an error object to record the stack before it gets lost in the promise chain.
+				const stack = new Error();
 				// Handle "promise like" objects by casting to a real Promise.
 				const intermediate = Promise.resolve(promise).then(noop, error => { // eslint-disable-line promise/prefer-await-to-then
 					throw new AssertionError({
 						assertion: 'notThrowsAsync',
 						message,
-						actualStack: stack,
+						savedError,
 						values: [formatWithLabel(`${wasReturned ? 'Returned promise' : 'Promise'} rejected with:`, error)]
 					});
 				});

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -53,14 +53,22 @@ class AssertionError extends Error {
 		// Reserved for power-assert statements
 		this.statements = [];
 
-        if (opts.savedError && isError(opts.savedError)) {
-            this.savedError = opts.savedError;
-        } else {
-            this.savedError = new Error();
-        }
+		if (opts.savedError && isError(opts.savedError)) {
+			this.savedError = opts.savedError;
+		} else {
+			this.savedError = getErrorWithLongStackTrace();
+		}
 	}
 }
 exports.AssertionError = AssertionError;
+
+function getErrorWithLongStackTrace() {
+	const limitBefore = Error.stackTraceLimit;
+	Error.stackTraceLimit = Infinity;
+	const err = new Error();
+	Error.stackTraceLimit = limitBefore;
+	return err;
+}
 
 function validateExpectations(assertion, expectations, numArgs) { // eslint-disable-line complexity
 	if (typeof expectations === 'function') {
@@ -469,7 +477,7 @@ class Assertions {
 
 			const handlePromise = (promise, wasReturned) => {
 				// Create an error object to record the stack before it gets lost in the promise chain.
-				const savedError = new Error();
+				const savedError = getErrorWithLongStackTrace();
 				// Handle "promise like" objects by casting to a real Promise.
 				const intermediate = Promise.resolve(promise).then(value => { // eslint-disable-line promise/prefer-await-to-then
 					throw new AssertionError({
@@ -576,7 +584,7 @@ class Assertions {
 
 			const handlePromise = (promise, wasReturned) => {
 				// Create an error object to record the stack before it gets lost in the promise chain.
-				const stack = new Error();
+				const savedError = getErrorWithLongStackTrace();
 				// Handle "promise like" objects by casting to a real Promise.
 				const intermediate = Promise.resolve(promise).then(noop, error => { // eslint-disable-line promise/prefer-await-to-then
 					throw new AssertionError({

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -53,7 +53,7 @@ class AssertionError extends Error {
 		// Reserved for power-assert statements
 		this.statements = [];
 
-		if (opts.savedError && isError(opts.savedError)) {
+		if (opts.savedError) {
 			this.savedError = opts.savedError;
 		} else {
 			this.savedError = getErrorWithLongStackTrace();

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -51,11 +51,11 @@ function buildSource(source) {
 }
 
 function trySerializeError(err, shouldBeautifyStack) {
-	if (err.savedError) {
-		err.stack = err.savedError.stack;
-	}
+	let stack = err.savedError ? err.savedError.stack : err.stack;
 
-	const stack = shouldBeautifyStack ? beautifyStack(err.stack) : err.stack;
+	if (shouldBeautifyStack) {
+		stack = beautifyStack(stack);
+	}
 
 	const retval = {
 		avaAssertionError: isAvaAssertionError(err),

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -51,10 +51,11 @@ function buildSource(source) {
 }
 
 function trySerializeError(err, shouldBeautifyStack) {
-    if (err.savedError) {
-        err.stack = err.savedError.stack
-    }
-    const stack = shouldBeautifyStack ? beautifyStack(err.stack) : err.stack;
+	if (err.savedError) {
+		err.stack = err.savedError.stack;
+	}
+
+	const stack = shouldBeautifyStack ? beautifyStack(err.stack) : err.stack;
 
 	const retval = {
 		avaAssertionError: isAvaAssertionError(err),

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -51,7 +51,10 @@ function buildSource(source) {
 }
 
 function trySerializeError(err, shouldBeautifyStack) {
-	const stack = shouldBeautifyStack ? beautifyStack(err.stack) : err.stack;
+    if (err.savedError) {
+        err.stack = err.savedError.stack
+    }
+    const stack = shouldBeautifyStack ? beautifyStack(err.stack) : err.stack;
 
 	const retval = {
 		avaAssertionError: isAvaAssertionError(err),

--- a/lib/test.js
+++ b/lib/test.js
@@ -13,14 +13,7 @@ function formatErrorValue(label, error) {
 	return {label, formatted};
 }
 
-const captureStack = start => {
-	const limitBefore = Error.stackTraceLimit;
-	Error.stackTraceLimit = 1;
-	const obj = {};
-	Error.captureStackTrace(obj, start);
-	Error.stackTraceLimit = limitBefore;
-	return obj.stack;
-};
+const captureSavedError = () => new Error();
 
 const testMap = new WeakMap();
 class ExecutionContext extends assert.Assertions {
@@ -60,7 +53,7 @@ class ExecutionContext extends assert.Assertions {
 		};
 
 		this.plan = count => {
-			test.plan(count, captureStack(test.plan));
+			test.plan(count, captureSavedError());
 		};
 
 		this.plan.skip = () => {};
@@ -72,7 +65,7 @@ class ExecutionContext extends assert.Assertions {
 
 	get end() {
 		const end = testMap.get(this).bindEndCallback();
-		const endFn = error => end(error, captureStack(endFn));
+		const endFn = error => end(error, captureSavedError());
 		return endFn;
 	}
 
@@ -143,15 +136,15 @@ class Test {
 
 	bindEndCallback() {
 		if (this.metadata.callback) {
-			return (error, stack) => {
-				this.endCallback(error, stack);
+			return (error, savedError) => {
+				this.endCallback(error, savedError);
 			};
 		}
 
 		throw new Error('`t.end()`` is not supported in this context. To use `t.end()` as a callback, you must use "callback mode" via `test.cb(testName, fn)`');
 	}
 
-	endCallback(error, stack) {
+	endCallback(error, savedError) {
 		if (this.calledEnd) {
 			this.saveFirstError(new Error('`t.end()` called more than once'));
 			return;
@@ -163,7 +156,7 @@ class Test {
 			this.saveFirstError(new assert.AssertionError({
 				actual: error,
 				message: 'Callback called with an error',
-				stack,
+				savedError,
 				values: [formatErrorValue('Callback called with an error:', error)]
 			}));
 		}
@@ -223,7 +216,7 @@ class Test {
 		}
 	}
 
-	plan(count, planStack) {
+	plan(count, planError) {
 		if (typeof count !== 'number') {
 			throw new TypeError('Expected a number');
 		}
@@ -232,7 +225,7 @@ class Test {
 
 		// In case the `planCount` doesn't match `assertCount, we need the stack of
 		// this function to throw with a useful stack.
-		this.planStack = planStack;
+		this.planError = planError;
 	}
 
 	timeout(ms) {
@@ -274,7 +267,7 @@ class Test {
 				assertion: 'plan',
 				message: `Planned for ${this.planCount} ${plur('assertion', this.planCount)}, but got ${this.assertCount}.`,
 				operator: '===',
-				stack: this.planStack
+				savedError: this.planError
 			}));
 		}
 	}
@@ -311,7 +304,7 @@ class Test {
 			fixedSource: {file: pending.file, line: pending.line},
 			improperUsage: true,
 			message: `Improper usage of \`t.${pending.assertion}()\` detected`,
-			stack: error instanceof Error && error.stack,
+			savedError: error instanceof Error && error,
 			values
 		}));
 		return true;
@@ -365,7 +358,7 @@ class Test {
 			if (!this.detectImproperThrows(result.error)) {
 				this.saveFirstError(new assert.AssertionError({
 					message: 'Error thrown in test',
-					stack: result.error instanceof Error && result.error.stack,
+					savedError: result.error instanceof Error && result.error,
 					values: [formatErrorValue('Error thrown in test:', result.error)]
 				}));
 			}
@@ -438,7 +431,7 @@ class Test {
 						if (!this.detectImproperThrows(error)) {
 							this.saveFirstError(new assert.AssertionError({
 								message: 'Rejected promise returned by test',
-								stack: error instanceof Error && error.stack,
+								savedError: error instanceof Error && error,
 								values: [formatErrorValue('Rejected promise returned by test. Reason:', error)]
 							}));
 						}

--- a/lib/test.js
+++ b/lib/test.js
@@ -13,7 +13,13 @@ function formatErrorValue(label, error) {
 	return {label, formatted};
 }
 
-const captureSavedError = () => new Error();
+const captureSavedError = () => {
+	const limitBefore = Error.stackTraceLimit;
+	Error.stackTraceLimit = 1;
+	const err = new Error();
+	Error.stackTraceLimit = limitBefore;
+	return err;
+};
 
 const testMap = new WeakMap();
 class ExecutionContext extends assert.Assertions {


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
Fixes #1399.

My idea was to always try to pass a new `Error` object in the AssertionError instead of a `stack` string. It might be a bit more memory inefficient, but it would allow for a more consistent behavior overall.
I then expose the `savedError`'s stack when `serializeError` is called.
One thing that I'm not too sure about is the `Error.stackTraceLimit` of the new Error object. I'm not sure if it takes effect when calling `new Error()` or at the point of getting the stack from the `savedError`. I would assume the first case applies. If that's the case, I can do the `Error.stackTraceLimit` "dance" before creating the new Error. 

The changes need to be unit tested and I will do that as well in this PR, but I first wanted someone to take a quick look over the changes and let me know if I should continue down this path or not. 