### PR TITLE
Tweak timeout value in t.try() test

### DIFF
--- a/test/test-try-commit.js
+++ b/test/test-try-commit.js
@@ -495,12 +495,12 @@ test('try-commit fails when it exceeds its own timeout', async t => {
 
 test('try-commit refreshes the timeout on commit/discard', async t => {
 	const result1 = await ava.cb(a => {
-		a.timeout(10);
+		a.timeout(100);
 		a.plan(3);
-		setTimeout(() => a.try(b => b.pass()).then(result => result.commit()), 5);
-		setTimeout(() => a.try(b => b.pass()).then(result => result.commit()), 10);
-		setTimeout(() => a.try(b => b.pass()).then(result => result.commit()), 15);
-		setTimeout(() => a.end(), 20);
+		setTimeout(() => a.try(b => b.pass()).then(result => result.commit()), 50);
+		setTimeout(() => a.try(b => b.pass()).then(result => result.commit()), 100);
+		setTimeout(() => a.try(b => b.pass()).then(result => result.commit()), 150);
+		setTimeout(() => a.end(), 200);
 	}).run();
 
 	t.is(result1.passed, true);


### PR DESCRIPTION
This is the one test that is still flaky on Windows.
