### PR TITLE
Set a default timeout of 10 seconds

### DIFF
--- a/docs/07-test-timeouts.md
+++ b/docs/07-test-timeouts.md
@@ -4,7 +4,7 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/do
 
 Timeouts in AVA behave differently than in other test frameworks. AVA resets a timer after each test, forcing tests to quit if no new test results were received within the specified timeout. This can be used to handle stalled tests.
 
-*There is no default timeout.*
+The default timeout is 10 seconds.
 
 You can configure timeouts using the `--timeout` [command line option](./05-command-line.md), or in the [configuration](./06-configuration.md). They can be set in a human-readable way:
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -336,7 +336,7 @@ exports.run = async () => { // eslint-disable-line complexity
 		resolveTestsFrom,
 		serial: combined.serial,
 		snapshotDir: combined.snapshotDir ? path.resolve(projectDir, combined.snapshotDir) : null,
-		timeout: combined.timeout,
+		timeout: combined.timeout || '10s',
 		updateSnapshots: combined.updateSnapshots,
 		workerArgv: argv['--']
 	});


### PR DESCRIPTION
Now that our timeout implementation is pretty good, we can set a default timeout.

10 seconds seems reasonable to me.

We exit the worker process after the timeout is reached, which should help with issues like #2310.

Fixes #2310.