### PR TITLE
Watcher: Only track test files has having exclusive tests if at least one test was selected

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -229,7 +229,8 @@ class Watcher {
 				}
 
 				const fileStats = plan.status.stats.byFile.get(evt.testFile);
-				this.updateExclusivity(evt.testFile, fileStats.declaredTests > fileStats.selectedTests);
+				const ranExclusiveTests = fileStats.selectedTests > 0 && fileStats.declaredTests > fileStats.selectedTests;
+				this.updateExclusivity(evt.testFile, ranExclusiveTests);
 			});
 		});
 	}


### PR DESCRIPTION
See https://github.com/avajs/ava/issues/2205#issuecomment-520237673.