### PR TITLE
Add debug --host option

### DIFF
--- a/docs/recipes/debugging-with-chrome-devtools.md
+++ b/docs/recipes/debugging-with-chrome-devtools.md
@@ -22,10 +22,10 @@ Run with the `--break` option to ensure the DevTools hit a breakpoint right befo
 npx ava debug --break test.js
 ```
 
-You can also customize the port. It defaults to `9229`:
+By default the inspector listens on `127.0.0.1:9229`. You can customize the host and the port:
 
 ```console
-npx ava debug --port 9230 test.js
+npx ava debug --host 0.0.0.0 --port 9230 test.js
 ```
 
-You'll have to add a connection for this port in the *Connection* tab. AVA only binds to `localhost`.
+You'll have to add a connection for this port in the *Connection* tab.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -133,7 +133,7 @@ exports.run = async () => { // eslint-disable-line complexity
 				},
 				host: {
 					default: '127.0.0.1',
-					description: 'Network interface Node.js will listen on for the inspector',
+					description: 'Address or hostname through which you can connect to the inspector',
 					type: 'string'
 				},
 				port: {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -131,6 +131,11 @@ exports.run = async () => { // eslint-disable-line complexity
 					description: 'Break before the test file is loaded',
 					type: 'boolean'
 				},
+				host: {
+					default: '127.0.0.1',
+					description: 'Network interface Node.js will listen on for the inspector',
+					type: 'string'
+				},
 				port: {
 					default: 9229,
 					description: 'Port on which you can connect to the inspector',
@@ -145,6 +150,7 @@ exports.run = async () => { // eslint-disable-line complexity
 				debug = {
 					break: argv.break === true,
 					files: argv.pattern,
+					host: argv.host,
 					port: argv.port
 				};
 			})

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -189,7 +189,7 @@ ipc.options.then(async options => {
 		dependencyTracking.install(testPath);
 
 		if (options.debug) {
-			require('inspector').open(options.debug.port, '127.0.0.1', true);
+			require('inspector').open(options.debug.port, options.debug.host, true);
 			if (options.debug.break) {
 				debugger; // eslint-disable-line no-debugger
 			}


### PR DESCRIPTION
Fixes #2406

Previously AVA in debug mode was listening only on hardcoded '127.0.0.1' (loopback) interface.
Now, it defaults to loopback, with an override command line option: "--host".

Example usage:
`node ava debug --host 0.0.0.0 --break "${relativeFile}"`