### PR TITLE
types: fix parameter types of throws and throwsAsync

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -250,13 +250,13 @@ export interface ThrowsAssertion {
 	/**
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
 	 */
-	<ThrownError extends Error>(fn: () => any, expectations?: null, message?: string): ThrownError;
+	<ThrownError extends Error>(fn: () => any): ThrownError;
 
 	/**
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
 	 * The error must satisfy all expectations.
 	 */
-	<ThrownError extends Error>(fn: () => any, expectations: ThrowsExpectation, message?: string): ThrownError;
+	<ThrownError extends Error>(fn: () => any, expectations: ThrowsExpectation | null, message?: string): ThrownError;
 
 	/** Skip this assertion. */
 	skip(fn: () => any, expectations?: any, message?: string): void;
@@ -267,25 +267,25 @@ export interface ThrowsAsyncAssertion {
 	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
 	 * value. You must await the result.
 	 */
-	<ThrownError extends Error>(fn: () => PromiseLike<any>, expectations?: null, message?: string): Promise<ThrownError>;
+	<ThrownError extends Error>(fn: () => PromiseLike<any>): Promise<ThrownError>;
 
 	/**
 	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
 	 * value. You must await the result. The error must satisfy all expectations.
 	 */
-	<ThrownError extends Error>(fn: () => PromiseLike<any>, expectations: ThrowsExpectation, message?: string): Promise<ThrownError>;
+	<ThrownError extends Error>(fn: () => PromiseLike<any>, expectations: ThrowsExpectation | null, message?: string): Promise<ThrownError>;
 
 	/**
 	 * Assert that the promise rejects with [an error](https://www.npmjs.com/package/is-error). If so, returns the
 	 * rejection reason. You must await the result.
 	 */
-	<ThrownError extends Error>(promise: PromiseLike<any>, expectations?: null, message?: string): Promise<ThrownError>;
+	<ThrownError extends Error>(promise: PromiseLike<any>): Promise<ThrownError>;
 
 	/**
 	 * Assert that the promise rejects with [an error](https://www.npmjs.com/package/is-error). If so, returns the
 	 * rejection reason. You must await the result. The error must satisfy all expectations.
 	 */
-	<ThrownError extends Error>(promise: PromiseLike<any>, expectations: ThrowsExpectation, message?: string): Promise<ThrownError>;
+	<ThrownError extends Error>(promise: PromiseLike<any>, expectations: ThrowsExpectation | null, message?: string): Promise<ThrownError>;
 
 	/** Skip this assertion. */
 	skip(thrower: any, expectations?: any, message?: string): void;

--- a/test/ts-types/throws.ts
+++ b/test/ts-types/throws.ts
@@ -13,6 +13,8 @@ test('throws', t => {
 	const err1: Error = t.throws(() => {});
 	// @ts-ignore
 	t.is(err1.foo, 'foo');
+	t.throws(() => {}, null, 'message');
+	t.throws(() => {}, {message: 'message'});
 	const err2: CustomError = t.throws(() => {});
 	t.is(err2.foo, 'foo');
 	const err3 = t.throws<CustomError>(() => {});
@@ -20,9 +22,14 @@ test('throws', t => {
 });
 
 test('throwsAsync', async t => {
+	t.throwsAsync(async () => {});
+	t.throwsAsync(async () => {}, null, 'message');
+	t.throwsAsync(async () => {}, {message: 'message'});
 	const err1: Error = await t.throwsAsync(Promise.reject());
 	// @ts-ignore
 	t.is(err1.foo, 'foo');
+	t.throwsAsync(Promise.reject(), null, 'message');
+	t.throwsAsync(Promise.reject(), {message: 'message'});
 	const err2 = await t.throwsAsync<CustomError>(Promise.reject());
 	t.is(err2.foo, 'foo');
 });


### PR DESCRIPTION
After upgrading to v3 I had to change every call-site of `t.throws` and `t.throwsAsync` because I only asserted the message.
I passed `undefined` as second argument as it's perfectly fine according to the type declarations.
After that all tests failed, telling me to pass `null` instead. So I had to go through all tests again and change `undefined` to `null`.

This PR changes the type declarations. Now you are no longer allowed to pass `undefined` as second argument.