### PR TITLE
Correctly set Chalk level based on --color CLI boolean flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -122,7 +122,7 @@ exports.run = async () => { // eslint-disable-line complexity
 	});
 
 	updateNotifier({pkg: cli.pkg}).notify();
-	const chalk = require('./chalk').set({enabled: cli.flags.color});
+	const chalk = require('./chalk').set({level: cli.flags.color ? 1 : 0});
 
 	if (confError) {
 		if (confError.parent) {


### PR DESCRIPTION
Missed this one in #2313. It's still kinda wrong, see https://github.com/avajs/ava/issues/1701 but that's for another time.