### PR TITLE
Update fake-tty for changes in Node.js 12.7.0

### DIFF
--- a/lib/worker/fake-tty.js
+++ b/lib/worker/fake-tty.js
@@ -9,30 +9,71 @@ const fakeTTYs = new Set();
 const {isatty} = tty;
 tty.isatty = fd => fakeTTYs.has(fd) || isatty(fd);
 
+const takesCallbackAndReturnWriteResult = tty.WriteStream.prototype.clearLine.length === 1;
+
+const assertCallback = callback => {
+	// FIXME: Better replicate Node.js' internal errors.
+	if (callback !== undefined && typeof callback !== 'function') {
+		const error = new TypeError('Callback must be a function');
+		error.code = 'ERR_INVALID_CALLBACK';
+		throw error;
+	}
+};
+
+const fakeWriters = {
+	clearLine(dir, callback) {
+		assertCallback(callback);
+
+		switch (dir) {
+			case -1:
+				return this.write(ansiEscapes.eraseStartLine, callback);
+			case 1:
+				return this.write(ansiEscapes.eraseEndLine, callback);
+			default:
+				return this.write(ansiEscapes.eraseLine, callback);
+		}
+	},
+
+	clearScreenDown(callback) {
+		assertCallback(callback);
+
+		return this.write(ansiEscapes.eraseDown, callback);
+	},
+
+	cursorTo(x, y, callback) {
+		assertCallback(callback);
+		return this.write(ansiEscapes.cursorTo(x, y), callback);
+	},
+
+	moveCursor(x, y, callback) {
+		assertCallback(callback);
+		return this.write(ansiEscapes.cursorMove(x, y), callback);
+	}
+};
+
 const simulateTTY = (stream, {colorDepth, hasColors, columns, rows}) => {
 	Object.assign(stream, {isTTY: true, columns, rows});
 
-	stream.clearLine = dir => {
-		switch (dir) {
-			case -1:
-				stream.write(ansiEscapes.eraseStartLine);
-				break;
-			case 1:
-				stream.write(ansiEscapes.eraseEndLine);
-				break;
-			default:
-				stream.write(ansiEscapes.eraseLine);
-		}
-	};
-
-	stream.clearScreenDown = () => stream.write(ansiEscapes.eraseDown);
-
-	stream.cursorTo = (x, y) => stream.write(ansiEscapes.cursorTo(x, y));
+	if (takesCallbackAndReturnWriteResult) {
+		Object.assign(stream, fakeWriters);
+	} else {
+		Object.assign(stream, {
+			clearLine(dir) {
+				fakeWriters.clearLine.call(this, dir);
+			},
+			clearScreenDown() {
+				fakeWriters.clearScreenDown.call(this);
+			},
+			cursorTo(x, y) {
+				fakeWriters.cursorTo.call(this, x, y);
+			},
+			moveCursor(x, y) {
+				fakeWriters.moveCursor.call(this, x, y);
+			}
+		});
+	}
 
 	stream.getWindowSize = () => [80, 24];
-
-	stream.moveCursor = (x, y) => stream.write(ansiEscapes.cursorMove(x, y));
-
 	if (colorDepth !== undefined) {
 		stream.getColorDepth = () => colorDepth;
 	}

--- a/test/fixture/tty/callbacks.js
+++ b/test/fixture/tty/callbacks.js
@@ -1,0 +1,24 @@
+import test from '../../..';
+
+const takesCallbackAndReturnWriteResult = require('tty').WriteStream.prototype.clearLine.length === 1;
+
+const assert = takesCallbackAndReturnWriteResult ?
+	async (t, stream) => {
+		t.is(stream.clearLine.length, 2, 'clearLine');
+		await new Promise(resolve => stream.clearLine(0, resolve));
+		t.is(stream.clearScreenDown.length, 1, 'clearScreenDown');
+		await new Promise(resolve => stream.clearScreenDown(resolve));
+		t.is(stream.cursorTo.length, 3, 'cursorTo');
+		await new Promise(resolve => stream.cursorTo(0, 0, resolve));
+		t.is(stream.moveCursor.length, 3, 'moveCursor');
+		await new Promise(resolve => stream.moveCursor(0, 0, resolve));
+	} :
+	(t, stream) => {
+		t.is(stream.clearLine.length, 1, 'clearLine');
+		t.is(stream.clearScreenDown.length, 0, 'clearScreenDown');
+		t.is(stream.cursorTo.length, 2, 'cursorTo');
+		t.is(stream.moveCursor.length, 2, 'cursorTo');
+	};
+
+test('stderr tty write methods take / do not take a callback', assert, process.stderr);
+test('stdout tty write methods take / do not take a callback', assert, process.stdout);

--- a/test/integration/tty.js
+++ b/test/integration/tty.js
@@ -62,3 +62,17 @@ test('test worker TTYs inherit color support from the parent TTY', t => {
 		t.end();
 	});
 });
+
+test('test worker TTYs take / do not take callbacks', t => {
+	const options = {
+		dirname: 'fixture/tty',
+		env: {
+			AVA_SIMULATE_TTY: true
+		}
+	};
+
+	execCli('callbacks.js', options, err => {
+		t.ifError(err);
+		t.end();
+	});
+});


### PR DESCRIPTION
See the release notes for `tty`: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.7.0:

We should really check if we can just use the built-in modules. I'm not sure why we're faking TTY anymore! 😄 