### PR TITLE
Gitignore vim's swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .nyc_output
 coverage
 bench/.results
+*.swp


### PR DESCRIPTION
Let's ignore *.swp files so we don't commit them accidentally. Those files are usually created by vim.
<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
