### PR TITLE
fix the “subprocess.kill"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .nyc_output
 coverage
 bench/.results
+.idea/*

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -119,10 +119,25 @@ module.exports = (file, opts, execArgv) => {
 		});
 	});
 
+	function killProcess() {
+		if (subprocess.pid && !subprocess.killed && !forcedExit) {
+			// Force kill the subprocess.
+			try {
+				if (process.platform === 'win32') {
+					childProcess.execSync(`taskkill /pid ${subprocess.pid} /T /F`);
+				} else {
+					process.kill(subprocess.pid, 'SIGKILL');
+				}
+				forcedExit = true;
+			} catch (e) {
+				// the process might have already stopped
+			}
+		}
+	}
+
 	return {
 		exit() {
-			forcedExit = true;
-			subprocess.kill();
+			killProcess();
 		},
 
 		notifyOfPeerFailure() {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -128,9 +128,10 @@ module.exports = (file, opts, execArgv) => {
 				} else {
 					process.kill(subprocess.pid, 'SIGKILL');
 				}
+
 				forcedExit = true;
-			} catch (e) {
-				// the process might have already stopped
+			} catch (error) {
+				// The process might have already stopped
 			}
 		}
 	}


### PR DESCRIPTION
The “subprocess.kill" only sends a termination signal to child process, but may not actually terminate the process. In the example below, because puppeteer was using child processes, the “subprocess.kill" triggered by timeout will actually not terminate the child process.
```js
import test from 'ava';
import delay from 'delay';
const puppeteer = require('puppeteer');

// the test timeout config is 2000
test.beforeEach(async t => {
  t.context.browser = await puppeteer.launch();
});

test('foo', async t => {
  const browser = t.context.browser;
  const page = await browser.newPage();
  await page.goto('https://xx.xx.com/teach', {timeout: 3000});
  await page.screenshot({path: 'example.png'});
  await t.context.browser.close();
  // t.pass();
});
````

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
