### PR TITLE
extend --match to support hash (generated from unique title)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,7 +39,7 @@ exports.run = async () => { // eslint-disable-line complexity
 
 		Options
 		  --watch, -w             Re-run tests when tests and source files change
-		  --match, -m             Only run tests with matching title (Can be repeated)
+		  --match, -m             Only run tests with matching title/hash (Can be repeated)
 		  --update-snapshots, -u  Update snapshots
 		  --fail-fast             Stop after first test failure
 		  --timeout, -T           Set global timeout (milliseconds or human-readable, e.g. 10s, 2m)

--- a/lib/reporters/colors.js
+++ b/lib/reporters/colors.js
@@ -12,5 +12,6 @@ module.exports = {
 	errorSource: chalk.gray,
 	errorStack: chalk.gray,
 	stack: chalk.red,
+	hash: chalk.dim,
 	information: chalk.magenta
 };

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -125,16 +125,16 @@ class VerboseReporter {
 				break;
 			case 'hook-finished':
 				if (evt.logs.length > 0) {
-					this.lineWriter.writeLine(`  ${this.prefixTitle(evt.testFile, evt.title)}`);
+					this.lineWriter.writeLine(`  ${evt.hash} ${this.prefixTitle(evt.testFile, evt.title)}`);
 					this.writeLogs(evt);
 				}
 
 				break;
 			case 'selected-test':
 				if (evt.skip) {
-					this.lineWriter.writeLine(colors.skip(`- ${this.prefixTitle(evt.testFile, evt.title)}`));
+					this.lineWriter.writeLine(colors.skip(`- ${evt.hash} ${this.prefixTitle(evt.testFile, evt.title)}`));
 				} else if (evt.todo) {
-					this.lineWriter.writeLine(colors.todo(`- ${this.prefixTitle(evt.testFile, evt.title)}`));
+					this.lineWriter.writeLine(colors.todo(`- ${evt.hash} ${this.prefixTitle(evt.testFile, evt.title)}`));
 				}
 
 				break;
@@ -293,15 +293,15 @@ class VerboseReporter {
 
 	writeTestSummary(evt) {
 		if (evt.type === 'hook-failed' || evt.type === 'test-failed') {
-			this.lineWriter.writeLine(`${colors.error(figures.cross)} ${this.prefixTitle(evt.testFile, evt.title)} ${colors.error(evt.err.message)}`);
+			this.lineWriter.writeLine(`${colors.error(figures.cross)} ${colors.hash(evt.hash)} ${this.prefixTitle(evt.testFile, evt.title)} ${colors.error(evt.err.message)}`);
 		} else if (evt.knownFailing) {
-			this.lineWriter.writeLine(`${colors.error(figures.tick)} ${colors.error(this.prefixTitle(evt.testFile, evt.title))}`);
+			this.lineWriter.writeLine(`${colors.error(figures.tick)} ${colors.hash(evt.hash)} ${colors.error(this.prefixTitle(evt.testFile, evt.title))}`);
 		} else {
 			// Display duration only over a threshold
 			const threshold = 100;
 			const duration = evt.duration > threshold ? colors.duration(' (' + prettyMs(evt.duration) + ')') : '';
 
-			this.lineWriter.writeLine(`${colors.pass(figures.tick)} ${this.prefixTitle(evt.testFile, evt.title)}${duration}`);
+			this.lineWriter.writeLine(`${colors.pass(figures.tick)} ${colors.hash(evt.hash)} ${this.prefixTitle(evt.testFile, evt.title)}${duration}`);
 		}
 
 		this.writeLogs(evt);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -79,17 +79,22 @@ class Runner extends Emittery {
 					uniqueTestTitles.add(specifiedTitle);
 				}
 
+				const specifiedHash = Runnable.getTitleHash(specifiedTitle);
+
 				if (this.match.length > 0) {
 					// --match selects TODO tests.
-					if (matcher([specifiedTitle], this.match).length === 1) {
+					const titleMatched = matcher([specifiedTitle], this.match).length === 1;
+					const hashMatched = matcher([specifiedHash], this.match).length === 1;
+					if (titleMatched || hashMatched) {
 						metadata.exclusive = true;
 						this.runOnlyExclusive = true;
 					}
 				}
 
-				this.tasks.todo.push({title: specifiedTitle, metadata});
+				this.tasks.todo.push({hash: specifiedHash, title: specifiedTitle, metadata});
 				this.emit('stateChange', {
 					type: 'declared-test',
+					hash: specifiedHash,
 					title: specifiedTitle,
 					knownFailing: false,
 					todo: true
@@ -126,7 +131,10 @@ class Runner extends Emittery {
 						}
 					}
 
+					const hash = Runnable.getTitleHash(title);
+
 					const task = {
+						hash,
 						title,
 						implementation,
 						args,
@@ -136,7 +144,9 @@ class Runner extends Emittery {
 					if (metadata.type === 'test') {
 						if (this.match.length > 0) {
 							// --match overrides .only()
-							task.metadata.exclusive = matcher([title], this.match).length === 1;
+							const titleMatched = matcher([title], this.match).length === 1;
+							const hashMatched = matcher([hash], this.match).length === 1;
+							task.metadata.exclusive = titleMatched || hashMatched;
 						}
 
 						if (task.metadata.exclusive) {
@@ -146,6 +156,7 @@ class Runner extends Emittery {
 						this.tasks[metadata.serial ? 'serial' : 'concurrent'].push(task);
 						this.emit('stateChange', {
 							type: 'declared-test',
+							hash,
 							title,
 							knownFailing: metadata.failing,
 							todo: false
@@ -283,6 +294,7 @@ class Runner extends Emittery {
 			if (result.passed) {
 				this.emit('stateChange', {
 					type: 'hook-finished',
+					hash: result.hash,
 					title: result.title,
 					duration: result.duration,
 					logs: result.logs
@@ -290,6 +302,7 @@ class Runner extends Emittery {
 			} else {
 				this.emit('stateChange', {
 					type: 'hook-failed',
+					hash: result.hash,
 					title: result.title,
 					err: serializeError('Hook failure', true, result.error),
 					duration: result.duration,
@@ -316,6 +329,7 @@ class Runner extends Emittery {
 				compareTestSnapshot: this.boundCompareTestSnapshot,
 				updateSnapshots: this.updateSnapshots,
 				metadata: task.metadata,
+				hash: task.hash,
 				title: task.title
 			});
 
@@ -323,6 +337,7 @@ class Runner extends Emittery {
 			if (result.passed) {
 				this.emit('stateChange', {
 					type: 'test-passed',
+					hash: result.hash,
 					title: result.title,
 					duration: result.duration,
 					knownFailing: result.metadata.failing,
@@ -332,6 +347,7 @@ class Runner extends Emittery {
 			} else {
 				this.emit('stateChange', {
 					type: 'test-failed',
+					hash: result.hash,
 					title: result.title,
 					err: serializeError('Test failure', true, result.error),
 					duration: result.duration,
@@ -356,6 +372,7 @@ class Runner extends Emittery {
 
 			this.emit('stateChange', {
 				type: 'selected-test',
+				hash: task.hash,
 				title: task.title,
 				knownFailing: task.metadata.failing,
 				skip: task.metadata.skipped,
@@ -374,6 +391,7 @@ class Runner extends Emittery {
 
 			this.emit('stateChange', {
 				type: 'selected-test',
+				hash: task.hash,
 				title: task.title,
 				knownFailing: task.metadata.failing,
 				skip: task.metadata.skipped,
@@ -396,6 +414,7 @@ class Runner extends Emittery {
 
 			this.emit('stateChange', {
 				type: 'selected-test',
+				hash: task.hash,
 				title: task.title,
 				knownFailing: false,
 				skip: false,

--- a/lib/test.js
+++ b/lib/test.js
@@ -4,6 +4,7 @@ const observableToPromise = require('observable-to-promise');
 const isPromise = require('is-promise');
 const isObservable = require('is-observable');
 const plur = require('plur');
+const objectHash = require('object-hash');
 const assert = require('./assert');
 const nowAndTimers = require('./now-and-timers');
 const concordanceOptions = require('./concordance-options').default;
@@ -102,6 +103,7 @@ class Test {
 		this.failWithoutAssertions = options.failWithoutAssertions;
 		this.fn = options.fn;
 		this.metadata = options.metadata;
+		this.hash = Test.getTitleHash(options.title);
 		this.title = options.title;
 		this.logs = [];
 
@@ -138,6 +140,10 @@ class Test {
 		this.startedAt = 0;
 		this.timeoutTimer = null;
 		this.timeoutMs = 0;
+	}
+
+	static getTitleHash(title) {
+		return title ? objectHash(title).substring(0, 10) : undefined;
 	}
 
 	bindEndCallback() {
@@ -481,6 +487,7 @@ class Test {
 			logs: this.logs,
 			metadata: this.metadata,
 			passed,
+			hash: this.hash,
 			title: this.title
 		};
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6283,6 +6283,12 @@
         }
       }
     },
+    "object-hash": {
+      "version": "1.3.1",
+      "resolved": "http://sinopia.samsungmtv.com/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
 		"git-branch": "^2.0.1",
 		"has-ansi": "^3.0.0",
 		"lolex": "^4.1.0",
+		"object-hash": "^1.3.1",
 		"proxyquire": "^2.1.0",
 		"react": "^16.8.6",
 		"react-test-renderer": "^16.8.6",

--- a/test/api.js
+++ b/test/api.js
@@ -112,12 +112,15 @@ test('fail-fast mode - single file & serial', t => {
 			t.ok(api.options.failFast);
 			t.strictDeepEqual(tests, [{
 				ok: true,
+				hash: '1221417f85',
 				title: 'first pass'
 			}, {
 				ok: false,
+				hash: 'a9039c8aa0',
 				title: 'second fail'
 			}, {
 				ok: true,
+				hash: '09fda0bbf9',
 				title: 'third pass'
 			}]);
 			t.is(runStatus.stats.passedTests, 2);
@@ -162,10 +165,12 @@ test('fail-fast mode - multiple files & serial', t => {
 			t.strictDeepEqual(tests, [{
 				ok: true,
 				testFile: path.join(__dirname, 'fixture/fail-fast/multiple-files/fails.js'),
+				hash: '1221417f85',
 				title: 'first pass'
 			}, {
 				ok: false,
 				testFile: path.join(__dirname, 'fixture/fail-fast/multiple-files/fails.js'),
+				hash: 'a9039c8aa0',
 				title: 'second fail'
 			}]);
 			t.is(runStatus.stats.passedTests, 1);
@@ -210,18 +215,22 @@ test('fail-fast mode - multiple files & interrupt', t => {
 			t.strictDeepEqual(tests, [{
 				ok: true,
 				testFile: path.join(__dirname, 'fixture/fail-fast/multiple-files/fails.js'),
+				hash: '1221417f85',
 				title: 'first pass'
 			}, {
 				ok: false,
 				testFile: path.join(__dirname, 'fixture/fail-fast/multiple-files/fails.js'),
+				hash: 'a9039c8aa0',
 				title: 'second fail'
 			}, {
 				ok: true,
 				testFile: path.join(__dirname, 'fixture/fail-fast/multiple-files/fails.js'),
+				hash: '09fda0bbf9',
 				title: 'third pass'
 			}, {
 				ok: true,
 				testFile: path.join(__dirname, 'fixture/fail-fast/multiple-files/passes-slow.js'),
+				hash: '1221417f85',
 				title: 'first pass'
 			}]);
 			t.is(runStatus.stats.passedTests, 3);

--- a/test/api.js
+++ b/test/api.js
@@ -94,11 +94,13 @@ test('fail-fast mode - single file & serial', t => {
 			if (evt.type === 'test-failed') {
 				tests.push({
 					ok: false,
+					hash: evt.hash,
 					title: evt.title
 				});
 			} else if (evt.type === 'test-passed') {
 				tests.push({
 					ok: true,
+					hash: evt.hash,
 					title: evt.title
 				});
 			}
@@ -137,12 +139,14 @@ test('fail-fast mode - multiple files & serial', t => {
 				tests.push({
 					ok: false,
 					testFile: evt.testFile,
+					hash: evt.hash,
 					title: evt.title
 				});
 			} else if (evt.type === 'test-passed') {
 				tests.push({
 					ok: true,
 					testFile: evt.testFile,
+					hash: evt.hash,
 					title: evt.title
 				});
 			}
@@ -183,12 +187,14 @@ test('fail-fast mode - multiple files & interrupt', t => {
 				tests.push({
 					ok: false,
 					testFile: evt.testFile,
+					hash: evt.hash,
 					title: evt.title
 				});
 			} else if (evt.type === 'test-passed') {
 				tests.push({
 					ok: true,
 					testFile: evt.testFile,
+					hash: evt.hash,
 					title: evt.title
 				});
 			}
@@ -237,11 +243,13 @@ test('fail-fast mode - crash & serial', t => {
 			if (evt.type === 'test-failed') {
 				tests.push({
 					ok: false,
+					hash: evt.hash,
 					title: evt.title
 				});
 			} else if (evt.type === 'test-passed') {
 				tests.push({
 					ok: true,
+					hash: evt.hash,
 					title: evt.title
 				});
 			} else if (evt.type === 'worker-failed') {
@@ -279,11 +287,13 @@ test('fail-fast mode - timeout & serial', t => {
 			if (evt.type === 'test-failed') {
 				tests.push({
 					ok: false,
+					hash: evt.hash,
 					title: evt.title
 				});
 			} else if (evt.type === 'test-passed') {
 				tests.push({
 					ok: true,
+					hash: evt.hash,
 					title: evt.title
 				});
 			} else if (evt.type === 'timeout') {

--- a/test/reporters/verbose.failfast.log
+++ b/test/reporters/verbose.failfast.log
@@ -1,6 +1,6 @@
 
 ---tty-stream-chunk-separator
-  [31m✖[39m a [90m[2m›[22m[39m fails [31mTest failed via `t.fail()`[39m
+  [31m✖[39m [2m9eaac03e61[22m a [90m[2m›[22m[39m fails [31mTest failed via `t.fail()`[39m
 ---tty-stream-chunk-separator
 
   [31m1 test failed[39m

--- a/test/reporters/verbose.failfast2.log
+++ b/test/reporters/verbose.failfast2.log
@@ -1,6 +1,6 @@
 
 ---tty-stream-chunk-separator
-  [31m✖[39m a [90m[2m›[22m[39m fails [31mTest failed via `t.fail()`[39m
+  [31m✖[39m [2m9eaac03e61[22m a [90m[2m›[22m[39m fails [31mTest failed via `t.fail()`[39m
 ---tty-stream-chunk-separator
 
   [31m1 test failed[39m

--- a/test/reporters/verbose.only.log
+++ b/test/reporters/verbose.only.log
@@ -1,8 +1,8 @@
 
 ---tty-stream-chunk-separator
-  [32m✔[39m a [90m[2m›[22m[39m only
+  [32m✔[39m [2me90e64e828[22m a [90m[2m›[22m[39m only
 ---tty-stream-chunk-separator
-  [32m✔[39m b [90m[2m›[22m[39m passes
+  [32m✔[39m [2m63d04ac302[22m b [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 
   [32m2 tests passed[39m

--- a/test/reporters/verbose.regular.log
+++ b/test/reporters/verbose.regular.log
@@ -13,9 +13,9 @@
 ---tty-stream-chunk-separator
   [31m✖ test/fixture/report/regular/bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
-  [32m✔[39m unhandled-rejection [90m[2m›[22m[39m passes
+  [32m✔[39m [2m63d04ac302[22m unhandled-rejection [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
-  [32m✔[39m unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
+  [32m✔[39m [2mb44eae8674[22m unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
 ---tty-stream-chunk-separator
 
   [1mUnhandled rejection in test/fixture/report/regular/unhandled-rejection.js[22m
@@ -34,7 +34,7 @@
   [33mnull[39m
 
 ---tty-stream-chunk-separator
-  [32m✔[39m uncaught-exception [90m[2m›[22m[39m passes
+  [32m✔[39m [2m63d04ac302[22m uncaught-exception [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 
   [1mUncaught exception in test/fixture/report/regular/uncaught-exception.js[22m
@@ -50,71 +50,71 @@
 ---tty-stream-chunk-separator
   [31m✖ test/fixture/report/regular/uncaught-exception.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
-  [31m✖[39m traces-in-t-throws [90m[2m›[22m[39m throws 
+  [31m✖[39m [2m9507681c96[22m traces-in-t-throws [90m[2m›[22m[39m throws 
 ---tty-stream-chunk-separator
-  [31m✖[39m traces-in-t-throws [90m[2m›[22m[39m notThrows 
+  [31m✖[39m [2m99e87f2b1a[22m traces-in-t-throws [90m[2m›[22m[39m notThrows 
 ---tty-stream-chunk-separator
-  [31m✖[39m traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync 
+  [31m✖[39m [2m23931cf3aa[22m traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync 
 ---tty-stream-chunk-separator
-  [31m✖[39m traces-in-t-throws [90m[2m›[22m[39m throwsAsync 
+  [31m✖[39m [2ma1f7fc6863[22m traces-in-t-throws [90m[2m›[22m[39m throwsAsync 
 ---tty-stream-chunk-separator
-  [31m✖[39m traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error 
+  [31m✖[39m [2m8cfa623137[22m traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error 
 ---tty-stream-chunk-separator
 stdout
 ---tty-stream-chunk-separator
 stderr
 ---tty-stream-chunk-separator
-  [33m- test [90m[2m›[22m[33m skip[39m
+  [33m- dcdac2905b test [90m[2m›[22m[33m skip[39m
 ---tty-stream-chunk-separator
-  [34m- test [90m[2m›[22m[34m todo[39m
+  [34m- 19a13f2a6c test [90m[2m›[22m[34m todo[39m
 ---tty-stream-chunk-separator
-  [32m✔[39m test [90m[2m›[22m[39m passes
+  [32m✔[39m [2m63d04ac302[22m test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m fails [31mTest failed via `t.fail()`[39m
+  [31m✖[39m [2m9eaac03e61[22m test [90m[2m›[22m[39m fails [31mTest failed via `t.fail()`[39m
 ---tty-stream-chunk-separator
-  [31m✔[39m [31mtest [90m[2m›[22m[31m known failure[39m
+  [31m✔[39m [2ma6ca6858c0[22m [31mtest [90m[2m›[22m[31m known failure[39m
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m no longer failing [31mTest was expected to fail, but succeeded, you should stop marking the test as failing[39m
+  [31m✖[39m [2m81c2e00085[22m test [90m[2m›[22m[39m no longer failing [31mTest was expected to fail, but succeeded, you should stop marking the test as failing[39m
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m logs [31mTest failed via `t.fail()`[39m
+  [31m✖[39m [2m5f363d84ec[22m test [90m[2m›[22m[39m logs [31mTest failed via `t.fail()`[39m
     [35mℹ[39m [90mhello[39m
     [35mℹ[39m [90mworld[39m
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m formatted 
+  [31m✖[39m [2m964fac7e8e[22m test [90m[2m›[22m[39m formatted 
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m power-assert 
+  [31m✖[39m [2m66b52c3d09[22m test [90m[2m›[22m[39m power-assert 
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m bad throws [31mImproper usage of `t.throws()` detected[39m
+  [31m✖[39m [2mea408ec6c1[22m test [90m[2m›[22m[39m bad throws [31mImproper usage of `t.throws()` detected[39m
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m bad notThrows [31mImproper usage of `t.notThrows()` detected[39m
+  [31m✖[39m [2m6b26aa87ad[22m test [90m[2m›[22m[39m bad notThrows [31mImproper usage of `t.notThrows()` detected[39m
 ---tty-stream-chunk-separator
-  [31m✖[39m test [90m[2m›[22m[39m implementation throws non-error [31mError thrown in test[39m
+  [31m✖[39m [2mf86d05e5da[22m test [90m[2m›[22m[39m implementation throws non-error [31mError thrown in test[39m
 ---tty-stream-chunk-separator
-  [32m✔[39m slow [90m[2m›[22m[39m slow[90m[2m  (000ms)[22m[39m
+  [32m✔[39m [2ma172f324e1[22m slow [90m[2m›[22m[39m slow[90m[2m  (000ms)[22m[39m
 ---tty-stream-chunk-separator
-    output-in-hook [90m[2m›[22m[39m before hook
+    e2795187d9 output-in-hook [90m[2m›[22m[39m before hook
     [35mℹ[39m [90mbefore[39m
 ---tty-stream-chunk-separator
-    output-in-hook [90m[2m›[22m[39m beforeEach hook for passing test
+    9a5cf57f11 output-in-hook [90m[2m›[22m[39m beforeEach hook for passing test
     [35mℹ[39m [90mbeforeEach[39m
 ---tty-stream-chunk-separator
-    output-in-hook [90m[2m›[22m[39m beforeEach hook for failing test
+    0b958afd77 output-in-hook [90m[2m›[22m[39m beforeEach hook for failing test
     [35mℹ[39m [90mbeforeEach[39m
 ---tty-stream-chunk-separator
-  [32m✔[39m output-in-hook [90m[2m›[22m[39m passing test
+  [32m✔[39m [2m4f05f173c9[22m output-in-hook [90m[2m›[22m[39m passing test
 ---tty-stream-chunk-separator
-  [31m✖[39m output-in-hook [90m[2m›[22m[39m failing test [31mTest failed via `t.fail()`[39m
+  [31m✖[39m [2m222e7143b4[22m output-in-hook [90m[2m›[22m[39m failing test [31mTest failed via `t.fail()`[39m
 ---tty-stream-chunk-separator
-    output-in-hook [90m[2m›[22m[39m afterEach hook for passing test
+    f7fe2b1cfe output-in-hook [90m[2m›[22m[39m afterEach hook for passing test
     [35mℹ[39m [90mafterEach[39m
 ---tty-stream-chunk-separator
-    output-in-hook [90m[2m›[22m[39m afterEach.always hook for failing test
+    b9941c5eef output-in-hook [90m[2m›[22m[39m afterEach.always hook for failing test
     [35mℹ[39m [90mafterEachAlways[39m
 ---tty-stream-chunk-separator
-    output-in-hook [90m[2m›[22m[39m afterEach.always hook for passing test
+    ea197df294 output-in-hook [90m[2m›[22m[39m afterEach.always hook for passing test
     [35mℹ[39m [90mafterEachAlways[39m
 ---tty-stream-chunk-separator
-    output-in-hook [90m[2m›[22m[39m cleanup
+    2b9e0faadf output-in-hook [90m[2m›[22m[39m cleanup
     [35mℹ[39m [90mafterAlways[39m
 ---tty-stream-chunk-separator
 

--- a/test/reporters/verbose.timeoutinmultiplefiles.log
+++ b/test/reporters/verbose.timeoutinmultiplefiles.log
@@ -1,8 +1,8 @@
 
 ---tty-stream-chunk-separator
-  [32m✔[39m a [90m[2m›[22m[39m a passes
+  [32m✔[39m [2m63ae91b74d[22m a [90m[2m›[22m[39m a passes
 ---tty-stream-chunk-separator
-  [32m✔[39m a [90m[2m›[22m[39m a passes two
+  [32m✔[39m [2ma8686a7d01[22m a [90m[2m›[22m[39m a passes two
 ---tty-stream-chunk-separator
   [31m[39m
   [31m✖ Timed out while running tests[39m
@@ -13,9 +13,9 @@
   ◌ a [90m[2m›[22m[39m a slow two
 
 ---tty-stream-chunk-separator
-  [32m✔[39m b [90m[2m›[22m[39m b passes
+  [32m✔[39m [2m8bcd3711a1[22m b [90m[2m›[22m[39m b passes
 ---tty-stream-chunk-separator
-  [32m✔[39m b [90m[2m›[22m[39m b passes two
+  [32m✔[39m [2m45a4102d84[22m b [90m[2m›[22m[39m b passes two
 ---tty-stream-chunk-separator
   [31m[39m
   [31m✖ Timed out while running tests[39m

--- a/test/reporters/verbose.timeoutinsinglefile.log
+++ b/test/reporters/verbose.timeoutinsinglefile.log
@@ -1,8 +1,8 @@
 
 ---tty-stream-chunk-separator
-  [32m✔[39m passes
+  [32m✔[39m [2m63d04ac302[22m passes
 ---tty-stream-chunk-separator
-  [32m✔[39m passes two
+  [32m✔[39m [2m084c165aae[22m passes two
 ---tty-stream-chunk-separator
   [31m[39m
   [31m✖ Timed out while running tests[39m

--- a/test/reporters/verbose.timeoutwithmatch.log
+++ b/test/reporters/verbose.timeoutwithmatch.log
@@ -1,6 +1,6 @@
 
 ---tty-stream-chunk-separator
-  [32m✔[39m passes needle
+  [32m✔[39m [2m581779f4d9[22m passes needle
 ---tty-stream-chunk-separator
   [31m[39m
   [31m✖ Timed out while running tests[39m

--- a/test/reporters/verbose.watch.log
+++ b/test/reporters/verbose.watch.log
@@ -1,6 +1,6 @@
 
 ---tty-stream-chunk-separator
-  [32m✔[39m test [90m[2m›[22m[39m passes
+  [32m✔[39m [2m63d04ac302[22m test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 
   [32m1 test passed[39m [90m[2m[17:19:12][22m[39m
@@ -10,7 +10,7 @@
 ---tty-stream-chunk-separator
 
 ---tty-stream-chunk-separator
-  [32m✔[39m test [90m[2m›[22m[39m passes
+  [32m✔[39m [2m63d04ac302[22m test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 
   [32m1 test passed[39m [90m[2m[17:19:12][22m[39m
@@ -21,7 +21,7 @@
 ---tty-stream-chunk-separator
 
 ---tty-stream-chunk-separator
-  [32m✔[39m test [90m[2m›[22m[39m passes
+  [32m✔[39m [2m63d04ac302[22m test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 
   [32m1 test passed[39m [90m[2m[17:19:12][22m[39m

--- a/test/runner.js
+++ b/test/runner.js
@@ -49,6 +49,7 @@ test('runner emits "stateChange" events', t => {
 		if (evt.type === 'declared-test') {
 			t.deepEqual(evt, {
 				type: 'declared-test',
+				hash: '7cd3edacc4',
 				title: 'foo',
 				knownFailing: false,
 				todo: false


### PR DESCRIPTION
extend --match to support hash key, which is generated from title (which ava ensure title to be unique).

<img width="1510" alt="Screen Shot 2019-07-25 at 1 42 17 PM" src="https://user-images.githubusercontent.com/13225610/61910311-1f76c080-aee9-11e9-8a36-4c3eb3de3ba2.png">




> What problems does this solve?

enhancement (how to add label)?