### PR TITLE
docs: add comment about global and concurrent test execution

### DIFF
--- a/docs/recipes/test-setup.md
+++ b/docs/recipes/test-setup.md
@@ -20,6 +20,8 @@ You could do all these things using plain setup functions, but there are tradeof
 | ✅ &nbsp; failure has friendly output| ⛔️ &nbsp; errors are attributed to the test
 | ✅ &nbsp; corresponding `afterEach` and `afterEach.always` for cleanup| ⛔️ &nbsp; cannot easily clean up
 
+An important consideration if you are modifying or adding Node global variables (and cleaning them after each test), it might introduce undesired effects in global test contexts since tests are run concurrently by default. In this edge cases you can pass the `--serial` flag, this will ensure that any modification inside hooks like `beforeEach` are preparing the setup for each test correctly.
+
 ## Complex test setup
 
 In this example, we have both a `beforeEach()` hook, and then more modifications within each test.


### PR DESCRIPTION
It happened to me several times of having issues with global varible injections, sometimes this is really necesssary for packages that rely on browser globals like `window` or `document`, and I lost a lot of time until I realize that my _cleaning_ was doing things right but the concurrent nature of AVA was causing tests not running on _cleaned_ contexts.

I don't know if this is the best place or best approach to inform this but I found it nowhere and needed to crawl into old issues. I would have loved to have this in the setup section.

I also prefered to do this than just opening an issue, but you contributors, authors, members let me know if you agree with adding this comment ❤️ 
