### PR TITLE
Ensure t.assert() counts as a passed assertion

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -853,7 +853,10 @@ class Assertions {
 						operator: '!!',
 						values: [formatWithLabel('Value is not truthy:', actual)]
 					}));
+					return;
 				}
+
+				pass();
 			});
 		} else {
 			this.assert = withSkip(withPowerAssert(


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

a fix to `t.assert()` implementation without power-assert.

closes #2354 