### PR TITLE
Explain how to use custom HTTP clients when endpoint testing

### DIFF
--- a/docs/recipes/endpoint-testing.md
+++ b/docs/recipes/endpoint-testing.md
@@ -2,32 +2,36 @@
 
 Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/docs/recipes/endpoint-testing.md), [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/recipes/endpoint-testing.md), [Italiano](https://github.com/avajs/ava-docs/blob/master/it_IT/docs/recipes/endpoint-testing.md), [日本語](https://github.com/avajs/ava-docs/blob/master/ja_JP/docs/recipes/endpoint-testing.md), [Português](https://github.com/avajs/ava-docs/blob/master/pt_BR/docs/recipes/endpoint-testing.md), [Русский](https://github.com/avajs/ava-docs/blob/master/ru_RU/docs/recipes/endpoint-testing.md), [简体中文](https://github.com/avajs/ava-docs/blob/master/zh_CN/docs/recipes/endpoint-testing.md)
 
-AVA doesn't have a builtin method for testing endpoints, but you can use any http client of your choosing, for example [got](https://github.com/sindresorhus/got). Next you need to bind a server instance, for that we recommend [test-listen](https://github.com/zeit/test-listen).
-Since tests run concurrently, it's best to create a fresh server instance for each test, because if we referenced the same instance, it could be mutated between tests. This can be accomplished with a `test.beforeEach` and `t.context`, or with simply a factory function.
+AVA doesn't have a built-in method for testing endpoints, but you can use any HTTP client of your choosing, for example [`got`](https://github.com/sindresorhus/got). You'll also need to start an HTTP server, preferrably on a unique port so that you can run tests in parallel. For that we recommend [`test-listen`](https://github.com/zeit/test-listen).
+
+Since tests run concurrently, it's best to create a fresh server instance at least for each test file, but perhaps even for each test. This can be accomplished with `test.before()` and `test.beforeEach()` hooks and `t.context`. If you start your server using a `test.before()` hook you should make sure to execute your tests serially.
+
 Check out the example below:
 
 ```js
-const app = require("../app")
-const listen = require("test-listen")
-const test = require("ava")
-const http = require("http")
-const got = require('got')
+const http = require('http');
+const test = require('ava');
+const got = require('got');
+const listen = require('test-listen');
+const app = require('../app');
 
 test.before(async t => {
-        const server = http.createServer(app);
-        t.context.baseURL = await listen(server);
-})
+	t.context.server = http.createServer(app);
+	t.context.baseURL = await listen(t.context.server);
+});
 
-test('get /user', async t => {
-        const res = await got('/user', { baseURL: t.context.baseURL, json: true });
+test.after.always(t => {
+	t.context.server.close();
+});
 
-        t.is(res.body.email, 'ava@rocks.com');
-
-        server.close();
+test.serial('get /user', async t => {
+	const res = await got('/user', { baseURL: t.context.baseURL, json: true });
+	t.is(res.body.email, 'ava@rocks.com');
 });
 ```
 
 Other libraries you may find useful: 
+
 - [`supertest`](https://github.com/visionmedia/supertest)
 - [`get-port`](https://github.com/sindresorhus/get-port)
 

--- a/docs/recipes/endpoint-testing.md
+++ b/docs/recipes/endpoint-testing.md
@@ -2,30 +2,32 @@
 
 Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/docs/recipes/endpoint-testing.md), [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/recipes/endpoint-testing.md), [Italiano](https://github.com/avajs/ava-docs/blob/master/it_IT/docs/recipes/endpoint-testing.md), [日本語](https://github.com/avajs/ava-docs/blob/master/ja_JP/docs/recipes/endpoint-testing.md), [Português](https://github.com/avajs/ava-docs/blob/master/pt_BR/docs/recipes/endpoint-testing.md), [Русский](https://github.com/avajs/ava-docs/blob/master/ru_RU/docs/recipes/endpoint-testing.md), [简体中文](https://github.com/avajs/ava-docs/blob/master/zh_CN/docs/recipes/endpoint-testing.md)
 
-AVA doesn't have a builtin method for testing endpoints, but you can use any assertion library with it. Let's use [`supertest`](https://github.com/visionmedia/supertest).
-
-Since tests run concurrently, it's best to create a fresh server instance for each test, because if we referenced the same instance, it could be mutated between tests. This can be accomplished with a `test.beforeEach` and `t.context`, or with simply a factory function:
-
-```js
-function makeApp() {
-	const app = express();
-	app.use(bodyParser.json());
-	app.post('/signup', signupHandler);
-	return app;
-}
-```
-
-Next, just inject your server instance into supertest. The only gotcha is to use a promise or async/await syntax instead of the supertest `end` method:
+AVA doesn't have a builtin method for testing endpoints, but you can use any http client of your choosing, for example [got](https://github.com/sindresorhus/got). Next you need to bind a server instance, for that we recommend [test-listen](https://github.com/zeit/test-listen).
+Since tests run concurrently, it's best to create a fresh server instance for each test, because if we referenced the same instance, it could be mutated between tests. This can be accomplished with a `test.beforeEach` and `t.context`, or with simply a factory function.
+Check out the example below:
 
 ```js
-test('signup:Success', async t => {
-	t.plan(2);
+const app = require("../app")
+const listen = require("test-listen")
+const test = require("ava")
+const http = require("http")
+const got = require('got')
 
-	const res = await request(makeApp())
-		.post('/signup')
-		.send({email: 'ava@rocks.com', password: '123123'});
+test.before(async t => {
+        const server = http.createServer(app);
+        t.context.baseURL = await listen(server);
+})
 
-	t.is(res.status, 200);
-	t.is(res.body.email, 'ava@rocks.com');
+test('get /user', async t => {
+        const res = await got('/user', { baseURL: t.context.baseURL, json: true });
+
+        t.is(res.body.email, 'ava@rocks.com');
+
+        server.close();
 });
 ```
+
+Other libraries you may find useful: 
+- [`supertest`](https://github.com/visionmedia/supertest)
+- [`get-port`](https://github.com/sindresorhus/get-port)
+


### PR DESCRIPTION
Some people may want to use a more familiar client to them like fetch, got and etc when endpoint testing. Let's explain how to do that!

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
