### PR TITLE
Disable deprecation warnings in reporter tests

### DIFF
--- a/test/helper/report.js
+++ b/test/helper/report.js
@@ -16,7 +16,13 @@ const createApi = options => {
 				child_process: { // eslint-disable-line camelcase
 					...childProcess,
 					fork(filename, argv, options) {
-						return childProcess.fork(path.join(__dirname, 'report-worker.js'), argv, options);
+						return childProcess.fork(path.join(__dirname, 'report-worker.js'), argv, {
+							...options,
+							env: {
+								...options.env,
+								NODE_NO_WARNINGS: '1'
+							}
+						});
 					}
 				}
 			})


### PR DESCRIPTION
To ensure tests pass under Node.js 12.6.