### PR TITLE
Fix: running tests without cache directory permissions (fix #2163)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -252,6 +252,7 @@ class Api extends Emittery {
 			if (!runStatus) {
 				throw error;
 			}
+
 			runStatus.emitStateChange({type: 'internal-error', err: serializeError('Internal error', false, error)});
 		}
 
@@ -273,7 +274,7 @@ class Api extends Emittery {
 			makeDir.sync(cacheDir);
 		} catch (error) {
 			if (error.code === 'ENOENT' || error.code === 'EPERM') {
-				console.warn(`[WARN] Disabling cache due to permission issues`);
+				console.warn('[WARN] Disabling cache due to permission issues');
 				makeDir.sync(cacheDir = uniqueTempDir());
 			} else {
 				throw error;

--- a/lib/api.js
+++ b/lib/api.js
@@ -249,6 +249,9 @@ class Api extends Emittery {
 				return worker.promise;
 			}, {concurrency});
 		} catch (error) {
+			if (!runStatus) {
+				throw error;
+			}
 			runStatus.emitStateChange({type: 'internal-error', err: serializeError('Internal error', false, error)});
 		}
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -264,12 +264,21 @@ class Api extends Emittery {
 			return this._precompiler;
 		}
 
-		const cacheDir = this.options.cacheEnabled === false ?
+		let cacheDir = this.options.cacheEnabled === false ?
 			uniqueTempDir() :
 			path.join(this.options.projectDir, 'node_modules', '.cache', 'ava');
 
 		// Ensure cacheDir exists
-		makeDir.sync(cacheDir);
+		try {
+			makeDir.sync(cacheDir);
+		} catch (error) {
+			if (error.code === 'ENOENT' || error.code === 'EPERM') {
+				console.warn(`[WARN] Disabling cache due to permission issues`);
+				makeDir.sync(cacheDir = uniqueTempDir());
+			} else {
+				throw error;
+			}
+		}
 
 		const {projectDir, babelConfig} = this.options;
 		const compileEnhancements = this.options.compileEnhancements !== false;


### PR DESCRIPTION
This PR provides two fixes related to #2163.

 1) If the `runStatus` object is missing, it throws the error as a regular exception so that the user is aware of the actual error rather than just that `runStatus` is undefined.
 2) If there is a permission issue with creating the cache directory, it writes a warning to the console and uses a temporary directory instead.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2163: TypeError: Cannot read property 'emitStateChange' of undefined](https://issuehunt.io/repos/26820798/issues/2163)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->