### PR TITLE
docs(readme): restore vscode debug recipe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,7 @@ We have a growing list of [common pitfalls](docs/08-common-pitfalls.md) you may 
 - [Testing Vue.js components](docs/recipes/vue.md)
 - [JSPM and SystemJS](docs/recipes/jspm-systemjs.md)
 - [Debugging tests with Chrome DevTools](docs/recipes/debugging-with-chrome-devtools.md)
+- [Debugging tests with VSCode](docs/recipes/debugging-with-vscode.md)
 - [Debugging tests with WebStorm](docs/recipes/debugging-with-webstorm.md)
 - [Isolated MongoDB integration tests](docs/recipes/isolated-mongodb-integration-tests.md)
 - [Testing web apps using Puppeteer](docs/recipes/puppeteer.md)


### PR DESCRIPTION
# problem

vscode recipe link is missing from readme

# solution

restore it