### PR TITLE
Use CJS syntax in documentation

### DIFF
--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -21,7 +21,7 @@ To declare a test you call the `test` function you imported from AVA. Provide th
 **Note:** In order for the [enhanced assertion messages](./03-assertions.md#enhanced-assertion-messages) to behave correctly, the first argument **must** be named `t`.
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('my passing test', t => {
 	t.pass();
@@ -272,7 +272,7 @@ test('context is unicorn', t => {
 Helper files can determine the filename of the test being run by reading `test.meta.file`.  This eliminates the need to pass `__filename` from the test to helpers.
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 console.log('Test currently being run: ', test.meta.file);
 ```

--- a/docs/02-execution-context.md
+++ b/docs/02-execution-context.md
@@ -5,7 +5,7 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/do
 Each test or hook is called with an execution context. By convention it's named `t`.
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('my passing test', t => {
 	t.pass();

--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -154,7 +154,7 @@ This won't give you as nice an experience as you'd get with the [built-in assert
 You'll have to configure AVA to not fail tests if no assertions are executed, because AVA can't tell if custom assertions pass. Set the `failWithoutAssertions` option to `false` in AVA's [`package.json` configuration](./06-configuration.md).
 
 ```js
-import assert from 'assert';
+const assert = require('assert');
 
 test('custom assertion', t => {
 	assert(true);

--- a/docs/04-snapshot-testing.md
+++ b/docs/04-snapshot-testing.md
@@ -13,9 +13,9 @@ export default HelloWorld;
 
 ```js
 // Your test
-import test from 'ava';
-import render from 'react-test-renderer';
-import HelloWorld from '.';
+const test = require('ava');
+const render = require('react-test-renderer');
+const HelloWorld = require('.');
 
 test('HelloWorld component', t => {
 	const tree = render.create(<HelloWorld/>).toJSON();

--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -134,9 +134,9 @@ You can now run your unit tests through `npx ava` and the integration tests thro
 By default, AVA prints nested objects to a depth of `3`. However, when debugging tests with deeply nested objects, it can be useful to print with more detail. This can be done by setting [`util.inspect.defaultOptions.depth`](https://nodejs.org/api/util.html#util_util_inspect_defaultoptions) to the desired depth, before the test is executed:
 
 ```js
-import util from 'util';
+const util = require('util');
 
-import test from 'ava';
+const test = require('ava');
 
 util.inspect.defaultOptions.depth = 5;  // Increase AVA's printing depth
 

--- a/docs/08-common-pitfalls.md
+++ b/docs/08-common-pitfalls.md
@@ -82,7 +82,7 @@ By default AVA executes tests concurrently. This can cause problems if your test
 Take this contrived example:
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 let count = 0;
 const incr = async () => {
@@ -109,7 +109,7 @@ test('increment twice', async t => {
 Concurrent tests allow for asynchronous tests to execute more quickly, but if they rely on shared state you this may lead to unexpected test failures. If the shared state cannot be avoided, you can execute your tests serially:
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 let count = 0;
 const incr = async () => {

--- a/docs/recipes/browser-testing.md
+++ b/docs/recipes/browser-testing.md
@@ -27,22 +27,22 @@ Create a helper file, prefixed with an underscore. This ensures AVA does not tre
 `test/_setup-browser-env.js`:
 
 ```js
-import browserEnv from 'browser-env';
+const browserEnv = require('browser-env');
 browserEnv();
 ```
 
 By default, `browser-env` will add all global browser variables to the Node.js global scope, creating a full browser environment. This should have good compatibility with most front-end libraries, however, it's generally not a good idea to create lots of global variables if you don't need to. If you know exactly which browser globals you need, you can pass an array of them.
 
 ```js
-import browserEnv from 'browser-env';
+const browserEnv = require('browser-env');
 browserEnv(['window', 'document', 'navigator']);
 ```
 
 You can expose more global variables by assigning them to the `global` object. For instance, jQuery is typically available through the `$` variable:
 
 ```js
-import browserEnv from 'browser-env';
-import jQuery from 'jquery';
+const browserEnv = require('browser-env');
+const jQuery = require('jquery');
 
 browserEnv();
 global.$ = jQuery(window);
@@ -71,7 +71,7 @@ Write your tests and enjoy a mocked browser environment.
 `test.js`:
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('Insert to DOM', t => {
 	const div = document.createElement('div');

--- a/docs/recipes/endpoint-testing-with-mongoose.md
+++ b/docs/recipes/endpoint-testing-with-mongoose.md
@@ -38,14 +38,14 @@ First, include the libraries you need:
 
 ```js
 // Libraries required for testing
-import test from 'ava'
-import request from 'supertest'
-import {MongoMemoryServer} from 'mongodb-memory-server'
-import mongoose from 'mongoose'
+const test = require('ava');
+const request = require('supertest');
+const {MongoMemoryServer} = require('mongodb-memory-server');
+const mongoose = require('mongoose');
 
 // Your server and models
-import app from '../server'
-import User from '../models/User'
+const app = require('../server');
+const User = require('../models/User');
 ```
 
 Next start the in-memory MongoDB instance and connect to Mongoose:

--- a/docs/recipes/es-modules.md
+++ b/docs/recipes/es-modules.md
@@ -37,8 +37,8 @@ export default function sum(a, b) {
 
 ```js
 // test.js
-import test from 'ava';
-import sum from './sum.mjs';
+const test = require('ava');
+const sum = require('./sum.mjs');
 
 test('2 + 2 = 4', t => {
 	t.is(sum(2, 2), 4);

--- a/docs/recipes/flow.md
+++ b/docs/recipes/flow.md
@@ -34,7 +34,7 @@ Create a `test.js` file.
 
 ```js
 // @flow
-import test from 'ava';
+const test = require('ava');
 
 const getFoo = () => 'foo';
 
@@ -49,8 +49,8 @@ By default, the type of `t.context` will be the empty object (`{}`). AVA exposes
 
 ```js
 // @flow
-import anyTest from 'ava';
-import type {TestInterface} from 'ava';
+const anyTest = require('ava');
+const type {TestInterface} = require('ava');
 
 const test: TestInterface<{foo: string}> = (anyTest: any);
 
@@ -79,7 +79,7 @@ The `t.throws()` and `t.throwsAsync()` assertions are typed to always return an 
 
 ```js
 // @flow
-import test from 'ava';
+const test = require('ava');
 
 class CustomError extends Error {
 	parent: Error;

--- a/docs/recipes/isolated-mongodb-integration-tests.md
+++ b/docs/recipes/isolated-mongodb-integration-tests.md
@@ -23,8 +23,8 @@ In your test file, import the module, and run the server.
 **Make sure to run the server at the start of your file, outside of any test cases.**
 
 ```js
-import test from 'ava';
-import {MongoDBServer} from 'mongomem';
+const test = require('ava');
+const {MongoDBServer} = require('mongomem');
 
 test.before('start server', async t => {
 	await MongoDBServer.start();

--- a/docs/recipes/passing-arguments-to-your-test-files.md
+++ b/docs/recipes/passing-arguments-to-your-test-files.md
@@ -6,7 +6,7 @@ You can pass command line arguments to your test files. Use the `--` argument te
 
 ```js
 // test.js
-import test from 'ava';
+const test = require('ava');
 
 test('argv', t => {
 	t.deepEqual(process.argv.slice(2), ['--hello', 'world']);

--- a/docs/recipes/puppeteer.md
+++ b/docs/recipes/puppeteer.md
@@ -13,7 +13,7 @@ The first step is setting up a helper to configure the environment:
 `./test/_withPage.js`
 
 ```js
-import puppeteer from 'puppeteer';
+const puppeteer = require('puppeteer');
 
 export default async function withPage(t, run) {
 	const browser = await puppeteer.launch();
@@ -32,8 +32,8 @@ export default async function withPage(t, run) {
 `./test/main.js`
 
 ```js
-import test from 'ava';
-import withPage from './_withPage';
+const test = require('ava');
+const withPage = require('./_withPage');
 
 const url = 'https://google.com';
 

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -39,9 +39,9 @@ $ npm install --save-dev enzyme react-addons-test-utils react-dom
 Then you can use Enzyme straight away:
 
 ```js
-import test from 'ava';
-import React from 'react';
-import {shallow} from 'enzyme';
+const test = require('ava');
+const React = require('react');
+const {shallow} = require('enzyme');
 
 const Foo = ({children}) =>
 	<div className="Foo">
@@ -91,9 +91,9 @@ $ npm install --save-dev jsx-test-helpers
 Usage example:
 
 ```js
-import test from 'ava';
-import React from 'react';
-import {renderJSX, JSX} from 'jsx-test-helpers';
+const test = require('ava');
+const React = require('react');
+const {renderJSX, JSX} = require('jsx-test-helpers');
 
 const Foo = ({children}) =>
 	<div className="Foo">

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -53,9 +53,9 @@ You can find more information about setting up Babel with AVA in [`@ava/babel`](
 ## Sample snapshot test
 
 ```js
-import test from 'ava';
-import Vue from 'vue';
-import Component from 'component.vue';
+const test = require('ava');
+const Vue = require('vue');
+const Component = require('component.vue');
 
 test('renders', t => {
 	const vm = new Vue(Component).$mount();

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ Don't forget to configure the `test` script in your `package.json` as per above.
 Create a file named `test.js` in the project root directory:
 
 ```js
-import test from 'ava';
+const test = require('ava');
 
 test('foo', t => {
 	t.pass();


### PR DESCRIPTION
Out of the box, ESM syntax will only work in Node.js 13, so having that
as the default example is misleading.

Leave it for the TypeScript recipe since TypeScript doesn't work out of
the box anyway. Leave the config example, which will be updated when we
update the config formats for ESM.
