### PR TITLE
Improve ESM support detect

### DIFF
--- a/lib/esm-probe.mjs
+++ b/lib/esm-probe.mjs
@@ -1,2 +1,0 @@
-// Keep this file in place.
-// It is there to check that ESM dynamic import actually works in the current Node.js version.

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -135,12 +135,13 @@ ipc.options.then(async options => {
 	}).filter(provider => provider !== null);
 
 	// Lazily determine support since this prints an experimental warning.
-	let supportsESM = async () => {
+	let supportsESM = () => {
 		try {
-			await import('../esm-probe.mjs');
-			supportsESM = async () => true;
+			// eslint-disable-next-line no-unused-expressions
+			import('data:,');
+			supportsESM = () => true;
 		} catch {
-			supportsESM = async () => false;
+			supportsESM = () => false;
 		}
 
 		return supportsESM();
@@ -150,7 +151,7 @@ ipc.options.then(async options => {
 	const load = async ref => {
 		for (const extension of extensionsToLoadAsModules) {
 			if (ref.endsWith(`.${extension}`)) {
-				if (await supportsESM()) { // eslint-disable-line no-await-in-loop
+				if (supportsESM()) {
 					return import(pathToFileURL(ref));
 				}
 

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -138,7 +138,7 @@ ipc.options.then(async options => {
 	let supportsESM = () => {
 		try {
 			// eslint-disable-next-line no-unused-expressions
-			import('data:text/javascript,');
+			import('data:,').catch(() => {});
 			supportsESM = () => true;
 		} catch {
 			supportsESM = () => false;

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -1,5 +1,4 @@
 'use strict';
-const {pathToFileURL} = require('url');
 const currentlyUnhandled = require('currently-unhandled')();
 
 require('./ensure-forked'); // eslint-disable-line import/no-unassigned-import
@@ -155,7 +154,7 @@ ipc.options.then(async options => {
 				}
 
 				if (isESMSupported) {
-					return import(pathToFileURL(ref));
+					return import(ref);
 				}
 
 				ipc.send({type: 'internal-error', err: serializeError('Internal runner error', false, new Error('ECMAScript Modules are not supported in this Node.js version.'))});

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -138,7 +138,7 @@ ipc.options.then(async options => {
 	let supportsESM = () => {
 		try {
 			// eslint-disable-next-line no-unused-expressions
-			import('data:,').catch(() => {});
+			import('data:text/javascript,');
 			supportsESM = () => true;
 		} catch {
 			supportsESM = () => false;

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -6,7 +6,6 @@ require('./ensure-forked'); // eslint-disable-line import/no-unassigned-import
 
 const ipc = require('./ipc');
 
-// Lazily determine support since this prints an experimental warning.
 const supportsESM = async () => {
 	try {
 		await import('data:text/javascript,');
@@ -150,6 +149,7 @@ ipc.options.then(async options => {
 		for (const extension of extensionsToLoadAsModules) {
 			if (ref.endsWith(`.${extension}`)) {
 				if (typeof isESMSupported !== 'boolean') {
+					// Lazily determine support since this prints an experimental warning.
 					// eslint-disable-next-line no-await-in-loop
 					isESMSupported = await supportsESM();
 				}

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -135,23 +135,26 @@ ipc.options.then(async options => {
 	}).filter(provider => provider !== null);
 
 	// Lazily determine support since this prints an experimental warning.
-	let supportsESM = () => {
+	const supportsESM = async () => {
 		try {
-			// eslint-disable-next-line no-unused-expressions
-			import('data:text/javascript,');
-			supportsESM = () => true;
-		} catch {
-			supportsESM = () => false;
-		}
+			await import('data:text/javascript,');
+			return true;
+		} catch {}
 
-		return supportsESM();
+		return false;
 	};
 
 	let requireFn = require;
+	let isESMSupported;
 	const load = async ref => {
 		for (const extension of extensionsToLoadAsModules) {
 			if (ref.endsWith(`.${extension}`)) {
-				if (supportsESM()) {
+				if (typeof isESMSupported !== 'boolean') {
+					// eslint-disable-next-line no-await-in-loop
+					isESMSupported = await supportsESM();
+				}
+
+				if (isESMSupported) {
 					return import(pathToFileURL(ref));
 				}
 

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -1,4 +1,5 @@
 'use strict';
+const {pathToFileURL} = require('url');
 const currentlyUnhandled = require('currently-unhandled')();
 
 require('./ensure-forked'); // eslint-disable-line import/no-unassigned-import
@@ -154,7 +155,7 @@ ipc.options.then(async options => {
 				}
 
 				if (isESMSupported) {
-					return import(ref);
+					return import(pathToFileURL(ref));
 				}
 
 				ipc.send({type: 'internal-error', err: serializeError('Internal runner error', false, new Error('ECMAScript Modules are not supported in this Node.js version.'))});

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -138,7 +138,7 @@ ipc.options.then(async options => {
 	let supportsESM = () => {
 		try {
 			// eslint-disable-next-line no-unused-expressions
-			import('data:,');
+			import('data:text/javascript,');
 			supportsESM = () => true;
 		} catch {
 			supportsESM = () => false;

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -6,6 +6,16 @@ require('./ensure-forked'); // eslint-disable-line import/no-unassigned-import
 
 const ipc = require('./ipc');
 
+// Lazily determine support since this prints an experimental warning.
+const supportsESM = async () => {
+	try {
+		await import('data:text/javascript,');
+		return true;
+	} catch {}
+
+	return false;
+};
+
 ipc.send({type: 'ready-for-options'});
 ipc.options.then(async options => {
 	require('./options').set(options);
@@ -133,16 +143,6 @@ ipc.options.then(async options => {
 
 		return null;
 	}).filter(provider => provider !== null);
-
-	// Lazily determine support since this prints an experimental warning.
-	const supportsESM = async () => {
-		try {
-			await import('data:text/javascript,');
-			return true;
-		} catch {}
-
-		return false;
-	};
 
 	let requireFn = require;
 	let isESMSupported;


### PR DESCRIPTION
Replace `lib/esm-probe.mjs` file by a dataURL, 

~and we don't care about the `import` result, we don't have to wait~

Cache the detect result, so we don't have to wait for a microtask everytime

@arlac77