### PR TITLE
Rudimentary support for loading TypeScript test files

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -61,6 +61,8 @@ Note that providing files on the CLI overrides the `files` option.
 
 Provide the `babel` option (and install [`@ava/babel`](https://github.com/avajs/babel) as an additional dependency) to enable Babel compilation.
 
+Provide the `typescript` option (and install [`@ava/typescript`](https://github.com/avajs/typescript) as an additional dependency) to enable (rudimentary) TypeScript support.
+
 ## Using `ava.config.*` files
 
 Rather than specifying the configuration in the `package.json` file you can use `ava.config.js` or `ava.config.cjs` files.

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -4,84 +4,15 @@ Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/doc
 
 AVA comes bundled with a TypeScript definition file. This allows developers to leverage TypeScript for writing tests.
 
+Out of the box AVA does not load TypeScript test files, however. Rudimentary support is available via the [`@ava/typescript`] package. You can also use AVA with [`ts-node`]. Read on for details.
+
 This guide assumes you've already set up TypeScript for your project. Note that AVA's definition has been tested with version 3.7.5.
 
-## Configuring AVA to compile TypeScript files on the fly
+## Enabling AVA's TypeScript support
 
-You can configure AVA to recognize TypeScript files. Then, with `ts-node` installed, you can compile them on the fly.
+Currently, AVA's TypeScript support is designed to work for projects that precompile TypeScript. Please see [`@ava/typescript`] for setup instructions.
 
-`package.json`:
-
-```json
-{
-	"ava": {
-		"extensions": [
-			"ts"
-		],
-		"require": [
-			"ts-node/register"
-		]
-	}
-}
-```
-
-It's worth noting that with this configuration tests will fail if there are TypeScript build errors. If you want to test while ignoring these errors you can use `ts-node/register/transpile-only` instead of `ts-node/register`.
-
-### Using module path mapping
-
-`ts-node` [does not support module path mapping](https://github.com/TypeStrong/ts-node/issues/138), however you can use [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths#readme).
-
-Once installed, add the `tsconfig-paths/register` entry to the `require` section of AVA's config:
-
-`package.json`:
-
-```json
-{
-	"ava": {
-		"extensions": [
-			"ts"
-		],
-		"require": [
-			"ts-node/register",
-			"tsconfig-paths/register"
-		]
-	}
-}
-```
-
-Then you can start using module aliases:
-
-`tsconfig.json`:
-```json
-{
-	"baseUrl": ".",
-	"paths": {
-		"@helpers/*": ["helpers/*"]
-	}
-}
-```
-
-Test:
-
-```ts
-import myHelper from '@helpers/myHelper';
-
-// Rest of the file
-```
-
-## Compiling TypeScript files before running AVA
-
-Add a `test` script in the `package.json` file. It will compile the project first and then run AVA.
-
-```json
-{
-	"scripts": {
-		"test": "tsc && ava"
-	}
-}
-```
-
-Make sure that AVA runs your built TypeScript files.
+Read on until the end to learn how to use [`ts-node`] with AVA.
 
 ## Writing tests
 
@@ -221,3 +152,69 @@ test('throwsAsync', async t => {
 ```
 
 Note that, despite the typing, the assertion returns `undefined` if it fails. Typing the assertions as returning `Error | undefined` didn't seem like the pragmatic choice.
+
+## On the fly compilation using `ts-node`
+
+If [`@ava/typescript`] doesn't do the trick you can use [`ts-node`]. Make sure it's installed and then configure AVA to recognize TypeScript files and register [`ts-node`]:
+
+`package.json`:
+
+```json
+{
+	"ava": {
+		"extensions": [
+			"ts"
+		],
+		"require": [
+			"ts-node/register"
+		]
+	}
+}
+```
+
+It's worth noting that with this configuration tests will fail if there are TypeScript build errors. If you want to test while ignoring these errors you can use `ts-node/register/transpile-only` instead of `ts-node/register`.
+
+### Using module path mapping
+
+`ts-node` [does not support module path mapping](https://github.com/TypeStrong/ts-node/issues/138), however you can use [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths#readme).
+
+Once installed, add the `tsconfig-paths/register` entry to the `require` section of AVA's config:
+
+`package.json`:
+
+```json
+{
+	"ava": {
+		"extensions": [
+			"ts"
+		],
+		"require": [
+			"ts-node/register",
+			"tsconfig-paths/register"
+		]
+	}
+}
+```
+
+Then you can start using module aliases:
+
+`tsconfig.json`:
+```json
+{
+	"baseUrl": ".",
+	"paths": {
+		"@helpers/*": ["helpers/*"]
+	}
+}
+```
+
+Test:
+
+```ts
+import myHelper from '@helpers/myHelper';
+
+// Rest of the file
+```
+
+[`@ava/typescript`]: https://github.com/avajs/typescript
+[`ts-node`]: https://www.npmjs.com/package/ts-node

--- a/eslint-plugin-helper.js
+++ b/eslint-plugin-helper.js
@@ -1,8 +1,8 @@
 'use strict';
-const babelManager = require('./lib/babel-manager');
 const normalizeExtensions = require('./lib/extensions');
 const {classify, hasExtension, isHelperish, matches, normalizeFileForMatching, normalizeGlobs, normalizePatterns} = require('./lib/globs');
 const loadConfig = require('./lib/load-config');
+const providerManager = require('./lib/provider-manager');
 
 const configCache = new Map();
 const helperCache = new Map();
@@ -14,22 +14,26 @@ function load(projectDir, overrides) {
 	}
 
 	let conf;
-	let babelProvider;
+	let providers;
 	if (configCache.has(projectDir)) {
-		({conf, babelProvider} = configCache.get(projectDir));
+		({conf, providers} = configCache.get(projectDir));
 	} else {
 		conf = loadConfig({resolveFrom: projectDir});
 
+		providers = [];
 		if (Reflect.has(conf, 'babel')) {
-			babelProvider = babelManager({projectDir}).main({config: conf.babel});
+			providers.push({
+				type: 'babel',
+				main: providerManager.babel(projectDir).main({config: conf.babel})
+			});
 		}
 
-		configCache.set(projectDir, {conf, babelProvider});
+		configCache.set(projectDir, {conf, providers});
 	}
 
 	const extensions = overrides && overrides.extensions ?
 		normalizeExtensions(overrides.extensions) :
-		normalizeExtensions(conf.extensions, babelProvider);
+		normalizeExtensions(conf.extensions, providers);
 
 	let helperPatterns = [];
 	if (overrides && overrides.helpers !== undefined) {

--- a/eslint-plugin-helper.js
+++ b/eslint-plugin-helper.js
@@ -28,6 +28,13 @@ function load(projectDir, overrides) {
 			});
 		}
 
+		if (Reflect.has(conf, 'typescript')) {
+			providers.push({
+				type: 'typescript',
+				main: providerManager.typescript(projectDir).main({config: conf.typescript})
+			});
+		}
+
 		configCache.set(projectDir, {conf, providers});
 	}
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -185,8 +185,11 @@ class Api extends Emittery {
 				}
 			});
 
-			const {babelProvider} = this.options;
-			const babelState = babelProvider === undefined ? null : await babelProvider.compile({cacheDir, files: testFiles});
+			const {providers = []} = this.options;
+			const providerStates = (await Promise.all(providers.map(async ({type, main}) => {
+				const state = await main.compile({cacheDir, files: testFiles});
+				return state === null ? null : {type, state};
+			}))).filter(state => state !== null);
 
 			// Resolve the correct concurrency value.
 			let concurrency = Math.min(os.cpus().length, isCi ? 2 : Infinity);
@@ -208,7 +211,7 @@ class Api extends Emittery {
 
 				const options = {
 					...apiOptions,
-					babelState,
+					providerStates,
 					recordNewSnapshots: !isCi,
 					// If we're looking for matches, run every single test process in exclusive-only mode
 					runOnlyExclusive: apiOptions.match.length > 0 || runtimeOptions.runOnlyExclusive === true

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -256,11 +256,11 @@ exports.run = async () => { // eslint-disable-line complexity
 	const MiniReporter = require('./reporters/mini');
 	const TapReporter = require('./reporters/tap');
 	const Watcher = require('./watcher');
-	const babelManager = require('./babel-manager');
 	const normalizeExtensions = require('./extensions');
 	const {normalizeGlobs, normalizePatterns} = require('./globs');
 	const normalizeNodeArguments = require('./node-arguments');
 	const validateEnvironmentVariables = require('./environment-variables');
+	const providerManager = require('./provider-manager');
 
 	let pkg;
 	try {
@@ -279,10 +279,13 @@ exports.run = async () => { // eslint-disable-line complexity
 		js: defaultModuleType
 	};
 
-	let babelProvider;
+	const providers = [];
 	if (Reflect.has(conf, 'babel')) {
 		try {
-			babelProvider = babelManager({projectDir}).main({config: conf.babel});
+			providers.push({
+				type: 'babel',
+				main: providerManager.babel(projectDir).main({config: conf.babel})
+			});
 		} catch (error) {
 			exit(error.message);
 		}
@@ -297,7 +300,7 @@ exports.run = async () => { // eslint-disable-line complexity
 
 	let extensions;
 	try {
-		extensions = normalizeExtensions(conf.extensions, babelProvider);
+		extensions = normalizeExtensions(conf.extensions, providers);
 	} catch (error) {
 		exit(error.message);
 	}
@@ -328,22 +331,22 @@ exports.run = async () => { // eslint-disable-line complexity
 	const filter = normalizePatterns(input.map(fileOrPattern => path.relative(projectDir, path.resolve(process.cwd(), fileOrPattern))));
 
 	const api = new Api({
-		babelProvider,
 		cacheEnabled: combined.cache !== false,
 		chalkOptions,
 		concurrency: combined.concurrency || 0,
 		debug,
+		environmentVariables,
 		experiments,
 		extensions,
 		failFast: combined.failFast,
 		failWithoutAssertions: combined.failWithoutAssertions !== false,
 		globs,
-		moduleTypes,
-		environmentVariables,
 		match,
+		moduleTypes,
 		nodeArguments,
 		parallelRuns,
 		projectDir,
+		providers,
 		ranFromCli: true,
 		require: arrify(combined.require),
 		serial: combined.serial,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -291,6 +291,17 @@ exports.run = async () => { // eslint-disable-line complexity
 		}
 	}
 
+	if (Reflect.has(conf, 'typescript')) {
+		try {
+			providers.push({
+				type: 'typescript',
+				main: providerManager.typescript(projectDir).main({config: conf.typescript})
+			});
+		} catch (error) {
+			exit(error.message);
+		}
+	}
+
 	let environmentVariables;
 	try {
 		environmentVariables = validateEnvironmentVariables(conf.environmentVariables);

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,4 +1,4 @@
-module.exports = (configuredExtensions, babelProvider) => {
+module.exports = (configuredExtensions, providers = []) => {
 	// Combine all extensions possible for testing. Remove duplicate extensions.
 	const duplicates = new Set();
 	const seen = new Set();
@@ -16,15 +16,15 @@ module.exports = (configuredExtensions, babelProvider) => {
 		combine(configuredExtensions);
 	}
 
-	if (babelProvider !== undefined) {
-		combine(babelProvider.extensions);
+	for (const {main} of providers) {
+		combine(main.extensions);
 	}
 
 	if (duplicates.size > 0) {
 		throw new Error(`Unexpected duplicate extensions in options: '${[...duplicates].join('\', \'')}'.`);
 	}
 
-	// Unless the default was used by `babelProvider`, as long as the extensions aren't explicitly set, set the default.
+	// Unless the default was used by providers, as long as the extensions aren't explicitly set, set the default.
 	if (configuredExtensions === undefined) {
 		if (!seen.has('cjs')) {
 			seen.add('cjs');

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -1,15 +1,15 @@
 const pkg = require('../package.json');
 const globs = require('./globs');
 
-module.exports = ({projectDir}) => {
+function load(providerModule, projectDir) {
 	const ava = {version: pkg.version};
-	const makeProvider = require('@ava/babel');
+	const makeProvider = require(providerModule);
 
 	let fatal;
 	const provider = makeProvider({
 		negotiateProtocol(identifiers, {version}) {
 			if (!identifiers.includes('ava-3')) {
-				fatal = new Error(`This version of AVA (${ava.version}) is not compatible with@ava/babel@${version}`);
+				fatal = new Error(`This version of AVA (${ava.version}) is not compatible with ${providerModule}@${version}`);
 				return null;
 			}
 
@@ -30,4 +30,6 @@ module.exports = ({projectDir}) => {
 	}
 
 	return provider;
-};
+}
+
+exports.babel = projectDir => load('@ava/babel', projectDir);

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -33,3 +33,4 @@ function load(providerModule, projectDir) {
 }
 
 exports.babel = projectDir => load('@ava/babel', projectDir);
+exports.typescript = projectDir => load('@ava/typescript', projectDir);

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -126,6 +126,10 @@ ipc.options.then(async options => {
 			return provider;
 		}
 
+		if (type === 'typescript') {
+			return providerManager.typescript(projectDir).worker({extensionsToLoadAsModules, state});
+		}
+
 		return null;
 	}).filter(provider => provider !== null);
 

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -15,8 +15,8 @@ ipc.options.then(async options => {
 		global.console = Object.assign(global.console, new console.Console({stdout, stderr, colorMode: true}));
 	}
 
-	const babelManager = require('../babel-manager');
 	const nowAndTimers = require('../now-and-timers');
+	const providerManager = require('../provider-manager');
 	const Runner = require('../runner');
 	const serializeError = require('../serialize-error');
 	const dependencyTracking = require('./dependency-tracker');
@@ -118,12 +118,16 @@ ipc.options.then(async options => {
 
 	// Install before processing options.require, so if helpers are added to the
 	// require configuration the *compiled* helper will be loaded.
-	let babelProvider;
-	if (options.babelState !== null) {
-		const {projectDir} = options;
-		babelProvider = babelManager({projectDir}).worker({extensionsToLoadAsModules, state: options.babelState});
-		runner.powerAssert = babelProvider.powerAssert;
-	}
+	const {projectDir, providerStates = []} = options;
+	const providers = providerStates.map(({type, state}) => {
+		if (type === 'babel') {
+			const provider = providerManager.babel(projectDir).worker({extensionsToLoadAsModules, state});
+			runner.powerAssert = provider.powerAssert;
+			return provider;
+		}
+
+		return null;
+	}).filter(provider => provider !== null);
 
 	let requireFn = require;
 	const load = async ref => {
@@ -135,8 +139,10 @@ ipc.options.then(async options => {
 			}
 		}
 
-		if (babelProvider !== undefined && babelProvider.canLoad(ref)) {
-			return babelProvider.load(ref, {requireFn});
+		for (const provider of providers) {
+			if (provider.canLoad(ref)) {
+				return provider.load(ref, {requireFn});
+			}
 		}
 
 		return requireFn(ref);

--- a/test/api.js
+++ b/test/api.js
@@ -6,15 +6,18 @@ const fs = require('fs');
 const del = require('del');
 const {test} = require('tap');
 const Api = require('../lib/api');
-const babelManager = require('../lib/babel-manager');
 const {normalizeGlobs} = require('../lib/globs');
+const providerManager = require('../lib/provider-manager');
 
 const ROOT_DIR = path.join(__dirname, '..');
 
 function apiCreator(options = {}) {
 	options.projectDir = options.projectDir || ROOT_DIR;
 	if (options.babelConfig !== undefined) {
-		options.babelProvider = babelManager({projectDir: options.projectDir}).main({config: options.babelConfig});
+		options.providers = [{
+			type: 'babel',
+			main: providerManager.babel(options.projectDir).main({config: options.babelConfig})
+		}];
 	}
 
 	options.chalkOptions = {level: 0};

--- a/test/helper/report.js
+++ b/test/helper/report.js
@@ -6,8 +6,8 @@ const globby = require('globby');
 const proxyquire = require('proxyquire');
 const replaceString = require('replace-string');
 const pkg = require('../../package.json');
-const babelManager = require('../../lib/babel-manager');
 const {normalizeGlobs} = require('../../lib/globs');
+const providerManager = require('../../lib/provider-manager');
 
 let _Api = null;
 const createApi = options => {
@@ -72,7 +72,10 @@ exports.projectDir = type => path.join(__dirname, '../fixture/report', type.toLo
 const run = (type, reporter, match = []) => {
 	const projectDir = exports.projectDir(type);
 
-	const babelProvider = babelManager({projectDir}).main({config: true});
+	const providers = [{
+		type: 'babel',
+		main: providerManager.babel(projectDir).main({config: true})
+	}];
 
 	const options = {
 		extensions: ['js'],
@@ -83,7 +86,7 @@ const run = (type, reporter, match = []) => {
 		cacheEnabled: true,
 		experiments: {},
 		match,
-		babelProvider,
+		providers,
 		projectDir,
 		timeout: type.startsWith('timeout') ? '10s' : undefined,
 		concurrency: 1,


### PR DESCRIPTION
This adds very rudimentary support for loading TypeScript test files, as discussed in https://github.com/avajs/ava/issues/1109#issuecomment-557805037.

Leaving this as a draft until `@ava/typescript` ships. See https://github.com/avajs/typescript/pull/1.