### PR TITLE
Include logs from successful hooks in TAP output

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -2,7 +2,6 @@
 const os = require('os');
 const path = require('path');
 
-const indentString = require('indent-string');
 const plur = require('plur');
 const stripAnsi = require('strip-ansi');
 const supertap = require('supertap');
@@ -119,13 +118,6 @@ class TapReporter {
 		}) + os.EOL);
 	}
 
-	writeLogs(evt) {
-		for (const log of evt.logs) {
-			const logLines = indentString(log, 4).replace(/^ {4}/, '  * ');
-			this.reportStream.write(logLines + os.EOL);
-		}
-	}
-
 	consumeStateChange(evt) { // eslint-disable-line complexity
 		const fileStats = this.stats && evt.testFile ? this.stats.byFile.get(evt.testFile) : null;
 
@@ -137,7 +129,7 @@ class TapReporter {
 				this.writeTest(evt, {passed: false, todo: false, skip: false});
 				break;
 			case 'hook-finished':
-				this.writeLogs(evt);
+				this.writeTest(evt, {passed: true, todo: false, skip: false});
 				break;
 			case 'internal-error':
 				this.writeCrash(evt);

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -120,11 +120,9 @@ class TapReporter {
 	}
 
 	writeLogs(evt) {
-		if (evt.logs) {
-			for (const log of evt.logs) {
-				const logLines = indentString(log, 4).replace(/^ {4}/, '  * ');
-				this.reportStream.write(logLines + os.EOL);
-			}
+		for (const log of evt.logs) {
+			const logLines = indentString(log, 4).replace(/^ {4}/, '  * ');
+			this.reportStream.write(logLines + os.EOL);
 		}
 	}
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -2,6 +2,7 @@
 const os = require('os');
 const path = require('path');
 
+const indentString = require('indent-string');
 const plur = require('plur');
 const stripAnsi = require('strip-ansi');
 const supertap = require('supertap');
@@ -118,6 +119,15 @@ class TapReporter {
 		}) + os.EOL);
 	}
 
+	writeLogs(evt) {
+		if (evt.logs) {
+			for (const log of evt.logs) {
+				const logLines = indentString(log, 4).replace(/^ {4}/, '  * ');
+				this.reportStream.write(logLines + os.EOL);
+			}
+		}
+	}
+
 	consumeStateChange(evt) { // eslint-disable-line complexity
 		const fileStats = this.stats && evt.testFile ? this.stats.byFile.get(evt.testFile) : null;
 
@@ -127,6 +137,9 @@ class TapReporter {
 				break;
 			case 'hook-failed':
 				this.writeTest(evt, {passed: false, todo: false, skip: false});
+				break;
+			case 'hook-finished':
+				this.writeLogs(evt);
 				break;
 			case 'internal-error':
 				this.writeCrash(evt);

--- a/test/reporters/tap.regular.log
+++ b/test/reporters/tap.regular.log
@@ -221,17 +221,26 @@ not ok 26 - test [90m[2m›[22m[39m implementation throws non-error
 # slow › slow
 ok 27 - slow [90m[2m›[22m[39m slow
 ---tty-stream-chunk-separator
+# output-in-hook › before hook
+ok 28 - output-in-hook [90m[2m›[22m[39m before hook
+---tty-stream-chunk-separator
+# output-in-hook › before hook
+ok 29 - output-in-hook [90m[2m›[22m[39m before hook
   * before
 ---tty-stream-chunk-separator
+# output-in-hook › beforeEach hook for passing test
+ok 30 - output-in-hook [90m[2m›[22m[39m beforeEach hook for passing test
   * beforeEach
 ---tty-stream-chunk-separator
+# output-in-hook › beforeEach hook for failing test
+ok 31 - output-in-hook [90m[2m›[22m[39m beforeEach hook for failing test
   * beforeEach
 ---tty-stream-chunk-separator
 # output-in-hook › passing test
-ok 28 - output-in-hook [90m[2m›[22m[39m passing test
+ok 32 - output-in-hook [90m[2m›[22m[39m passing test
 ---tty-stream-chunk-separator
 # output-in-hook › failing test
-not ok 29 - output-in-hook [90m[2m›[22m[39m failing test
+not ok 33 - output-in-hook [90m[2m›[22m[39m failing test
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -239,12 +248,20 @@ not ok 29 - output-in-hook [90m[2m›[22m[39m failing test
     at: 'fail (output-in-hook.js:34:4)'
   ...
 ---tty-stream-chunk-separator
+# output-in-hook › afterEach hook for passing test
+ok 34 - output-in-hook [90m[2m›[22m[39m afterEach hook for passing test
   * afterEach
 ---tty-stream-chunk-separator
+# output-in-hook › afterEach.always hook for failing test
+ok 35 - output-in-hook [90m[2m›[22m[39m afterEach.always hook for failing test
   * afterEachAlways
 ---tty-stream-chunk-separator
+# output-in-hook › afterEach.always hook for passing test
+ok 36 - output-in-hook [90m[2m›[22m[39m afterEach.always hook for passing test
   * afterEachAlways
 ---tty-stream-chunk-separator
+# output-in-hook › cleanup
+ok 37 - output-in-hook [90m[2m›[22m[39m cleanup
   * afterAlways
 ---tty-stream-chunk-separator
 

--- a/test/reporters/tap.regular.log
+++ b/test/reporters/tap.regular.log
@@ -221,6 +221,12 @@ not ok 26 - test [90m[2m›[22m[39m implementation throws non-error
 # slow › slow
 ok 27 - slow [90m[2m›[22m[39m slow
 ---tty-stream-chunk-separator
+  * before
+---tty-stream-chunk-separator
+  * beforeEach
+---tty-stream-chunk-separator
+  * beforeEach
+---tty-stream-chunk-separator
 # output-in-hook › passing test
 ok 28 - output-in-hook [90m[2m›[22m[39m passing test
 ---tty-stream-chunk-separator
@@ -232,6 +238,14 @@ not ok 29 - output-in-hook [90m[2m›[22m[39m failing test
     assertion: fail
     at: 'fail (output-in-hook.js:34:4)'
   ...
+---tty-stream-chunk-separator
+  * afterEach
+---tty-stream-chunk-separator
+  * afterEachAlways
+---tty-stream-chunk-separator
+  * afterEachAlways
+---tty-stream-chunk-separator
+  * afterAlways
 ---tty-stream-chunk-separator
 
 1..23


### PR DESCRIPTION
The `t.log` outputs were not included in the TAP reporter output (`--tap`) unless they failed:
```
TAP version 13
console.log in hook
console.log inside
# suite › api › events › [C806010, monitoring, validation, xxx] [eventsApi ea2] Get Events
ok 1 - suite › api › events › [C806010, monitoring, validation, xxx] [eventsApi ea2] Get Events
  * t.log inside
  * t.log inside2

1..1
# tests 1
# pass 1
# fail 0
```