### PR TITLE
Fix fail-fast interrupt test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5637,6 +5637,15 @@
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
 			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
 		},
+		"p-event": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
+			"integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
+			"dev": true,
+			"requires": {
+				"p-timeout": "^2.0.1"
+			}
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -5665,6 +5674,15 @@
 			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
 			"requires": {
 				"aggregate-error": "^3.0.0"
+			}
+		},
+		"p-timeout": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"dev": true,
+			"requires": {
+				"p-finally": "^1.0.0"
 			}
 		},
 		"p-try": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
 		"execa": "^4.0.0",
 		"get-stream": "^5.1.0",
 		"lolex": "^5.1.2",
+		"p-event": "^4.1.0",
 		"proxyquire": "^2.1.3",
 		"react": "^16.12.0",
 		"react-test-renderer": "^16.12.0",

--- a/test/fixture/fail-fast/multiple-files/passes-slow.js
+++ b/test/fixture/fail-fast/multiple-files/passes-slow.js
@@ -1,8 +1,17 @@
+const pEvent = require('p-event');
 const test = require('../../../..');
 
-test.serial('first pass', t => {
+test.serial('first pass', async t => {
 	t.pass();
-	return new Promise(resolve => setTimeout(resolve, 60000));
+	const timer = setTimeout(() => {}, 60000); // Ensure process stays alive.
+	await pEvent(process, 'message', message => {
+		if (message.ava) {
+			return message.ava.type === 'peer-failed';
+		}
+
+		return false;
+	});
+	clearTimeout(timer);
 });
 
 test.serial('second pass', t => {


### PR DESCRIPTION
Listen for the peer-failure notification before resuming tests. Then
verify the test execution was interrupted.
