### PR TITLE
fix #2205 duplicate runs of `.only` test cases

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -229,7 +229,7 @@ class Watcher {
 				}
 
 				const fileStats = plan.status.stats.byFile.get(evt.testFile);
-				this.updateExclusivity(evt.testFile, fileStats.declaredTests > fileStats.selectedTests);
+				this.updateExclusivity(nodePath.relative(process.cwd(), evt.testFile), fileStats.declaredTests > fileStats.selectedTests);
 			});
 		});
 	}

--- a/test/fixture/watcher/with-only/test-only.js
+++ b/test/fixture/watcher/with-only/test-only.js
@@ -1,0 +1,9 @@
+import test from '../../../..';
+
+test.only('works', t => {
+	t.pass();
+});
+
+test('also works', t => {
+	t.pass();
+});


### PR DESCRIPTION
Fixes #2205

When watcher triggers re-run of test cases, it would re-run `.only` declared test case twice.
Seems to only happen when test file contains other test cases without `.only`