### PR TITLE
Improve error message when `test.cb()` is used with promises

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -594,7 +594,7 @@ class Test {
 		if (this.metadata.callback) {
 			if (returnedObservable || returnedPromise) {
 				const asyncType = returnedObservable ? 'observables' : 'promises';
-				this.saveFirstError(new Error(`Do not return ${asyncType} from tests declared via \`test.cb(...)\`. Use \`test.cb(...)\` for legacy callback APIs. When using promises or async functions, use \`test(...)\`.`));
+				this.saveFirstError(new Error(`Do not return ${asyncType} from tests declared via \`test.cb(...)\`. Use \`test.cb(...)\` for legacy callback APIs. When using promises, observables or async functions, use \`test(...)\`.`));
 				return this.finishPromised();
 			}
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -594,7 +594,7 @@ class Test {
 		if (this.metadata.callback) {
 			if (returnedObservable || returnedPromise) {
 				const asyncType = returnedObservable ? 'observables' : 'promises';
-				this.saveFirstError(new Error(`Do not return ${asyncType} from tests declared via \`test.cb(...)\`, if you want to return a promise simply declare the test via \`test(...)\``));
+				this.saveFirstError(new Error(`Do not return ${asyncType} from tests declared via \`test.cb(...)\`. Use \`test.cb(...)\` for legacy callback APIs. When using promises or async functions, use \`test(...)\`.`));
 				return this.finishPromised();
 			}
 


### PR DESCRIPTION
Fixes #2386 