### PR TITLE
Remove Flow references

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,8 +166,7 @@
 			"test/fixture/{source-map-initial,syntax-error}.js",
 			"test/fixture/snapshots/test-sourcemaps/build/**",
 			"test/fixture/power-assert.js",
-			"**/*.ts",
-			"test/flow-types/*"
+			"**/*.ts"
 		],
 		"rules": {
 			"no-use-extend-native/no-use-extend-native": "off"

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/rea
 - Runs tests concurrently
 - Enforces writing atomic tests
 - No implicit globals
-- Includes TypeScript & Flow type definitions
+- Includes TypeScript
 - [Magic assert](#magic-assert)
 - [Isolated environment for each test file](./docs/01-writing-tests.md#process-isolation)
 - [Write your tests using the latest JavaScript syntax](#latest-javascript-support)

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/rea
 - Runs tests concurrently
 - Enforces writing atomic tests
 - No implicit globals
-- Includes TypeScript
+- Includes TypeScript definitions
 - [Magic assert](#magic-assert)
 - [Isolated environment for each test file](./docs/01-writing-tests.md#process-isolation)
 - [Write your tests using the latest JavaScript syntax](#latest-javascript-support)


### PR DESCRIPTION
Amends #2098 and entirely removes Flow references, as support currently does not exist and retained information is misleading.