### PR TITLE
Ship t.try() without requiring opt-in

### DIFF
--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -307,8 +307,6 @@ Snapshot assertions cannot be skipped when snapshots are being updated.
 
 `.try()` allows you to *try* assertions without causing the test to fail.
 
-*This assertion is experimental. [Enable the `tryAssertion` experiment](./06-configuration.md#experiments) to use it.*
-
 The implementation function behaves the same as any other test function. You can even use macros. The first title argument is always optional. Additional arguments are passed to the implemetation or macro function.
 
 `.try()` is an asynchronous function. You must `await` it. The result object has `commit()` and `discard()` methods. You must decide whether to commit or discard the result. If you commit a failed result, your test will fail.

--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -213,17 +213,6 @@ export default {
 };
 ```
 
-You can opt in to the new `t.try()` assertion by specifying `tryAssertion`:
-
-`ava.config.js`:
-```js
-export default {
-	nonSemVerExperiments: {
-		tryAssertion: true
-	}
-};
-```
-
 ## Node arguments
 
 The `nodeArguments` configuration may be used to specify additional arguments for launching worker processes. These are combined with `--node-arguments` passed on the CLI and any arguments passed to the `node` binary when starting AVA.

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -7,7 +7,7 @@ const pkgConf = require('pkg-conf');
 
 const NO_SUCH_FILE = Symbol('no ava.config.js file');
 const MISSING_DEFAULT_EXPORT = Symbol('missing default export');
-const EXPERIMENTS = new Set(['tryAssertion']);
+const EXPERIMENTS = new Set();
 
 class LegacyCommonJsAccessError extends Error {
 	constructor(thing, fileForErrorMessage) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -69,10 +69,6 @@ class ExecutionContext extends assert.Assertions {
 		};
 
 		this.try = async (...attemptArgs) => {
-			if (test.experiments.tryAssertion !== true) {
-				throw new Error('t.try() is currently an experiment. Opt in by setting `nonSemVerExperiments.tryAssertion` to `true`.');
-			}
-
 			const {args, buildTitle, implementations, receivedImplementationArray} = parseTestArgs(attemptArgs);
 
 			if (implementations.length === 0) {

--- a/test/helper/ava-test.js
+++ b/test/helper/ava-test.js
@@ -65,3 +65,4 @@ function withExperiments(experiments = {}) {
 
 exports.ava = withExperiments();
 exports.withExperiments = withExperiments;
+exports.newAva = () => withExperiments();

--- a/test/test-try-commit.js
+++ b/test/test-try-commit.js
@@ -5,10 +5,10 @@ require('../lib/worker/options').set({chalkOptions: {level: 0}});
 const {test} = require('tap');
 const delay = require('delay');
 const ContextRef = require('../lib/context-ref');
-const {withExperiments} = require('./helper/ava-test');
+const {newAva} = require('./helper/ava-test');
 
 test('try-commit works', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const instance = ava(async a => {
 		const res = await a.try(b => b.pass());
 		t.true(res.passed);
@@ -22,7 +22,7 @@ test('try-commit works', async t => {
 });
 
 test('try-commit is bound', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const {try: tryFn} = a;
 		const res = await tryFn(b => b.pass());
@@ -33,7 +33,7 @@ test('try-commit is bound', async t => {
 });
 
 test('try-commit discards failed attempt', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => b.fail());
 		await res.discard();
@@ -44,7 +44,7 @@ test('try-commit discards failed attempt', async t => {
 });
 
 test('try-commit can discard produced result', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => b.pass());
 		res.discard();
@@ -57,7 +57,7 @@ test('try-commit can discard produced result', async t => {
 });
 
 test('try-commit fails when not all assertions were committed/discarded', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		a.pass();
 		await a.try(b => b.pass());
@@ -73,7 +73,7 @@ test('try-commit works with values', async t => {
 	const testValue1 = 123;
 	const testValue2 = 123;
 
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try((b, val1, val2) => {
 			b.is(val1, val2);
@@ -86,7 +86,7 @@ test('try-commit works with values', async t => {
 });
 
 test('try-commit is properly counted', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const instance = ava(async a => {
 		const res = await a.try(b => {
 			b.is(1, 1);
@@ -107,7 +107,7 @@ test('try-commit is properly counted', async t => {
 });
 
 test('try-commit is properly counted multiple', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const instance = ava(async a => {
 		const [res1, res2, res3] = await Promise.all([
 			a.try(b => b.pass()),
@@ -130,7 +130,7 @@ test('try-commit is properly counted multiple', async t => {
 
 test('try-commit goes as many levels', async t => {
 	t.plan(5);
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const instance = ava(async a => {
 		t.ok(a.try);
 		const res1 = await a.try(async b => {
@@ -151,7 +151,7 @@ test('try-commit goes as many levels', async t => {
 });
 
 test('try-commit fails when not committed', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => b.pass());
 		t.true(res.passed);
@@ -164,7 +164,7 @@ test('try-commit fails when not committed', async t => {
 });
 
 test('try-commit fails when no assertions inside try', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(() => {});
 		t.false(res.passed);
@@ -180,7 +180,7 @@ test('try-commit fails when no assertions inside try', async t => {
 });
 
 test('try-commit fails when no assertions inside multiple try', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const [res1, res2] = await Promise.all([
 			a.try(b => b.pass()),
@@ -203,7 +203,7 @@ test('try-commit fails when no assertions inside multiple try', async t => {
 });
 
 test('test fails when try-commit committed to failed state', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => b.fail());
 		t.false(res.passed);
@@ -215,7 +215,7 @@ test('test fails when try-commit committed to failed state', async t => {
 
 test('try-commit has proper titles, when going in depth and width', async t => {
 	t.plan(6);
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	await ava(async a => {
 		t.is(a.title, 'test');
 
@@ -235,7 +235,7 @@ test('try-commit has proper titles, when going in depth and width', async t => {
 });
 
 test('try-commit does not fail when calling commit twice', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => b.pass());
 		res.commit();
@@ -247,7 +247,7 @@ test('try-commit does not fail when calling commit twice', async t => {
 });
 
 test('try-commit does not fail when calling discard twice', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => b.pass());
 		res.discard();
@@ -261,7 +261,7 @@ test('try-commit does not fail when calling discard twice', async t => {
 });
 
 test('try-commit allows planning inside the try', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => {
 			b.plan(3);
@@ -278,7 +278,7 @@ test('try-commit allows planning inside the try', async t => {
 });
 
 test('try-commit fails when plan is not reached inside the try', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => {
 			b.plan(3);
@@ -294,7 +294,7 @@ test('try-commit fails when plan is not reached inside the try', async t => {
 });
 
 test('plan within try-commit is not affected by assertions outside', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		a.is(1, 1);
 		a.is(2, 2);
@@ -314,7 +314,7 @@ test('plan within try-commit is not affected by assertions outside', async t => 
 });
 
 test('assertions within try-commit do not affect plan in the parent test', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		a.plan(2);
 
@@ -335,7 +335,7 @@ test('assertions within try-commit do not affect plan in the parent test', async
 });
 
 test('test expected to fail will pass with failing try-commit within the test', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava.failing(async a => {
 		const res = await a.try(b => b.fail());
 		t.false(res.passed);
@@ -351,7 +351,7 @@ test('test expected to fail will pass with failing try-commit within the test', 
 });
 
 test('try-commit works with callback test', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava.cb(a => {
 		a
 			.try(b => b.pass())
@@ -365,7 +365,7 @@ test('try-commit works with callback test', async t => {
 });
 
 test('try-commit works with failing callback test', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava.cb.failing(a => {
 		a
 			.try(b => b.fail())
@@ -387,7 +387,7 @@ test('try-commit works with failing callback test', async t => {
 });
 
 test('try-commit does not allow to use .end() in attempt when parent is callback test', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava.cb(a => {
 		a
 			.try(b => {
@@ -408,7 +408,7 @@ test('try-commit does not allow to use .end() in attempt when parent is callback
 });
 
 test('try-commit does not allow to use .end() in attempt when parent is regular test', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => {
 			b.pass();
@@ -433,7 +433,7 @@ test('try-commit accepts macros', async t => {
 
 	macro.title = (providedTitle = '') => `${providedTitle} Title`.trim();
 
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(macro);
 		t.true(res.passed);
@@ -444,7 +444,7 @@ test('try-commit accepts macros', async t => {
 });
 
 test('try-commit accepts multiple macros', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const [res1, res2] = await a.try([
 			b => {
@@ -481,7 +481,7 @@ test('try-commit accepts multiple macros', async t => {
 });
 
 test('try-commit returns results in the same shape as when implementations are passed', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const [res1, res2, res3] = await Promise.all([
 			a.try(b => b.pass()),
@@ -506,7 +506,7 @@ test('try-commit returns results in the same shape as when implementations are p
 });
 
 test('try-commit abides timeout', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result1 = await ava(async a => {
 		a.timeout(10);
 		const result = await a.try(async b => {
@@ -521,7 +521,7 @@ test('try-commit abides timeout', async t => {
 });
 
 test('try-commit fails when it exceeds its own timeout', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		a.timeout(200);
 		const result = await a.try(async b => {
@@ -545,7 +545,7 @@ test('try-commit fails when it exceeds its own timeout', async t => {
 });
 
 test('try-commit refreshes the timeout on commit/discard', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result1 = await ava.cb(a => {
 		a.timeout(100);
 		a.plan(3);
@@ -559,7 +559,7 @@ test('try-commit refreshes the timeout on commit/discard', async t => {
 });
 
 test('assertions within try-commit do not refresh the timeout', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		a.timeout(15);
 		a.pass();
@@ -587,7 +587,7 @@ test('try-commit inherits the test context', async t => {
 	const context = new ContextRef();
 	const data = {foo: 'bar'};
 	context.set(data);
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		const res = await a.try(b => {
 			b.pass();
@@ -603,7 +603,7 @@ test('assigning context in try-commit does not affect parent', async t => {
 	const context = new ContextRef();
 	const data = {foo: 'bar'};
 	context.set(data);
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const result = await ava(async a => {
 		t.strictDeepEqual(a.context, data);
 		const res = await a.try(b => {
@@ -618,7 +618,7 @@ test('assigning context in try-commit does not affect parent', async t => {
 });
 
 test('do not run assertions outside of an active attempt', async t => {
-	const ava = withExperiments({tryAssertion: true});
+	const ava = newAva();
 	const passing = await ava(async a => {
 		await a.try(() => {});
 		a.pass();

--- a/test/try-snapshot.js
+++ b/test/try-snapshot.js
@@ -10,7 +10,7 @@ const ContextRef = require('../lib/context-ref');
 
 function setup(title, manager, fn) {
 	return new Test({
-		experiments: {tryAssertion: true},
+		experiments: {},
 		fn,
 		failWithoutAssertions: true,
 		metadata: {type: 'test', callback: false},


### PR DESCRIPTION
This removes the tryAssertion experiment.