### PR TITLE
Experimentally disable Babel out of the box

### DIFF
--- a/docs/recipes/babel.md
+++ b/docs/recipes/babel.md
@@ -138,6 +138,56 @@ You can completely disable AVA's use of Babel.
 }
 ```
 
+## Experimental feature: No Babel out of the box
+
+A future release of AVA will not use Babel out of the box. You can opt in to this feature. **This feature may change or be removed at any time**:
+
+**`package.json`:**
+
+```js
+{
+	"ava": {
+		"nonSemVerExperiments": {
+			"noBabelOutOfTheBox": true
+		}
+	}
+}
+```
+
+This disables AVA's Babel pipeline, though you can still enable it by configuring it as described above.
+
+`compileEnhancements` can no longer be configured on the top-level AVA configuration. It must be configured in AVA's `babel` configuration instead. It defaults to `true`.
+
+**`package.json`:**
+
+```json
+{
+	"ava": {
+		"nonSemVerExperiments": {
+			"noBabelOutOfTheBox": true
+		},
+		"babel": {
+			"compileEnhancements": false
+		}
+	}
+}
+```
+
+You can disable the non-enhancement compilation of your test files by setting `testOptions` to `false`.
+
+```json
+{
+	"ava": {
+		"nonSemVerExperiments": {
+			"noBabelOutOfTheBox": true
+		},
+		"babel": {
+			"testOptions": false
+		}
+	}
+}
+```
+
 ## Use Babel polyfills
 
 AVA lets you write your tests using new JavaScript syntax, even on Node.js versions that otherwise wouldn't support it. However, it doesn't add or modify built-ins of your current environment. Using AVA would, for example, not provide modern features such as `Object.entries()` to an underlying Node.js 6 environment.

--- a/lib/api.js
+++ b/lib/api.js
@@ -149,7 +149,6 @@ class Api extends Emittery {
 
 			await this.emit('run', {
 				clearLogOnNextRun: runtimeOptions.clearLogOnNextRun === true,
-				experiments: Object.keys(apiOptions.experiments),
 				failFastEnabled: failFast,
 				filePathPrefix: commonPathPrefix(files),
 				files,

--- a/lib/api.js
+++ b/lib/api.js
@@ -281,16 +281,16 @@ class Api extends Emittery {
 		// Ensure cacheDir exists
 		makeDir.sync(cacheDir);
 
-		const {projectDir, babelConfig} = this.options;
+		const {projectDir, babelConfig, experiments} = this.options;
 		const compileEnhancements = this.options.compileEnhancements !== false;
 		const precompileFull = babelConfig ?
-			babelPipeline.build(projectDir, cacheDir, babelConfig, compileEnhancements) :
+			babelPipeline.build(projectDir, cacheDir, babelConfig, compileEnhancements, experiments) :
 			filename => {
 				throw new Error(`Cannot apply full precompilation, possible bad usage: ${filename}`);
 			};
 
 		let precompileEnhancementsOnly = () => null;
-		if (compileEnhancements) {
+		if (compileEnhancements && !experiments.noBabelOutOfTheBox) {
 			precompileEnhancementsOnly = this.options.extensions.enhancementsOnly.length > 0 ?
 				babelPipeline.build(projectDir, cacheDir, null, compileEnhancements) :
 				filename => {
@@ -300,7 +300,7 @@ class Api extends Emittery {
 
 		this._precompiler = {
 			cacheDir,
-			enabled: babelConfig || compileEnhancements,
+			enabled: experiments.noBabelOutOfTheBox ? precompileFull !== null : babelConfig || compileEnhancements,
 			precompileEnhancementsOnly,
 			precompileFull
 		};

--- a/lib/babel-pipeline.js
+++ b/lib/babel-pipeline.js
@@ -24,15 +24,22 @@ function getSourceMap(filePath, code) {
 	return sourceMap ? sourceMap.toObject() : undefined;
 }
 
-function hasValidKeys(conf) {
-	return Object.keys(conf).every(key => key === 'extensions' || key === 'testOptions');
+function hasValidKeys(conf, {experiments}) {
+	return Object.keys(conf).every(key => {
+		if (key === 'compileEnhancements') {
+			// This key is only allowed when the no-Babel-out-of-the-box experiment has been opted into.
+			return experiments.noBabelOutOfTheBox === true;
+		}
+
+		return key === 'extensions' || key === 'testOptions';
+	});
 }
 
 function isValidExtensions(extensions) {
 	return Array.isArray(extensions) && extensions.every(ext => typeof ext === 'string' && ext !== '');
 }
 
-function validate(conf) {
+function validate(conf, {experiments = {}} = {}) {
 	if (conf === false) {
 		return null;
 	}
@@ -40,22 +47,56 @@ function validate(conf) {
 	const defaultOptions = {babelrc: true, configFile: true};
 
 	if (conf === undefined) {
+		// There is no default config when the no-Babel-out-of-the-box experiment has been opted into.
+		if (experiments.noBabelOutOfTheBox) {
+			return null;
+		}
+
 		return {testOptions: defaultOptions};
 	}
 
-	if (
-		!isPlainObject(conf) ||
-		!hasValidKeys(conf) ||
-		(conf.testOptions !== undefined && !isPlainObject(conf.testOptions)) ||
-		(conf.extensions !== undefined && !isValidExtensions(conf.extensions))
-	) {
+	let isValid = isPlainObject(conf) && hasValidKeys(conf, {experiments});
+
+	let compileEnhancements;
+	let extensions;
+	let testOptions;
+
+	if (isValid) {
+		({compileEnhancements, extensions, testOptions} = conf);
+
+		// If a valid key, `compileEnhancements` *must* be a boolean.
+		if (compileEnhancements !== undefined && typeof compileEnhancements !== 'boolean') {
+			isValid = false;
+		}
+
+		if (extensions !== undefined && !isValidExtensions(extensions)) {
+			isValid = false;
+		}
+
+		if (testOptions !== undefined) {
+			if (testOptions === false) {
+				if (!experiments.noBabelOutOfTheBox) {
+					isValid = false;
+				}
+			} else if (!isPlainObject(conf.testOptions)) {
+				isValid = false;
+			}
+		}
+	}
+
+	if (!isValid) {
 		throw new Error(`Unexpected Babel configuration for AVA. See https://github.com/avajs/ava/blob/v${pkg.version}/docs/recipes/babel.md for allowed values.`);
 	}
 
-	return {
-		extensions: conf.extensions,
-		testOptions: {...defaultOptions, ...conf.testOptions}
-	};
+	if (experiments.noBabelOutOfTheBox && compileEnhancements !== false) {
+		compileEnhancements = true;
+	}
+
+	if (testOptions !== false) {
+		testOptions = {...defaultOptions, ...testOptions};
+	}
+
+	return {compileEnhancements, extensions, testOptions};
 }
 
 function enableParserPlugins(api) {
@@ -98,8 +139,12 @@ function createConfigItem(ref, type, options = {}) {
 // Ideally we'd detect the stage-4 preset anywhere in the configuration
 // hierarchy, but Babel's loadPartialConfig() does not return disabled presets.
 // See <https://github.com/babel/babel/issues/7920>.
-function wantsStage4(userOptions, projectDir) {
+function wantsStage4(userOptions, projectDir, {experiments}) {
 	if (!userOptions) {
+		return false;
+	}
+
+	if (experiments.noBabelOutOfTheBox && userOptions.testOptions === false) {
 		return false;
 	}
 
@@ -164,9 +209,20 @@ function hashPartialTestConfig({babelrc, config, options: {plugins, presets}}, p
 	return md5Hex(inputs);
 }
 
-function build(projectDir, cacheDir, userOptions, compileEnhancements) {
-	if (!userOptions && !compileEnhancements) {
-		return null;
+function build(projectDir, cacheDir, userOptions, compileEnhancements, experiments = {}) { // eslint-disable-line max-params
+	if (experiments.noBabelOutOfTheBox) {
+		// Don't trust the `compileEnhancements` argument when the no-Babel-out-of-the-box experiment has been opted into.
+		compileEnhancements = userOptions.compileEnhancements === true;
+	}
+
+	if (!compileEnhancements) {
+		if (!userOptions) {
+			return null;
+		}
+
+		if (experiments.noBabelOutOfTheBox && userOptions.testOptions === false) {
+			return null;
+		}
 	}
 
 	// Note that Babel ignores empty string values, even for NODE_ENV. Here
@@ -192,7 +248,7 @@ function build(projectDir, cacheDir, userOptions, compileEnhancements) {
 	const partialCacheKey = md5Hex(seedInputs);
 	const pluginAndPresetHashes = new Map();
 
-	const ensureStage4 = wantsStage4(userOptions, projectDir);
+	const ensureStage4 = wantsStage4(userOptions, projectDir, {experiments});
 	const containsStage4 = makeValueChecker('../stage-4');
 	const containsTransformTestFiles = makeValueChecker('@ava/babel-preset-transform-test-files');
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,7 @@ const loadConfig = require('./load-config');
 Promise.longStackTraces();
 
 function exit(message) {
-	console.error(`\n${require('./chalk').get().red(figures.cross)} ${message}`);
+	console.error(`\n  ${require('./chalk').get().red(figures.cross)} ${message}`);
 	process.exit(1); // eslint-disable-line unicorn/no-process-exit
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -168,6 +168,10 @@ exports.run = async () => { // eslint-disable-line complexity
 		console.log(chalk.magenta(`  ${figures.warning} Experiments are enabled. These are unsupported and may change or be removed at any time.`));
 	}
 
+	if (experiments.noBabelOutOfTheBox && typeof conf.compileEnhancements === 'boolean') {
+		exit('Enhancement compilation must be configured in AVA’s Babel options');
+	}
+
 	const ciParallelVars = require('ci-parallel-vars');
 	const Api = require('./api');
 	const VerboseReporter = require('./reporters/verbose');
@@ -181,7 +185,7 @@ exports.run = async () => { // eslint-disable-line complexity
 
 	let babelConfig = null;
 	try {
-		babelConfig = babelPipeline.validate(conf.babel);
+		babelConfig = babelPipeline.validate(conf.babel, {experiments});
 	} catch (error) {
 		exit(error.message);
 	}
@@ -195,7 +199,7 @@ exports.run = async () => { // eslint-disable-line complexity
 
 	let extensions;
 	try {
-		extensions = normalizeExtensions(conf.extensions || [], babelConfig);
+		extensions = normalizeExtensions(conf.extensions || [], babelConfig, {experiments});
 	} catch (error) {
 		exit(error.message);
 	}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -132,7 +132,7 @@ exports.run = async () => { // eslint-disable-line complexity
 		}
 	}
 
-	const {projectDir} = conf;
+	const {nonSemVerExperiments: experiments, projectDir} = conf;
 	if (cli.flags.resetCache) {
 		const cacheDir = path.join(projectDir, 'node_modules', '.cache', 'ava');
 		try {
@@ -162,6 +162,10 @@ exports.run = async () => { // eslint-disable-line complexity
 		(cli.flags.concurrency && (!Number.isInteger(Number.parseFloat(cli.flags.concurrency)) || parseInt(cli.flags.concurrency, 10) < 0))
 	) {
 		exit('The --concurrency or -c flag must be provided with a nonnegative integer.');
+	}
+
+	if (!conf.tap && Object.keys(experiments).length > 0) {
+		console.log(chalk.magenta(`  ${figures.warning} Experiments are enabled. These are unsupported and may change or be removed at any time.`));
 	}
 
 	const ciParallelVars = require('ci-parallel-vars');
@@ -238,7 +242,7 @@ exports.run = async () => { // eslint-disable-line complexity
 		color: conf.color,
 		compileEnhancements: conf.compileEnhancements !== false,
 		concurrency: conf.concurrency ? parseInt(conf.concurrency, 10) : 0,
-		experiments: conf.nonSemVerExperiments,
+		experiments,
 		extensions,
 		failFast: conf.failFast,
 		failWithoutAssertions: conf.failWithoutAssertions !== false,

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,10 +1,26 @@
-module.exports = (enhancementsOnly, babelConfig) => {
-	const {extensions: full = []} = babelConfig || {};
-
+module.exports = (configuredExtensions, babelConfig, {experiments = {}} = {}) => {
 	// Combine all extensions possible for testing. Remove duplicate extensions.
 	const duplicates = [];
 	const seen = new Set();
-	for (const ext of [...enhancementsOnly, ...full]) {
+
+	let all = [];
+	let enhancementsOnly = [];
+	let full = [];
+
+	if (experiments.noBabelOutOfTheBox) {
+		if (babelConfig) {
+			// When this experiment is opted into, the Babel pipeline takes care of
+			// compiling enhancements, so `enhancementsOnly` can be left empty.
+			({extensions: full = []} = babelConfig);
+		} else {
+			all = configuredExtensions;
+		}
+	} else {
+		enhancementsOnly = configuredExtensions;
+		({extensions: full = []} = babelConfig || {});
+	}
+
+	for (const ext of [...all, ...enhancementsOnly, ...full]) {
 		if (seen.has(ext)) {
 			duplicates.push(ext);
 		} else {
@@ -15,18 +31,25 @@ module.exports = (enhancementsOnly, babelConfig) => {
 	// Decide if and where to add the default `js` extension. Keep in mind it's not
 	// added if extensions have been explicitly given.
 	if (!seen.has('js')) {
-		if (babelConfig && full.length === 0) {
+		if (experiments.noBabelOutOfTheBox) {
 			seen.add('js');
-			full.push('js');
-		}
+			if (babelConfig && full.length === 0) {
+				full.push('js');
+			}
+		} else {
+			if (babelConfig && full.length === 0) {
+				seen.add('js');
+				full.push('js');
+			}
 
-		if (!babelConfig && enhancementsOnly.length === 0) {
-			seen.add('js');
-			enhancementsOnly.push('js');
+			if (!babelConfig && enhancementsOnly.length === 0) {
+				seen.add('js');
+				enhancementsOnly.push('js');
+			}
 		}
-	} else if (babelConfig && full.length === 0) {
+	} else if (!experiments.noBabelOutOfTheBox && babelConfig && full.length === 0) {
 		// If Babel is not disabled, and has the default extensions (or, explicitly,
-		// no configured extensions), thes the `js` extension must have come from
+		// no configured extensions), then the `js` extension must have come from
 		// the `enhancementsOnly` value. That's not allowed since it'd be a
 		// roundabout way of disabling Babel.
 		throw new Error('Cannot specify generic \'js\' extension without disabling AVA\'s Babel usage.');
@@ -36,6 +59,6 @@ module.exports = (enhancementsOnly, babelConfig) => {
 		throw new Error(`Unexpected duplicate extensions in options: '${duplicates.join('\', \'')}'.`);
 	}
 
-	const all = [...seen];
+	all = [...seen];
 	return {all, enhancementsOnly, full};
 };

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -6,7 +6,7 @@ const pkgConf = require('pkg-conf');
 
 const NO_SUCH_FILE = Symbol('no ava.config.js file');
 const MISSING_DEFAULT_EXPORT = Symbol('missing default export');
-const EXPERIMENTS = new Set(['tryAssertion']);
+const EXPERIMENTS = new Set(['noBabelOutOfTheBox', 'tryAssertion']);
 
 function loadConfig({configFile, resolveFrom = process.cwd(), defaults = {}} = {}) { // eslint-disable-line complexity
 	let packageConf = pkgConf.sync('ava', {cwd: resolveFrom});

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -136,10 +136,6 @@ class MiniReporter {
 		cliCursor.hide(this.reportStream);
 		this.lineWriter.writeLine();
 
-		if (plan.experiments.length > 0) {
-			this.lineWriter.writeLine(colors.information(`${figures.warning} Experiments are enabled. These are unsupported and may change or be be removed at any time.`));
-		}
-
 		this.spinner.start();
 	}
 

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -97,9 +97,6 @@ class VerboseReporter {
 		}
 
 		this.lineWriter.writeLine();
-		if (plan.experiments.length > 0) {
-			this.lineWriter.writeLine(colors.information(`${figures.warning} Experiments are enabled. These are unsupported and may change or be removed at any time.${os.EOL}`));
-		}
 	}
 
 	consumeStateChange(evt) { // eslint-disable-line complexity

--- a/profile.js
+++ b/profile.js
@@ -145,7 +145,6 @@ runStatus.observeWorker({
 }, file);
 
 reporter.startRun({
-	experiments: [],
 	failFastEnabled: false,
 	files: [file],
 	matching: false,

--- a/test/integration/babel.js
+++ b/test/integration/babel.js
@@ -23,7 +23,7 @@ for (const which of [
 		execCli(['es2015.js'], {dirname: `fixture/invalid-babel-config/${which}`}, (err, stdout, stderr) => {
 			t.ok(err);
 
-			let expectedOutput = '\n';
+			let expectedOutput = '\n  ';
 			expectedOutput += figures.cross + ' Unexpected Babel configuration for AVA.';
 			expectedOutput += ` See https://github.com/avajs/ava/blob/v${pkg.version}/docs/recipes/babel.md for allowed values.`;
 			expectedOutput += '\n';

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -13,7 +13,7 @@ test('formats errors from ava.config.js', t => {
 
 		const lines = stderr.split('\n');
 		t.is(lines[0], '');
-		t.is(lines[1], figures.cross + ' Error loading ava.config.js');
+		t.is(lines[1], '  ' + figures.cross + ' Error loading ava.config.js');
 		t.is(lines[2], '');
 		t.match(lines[3], /ava\.config\.js/);
 		t.match(lines[4], /foo/);

--- a/test/integration/environment-variables.js
+++ b/test/integration/environment-variables.js
@@ -26,7 +26,7 @@ test('errors if environment variables are not string values', t => {
 	execCli(['es2015.js'], {dirname: 'fixture/invalid-environment-variables'}, (err, stdout, stderr) => {
 		t.ok(err);
 
-		let expectedOutput = '\n';
+		let expectedOutput = '\n  ';
 		expectedOutput += figures.cross + ' The \'environmentVariables\' configuration must be an object containing string values.';
 		expectedOutput += '\n';
 

--- a/test/integration/extensions.js
+++ b/test/integration/extensions.js
@@ -7,7 +7,7 @@ test('errors if top-level extensions include "js" without babel=false', t => {
 	execCli(['es2015.js'], {dirname: 'fixture/invalid-extensions/top-level'}, (err, stdout, stderr) => {
 		t.ok(err);
 
-		let expectedOutput = '\n';
+		let expectedOutput = '\n  ';
 		expectedOutput += figures.cross + ' Cannot specify generic \'js\' extension without disabling AVA\'s Babel usage.';
 		expectedOutput += '\n';
 
@@ -25,7 +25,7 @@ for (const [where, which, msg = '\'js\', \'jsx\''] of [
 		execCli(['es2015.js'], {dirname: `fixture/invalid-extensions/${which}`}, (err, stdout, stderr) => {
 			t.ok(err);
 
-			let expectedOutput = '\n';
+			let expectedOutput = '\n  ';
 			expectedOutput += figures.cross + ` Unexpected duplicate extensions in options: ${msg}.`;
 			expectedOutput += '\n';
 

--- a/test/integration/globs.js
+++ b/test/integration/globs.js
@@ -7,7 +7,7 @@ test('errors if top-level files is an empty array', t => {
 	execCli(['es2015.js'], {dirname: 'fixture/invalid-globs/files'}, (err, stdout, stderr) => {
 		t.ok(err);
 
-		let expectedOutput = '\n';
+		let expectedOutput = '\n  ';
 		expectedOutput += figures.cross + ' The \'files\' configuration must be an array containing glob patterns.';
 		expectedOutput += '\n';
 
@@ -20,7 +20,7 @@ test('errors if top-level helpers is an empty array', t => {
 	execCli(['es2015.js'], {dirname: 'fixture/invalid-globs/helpers'}, (err, stdout, stderr) => {
 		t.ok(err);
 
-		let expectedOutput = '\n';
+		let expectedOutput = '\n  ';
 		expectedOutput += figures.cross + ' The \'helpers\' configuration must be an array containing glob patterns.';
 		expectedOutput += '\n';
 
@@ -33,7 +33,7 @@ test('errors if top-level sources is an empty array', t => {
 	execCli(['es2015.js'], {dirname: 'fixture/invalid-globs/sources'}, (err, stdout, stderr) => {
 		t.ok(err);
 
-		let expectedOutput = '\n';
+		let expectedOutput = '\n  ';
 		expectedOutput += figures.cross + ' The \'sources\' configuration must be an array containing glob patterns.';
 		expectedOutput += '\n';
 


### PR DESCRIPTION
This lays the groundwork for a future AVA release which will *not* run Babel out of the box. This also explicitly couples the compiled enhancements (power-assert, `t.throws()` error handling) with the Babel pipeline.

The implementation is a bit muddled with lots of checks for the experiment, but it gets the ball rolling. The next step is to create a new `@ava/babel` package which will implement both the legacy Babel pipeline *and* the new one.

Then, in a future breaking release we'll make `@ava/babel` an optional peer dependency, and require AVA's `babel` configuration to be set before files are processed by the Babel pipeline.

We'll build on top of this to enable source file compilation and find a shared interface we can use to do TypeScript compilation.