### PR TITLE
Create recipe "Debugging with node inspect"

### DIFF
--- a/docs/recipes/debugging-with-node-inspect.md
+++ b/docs/recipes/debugging-with-node-inspect.md
@@ -1,0 +1,24 @@
+# Debugging tests with node-inspect
+
+Because ava exectes its tests in parallel over multiple worker processes, it doesn't play nice with node's inspect feature by default.
+
+If you want to use the [node inspect CLI debugger](https://nodejs.org/api/debugger.html), you can use the `profile.js` entrypoint like this:
+```
+node inspect ./node_modules/ava/profile.js <file>
+```
+Where `<file>` is the test you want to debug. It is currently only possible to debug one testfile at a time.
+
+If you want to use yarn or npm to start the debugger you can add the following script in your `package.json`:
+
+```json
+{
+  "scripts": {
+    "test:debug": "node inspect ./node_modules/ava/profile.js --"
+  }
+}
+```
+
+You can now debug in your console using `{npm,yarn} run test:debug test/test.js`
+
+
+

--- a/docs/recipes/debugging-with-node-inspect.md
+++ b/docs/recipes/debugging-with-node-inspect.md
@@ -1,12 +1,12 @@
 # Debugging tests with node-inspect
 
-Because ava exectes its tests in parallel over multiple worker processes, it doesn't play nice with node's inspect feature by default.
+Because AVA executes its tests in parallel over multiple worker processes, it doesn't play nice with node's inspect feature by default.
 
 If you want to use the [node inspect CLI debugger](https://nodejs.org/api/debugger.html), you can use the `profile.js` entrypoint like this:
 ```
 node inspect ./node_modules/ava/profile.js <file>
 ```
-Where `<file>` is the test you want to debug. It is currently only possible to debug one testfile at a time.
+Where `<file>` is the test you want to debug. It is currently only possible to debug one test file at a time.
 
 If you want to use yarn or npm to start the debugger you can add the following script in your `package.json`:
 
@@ -18,7 +18,7 @@ If you want to use yarn or npm to start the debugger you can add the following s
 }
 ```
 
-You can now debug in your console using `{npm,yarn} run test:debug test/test.js`
+You can now debug in your console using:
 
-
-
+- npm: `npm run test:debug test/test.js`
+- yarn: `yarn run test:debug test/test.js`

--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,7 @@ We have a growing list of [common pitfalls](docs/08-common-pitfalls.md) you may 
 - [Debugging tests with Chrome DevTools](docs/recipes/debugging-with-chrome-devtools.md)
 - [Debugging tests with VSCode](docs/recipes/debugging-with-vscode.md)
 - [Debugging tests with WebStorm](docs/recipes/debugging-with-webstorm.md)
+- [Debugging tests with node-inspect](docs/recipes/debugging-with-node-inspect.md)
 - [Isolated MongoDB integration tests](docs/recipes/isolated-mongodb-integration-tests.md)
 - [Testing web apps using Puppeteer](docs/recipes/puppeteer.md)
 


### PR DESCRIPTION
I had some trouble to get the node inspector to work with ava, but after digging trough the issues (e.g. #1505, #1108) I found you had to use the (undocumented) `profile.js` file.

This PR adds a recipe with some documentation of this method, so it's easier for people to find.
