### PR TITLE
Minor code refactor

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -323,7 +323,7 @@ class Api extends Emittery {
 		const forkExecArgv = execArgv.slice();
 		let flagName = '--inspect';
 		const oldValue = forkExecArgv[inspectArgIndex];
-		if (oldValue.indexOf('brk') > 0) {
+		if (oldValue.includes('brk')) {
 			flagName += '-brk';
 		}
 


### PR DESCRIPTION
use `includes()` to check for existence instead of `indexOf()`