### PR TITLE
Report failed hooks to tap

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -142,7 +142,7 @@ class TapReporter {
 				// Ignore
 				break;
 			case 'hook-failed':
-				this.writeComment(evt, {error: true});
+				this.writeTest(evt, {passed: false, todo: false, skip: false});
 				break;
 			case 'hook-finished':
 				this.writeComment(evt, {});


### PR DESCRIPTION
When a test fails in the hooks we don't want the test to be marked as passing for a tap parser.
This fixes #2237

