### PR TITLE
Document module path mapping in TypeScript recipe

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -28,6 +28,45 @@ You can configure AVA to recognize TypeScript files. Then, with `ts-node` instal
 
 It's worth noting that with this configuration tests will fail if there are TypeScript build errors. If you want to test while ignoring these errors you can use `ts-node/register/transpile-only` instead of `ts-node/register`.
 
+## Using module path mapping
+
+Install the [tsconfig-paths](https://github.com/dividab/tsconfig-paths#readme) package.
+
+Add the `tsconfig-paths/register` entry to the `require` section of AVA's config
+
+```json
+{
+	"ava": {
+		"compileEnhancements": false,
+		"extensions": [
+			"ts"
+		],
+		"require": [
+			"ts-node/register",
+            "tsconfig-paths/register"
+		]
+	}
+}
+```
+
+Then you can start using module aliases:
+
+`tsconfig.json`:
+```json
+{
+"baseUrl": "./",
+"paths": {
+      "@helpers/*": ["helpers/*"]
+    }
+}
+```
+
+Test:
+```typescript
+import myHelper from '@helpers/myHelper';
+// rest of the file
+```
+
 ## Compiling TypeScript files before running AVA
 
 Add a `test` script in the `package.json` file. It will compile the project first and then run AVA.

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -30,9 +30,12 @@ It's worth noting that with this configuration tests will fail if there are Type
 
 ## Using module path mapping
 
-Install the [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths#readme) package.
+`ts-node` [does not support module path mapping](https://github.com/TypeStrong/ts-node/issues/138) out of the box
+(and not going to do it in the future). To use this feature do the following: 
 
-Add the `tsconfig-paths/register` entry to the `require` section of AVA's config:
+1) Install the [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths#readme) package.
+
+2) Add the `tsconfig-paths/register` entry to the `require` section of AVA's config:
 
 ```json
 {

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -30,9 +30,9 @@ It's worth noting that with this configuration tests will fail if there are Type
 
 ## Using module path mapping
 
-Install the [tsconfig-paths](https://github.com/dividab/tsconfig-paths#readme) package.
+Install the [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths#readme) package.
 
-Add the `tsconfig-paths/register` entry to the `require` section of AVA's config
+Add the `tsconfig-paths/register` entry to the `require` section of AVA's config:
 
 ```json
 {
@@ -43,7 +43,7 @@ Add the `tsconfig-paths/register` entry to the `require` section of AVA's config
 		],
 		"require": [
 			"ts-node/register",
-            "tsconfig-paths/register"
+			"tsconfig-paths/register"
 		]
 	}
 }
@@ -54,17 +54,19 @@ Then you can start using module aliases:
 `tsconfig.json`:
 ```json
 {
-"baseUrl": "./",
-"paths": {
-      "@helpers/*": ["helpers/*"]
-    }
+	"baseUrl": ".",
+	"paths": {
+		"@helpers/*": ["helpers/*"]
+	}
 }
 ```
 
 Test:
-```typescript
+
+```ts
 import myHelper from '@helpers/myHelper';
-// rest of the file
+
+// Rest of the file
 ```
 
 ## Compiling TypeScript files before running AVA

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -10,7 +10,7 @@ This guide assumes you've already set up TypeScript for your project. Note that 
 
 You can configure AVA to recognize TypeScript files. Then, with `ts-node` installed, you can compile them on the fly.
 
-**`package.json`:**
+`package.json`:
 
 ```json
 {
@@ -28,14 +28,13 @@ You can configure AVA to recognize TypeScript files. Then, with `ts-node` instal
 
 It's worth noting that with this configuration tests will fail if there are TypeScript build errors. If you want to test while ignoring these errors you can use `ts-node/register/transpile-only` instead of `ts-node/register`.
 
-## Using module path mapping
+### Using module path mapping
 
-`ts-node` [does not support module path mapping](https://github.com/TypeStrong/ts-node/issues/138) out of the box
-(and not going to do it in the future). To use this feature do the following: 
+`ts-node` [does not support module path mapping](https://github.com/TypeStrong/ts-node/issues/138), however you can use [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths#readme).
 
-1) Install the [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths#readme) package.
+Once installed, add the `tsconfig-paths/register` entry to the `require` section of AVA's config:
 
-2) Add the `tsconfig-paths/register` entry to the `require` section of AVA's config:
+`package.json`:
 
 ```json
 {


### PR DESCRIPTION
`ts-node` has issues with usage of the path aliases. The only solution, that I've found so far is to use the [tsconfig-paths](https://github.com/dividab/tsconfig-paths#readme), which is dedicated for address this problem. So decided to add another typescript recipe