### PR TITLE
Print internal errors when precompiler setup or globbing fails

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -51,6 +51,7 @@ class Api extends Emittery {
 	}
 
 	async run(files = [], runtimeOptions = {}) {
+		let setupOrGlobError;
 		files = files.map(file => path.resolve(this.options.resolveTestsFrom, file));
 
 		const apiOptions = this.options;
@@ -122,7 +123,11 @@ class Api extends Emittery {
 					({tests: files} = found);
 				}
 			}
-
+		} catch (e) {
+			files = [];
+			setupOrGlobError = e;
+		}
+		try {
 			if (this.options.parallelRuns) {
 				const {currentIndex, totalRuns} = this.options.parallelRuns;
 				const fileCount = files.length;
@@ -149,6 +154,10 @@ class Api extends Emittery {
 				runVector: runtimeOptions.runVector || 0,
 				status: runStatus
 			});
+
+			if(setupOrGlobError) {
+				throw setupOrGlobError;
+			}
 
 			// Bail out early if no files were found.
 			if (files.length === 0) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -107,9 +107,12 @@ class Api extends Emittery {
 			}
 		};
 
+		let precompiler;
+		let helpers;
+
 		try {
-			const precompiler = await this._setupPrecompiler();
-			let helpers = [];
+			precompiler = await this._setupPrecompiler(); // eslint-disable-line require-atomic-updates
+			helpers = [];
 			if (files.length === 0 || precompiler.enabled) {
 				let found;
 				if (precompiler.enabled) {
@@ -123,10 +126,11 @@ class Api extends Emittery {
 					({tests: files} = found);
 				}
 			}
-		} catch (e) {
+		} catch (error) {
 			files = [];
-			setupOrGlobError = e;
+			setupOrGlobError = error;
 		}
+
 		try {
 			if (this.options.parallelRuns) {
 				const {currentIndex, totalRuns} = this.options.parallelRuns;
@@ -155,7 +159,7 @@ class Api extends Emittery {
 				status: runStatus
 			});
 
-			if(setupOrGlobError) {
+			if (setupOrGlobError) {
 				throw setupOrGlobError;
 			}
 


### PR DESCRIPTION
Fixes #2163 
Now the error is:
```
➜  test npx ava test.js --verbose

  ✖ Couldn't find any files to test

  ✖ Internal error
  Error: ENOENT: no such file or directory, mkdir '/Users/yovasx2/test/node_modules/.cache/ava'
  Error: ENOENT: no such file or directory, mkdir '/Users/yovasx2/test/node_modules/.cache/ava'
      at Object.mkdirSync (fs.js:752:3)
      at AsyncFunction.module.exports.sync (/Users/yovasx2/test/node_modules/make-dir/index.js:108:6)
      at Api._setupPrecompiler (/Users/yovasx2/test/node_modules/ava/lib/api.js:278:11)
      at Api.run (/Users/yovasx2/test/node_modules/ava/lib/api.js:111:35)
      at Object.exports.run (/Users/yovasx2/test/node_modules/ava/lib/cli.js:283:31)
      at Object.<anonymous> (/Users/yovasx2/test/node_modules/ava/cli.js:10:23)
      at Module._compile (internal/modules/cjs/loader.js:701:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
      at Module.load (internal/modules/cjs/loader.js:600:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
      at Function.Module._load (internal/modules/cjs/loader.js:531:3)
      at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
      at findNodeScript.then.existing (/usr/local/lib/node_modules/npm/node_modules/libnpx/index.js:268:14)

```

We cannot get **EACCESS** error since the library make-dir is using fs.mkdirSync with recursive option:
* Without **recursive**, we obtain **EACCESS**
```
> fs.mkdirSync('/Users/yovasx2/test/node_modules/l')
{ Error: EACCES: permission denied, mkdir '/Users/yovasx2/test/node_modules/l'
    at Object.mkdirSync (fs.js:752:3)
  errno: -13,
  syscall: 'mkdir',
  code: 'EACCES',
  path: '/Users/yovasx2/test/node_modules/l' }
```

* With **recursive**, we obtain **ENOENT**
```
> fs.mkdirSync('/Users/yovasx2/test/node_modules/l/l', {recursive: true})
{ Error: ENOENT: no such file or directory, mkdir '/Users/yovasx2/test/node_modules/l/l'
    at Object.mkdirSync (fs.js:752:3)
  errno: -2,
  syscall: 'mkdir',
  code: 'ENOENT',
  path: '/Users/yovasx2/test/node_modules/l/l' }
```