### PR TITLE
Increase timeout in fail-fast interrupt test

### DIFF
--- a/test/fixture/fail-fast/multiple-files/passes-slow.js
+++ b/test/fixture/fail-fast/multiple-files/passes-slow.js
@@ -2,7 +2,7 @@ const test = require('../../../..');
 
 test.serial('first pass', t => {
 	t.pass();
-	return new Promise(resolve => setTimeout(resolve, 3000));
+	return new Promise(resolve => setTimeout(resolve, 60000));
 });
 
 test.serial('second pass', t => {


### PR DESCRIPTION
Hopefully this removes more flakiness from Windows tests.
