### PR TITLE
Disallow `null` expectations for `throws` and `throwsAsync` assertions

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -73,7 +73,7 @@ function getErrorWithLongStackTrace() {
 }
 
 function validateExpectations(assertion, expectations, numArgs) { // eslint-disable-line complexity
-	if (numArgs === 1 || expectations === null || expectations === undefined) {
+	if (numArgs === 1 || expectations === undefined) {
 		expectations = {};
 	} else if (
 		typeof expectations === 'function' ||
@@ -85,7 +85,7 @@ function validateExpectations(assertion, expectations, numArgs) { // eslint-disa
 	) {
 		throw new AssertionError({
 			assertion,
-			message: `The second argument to \`t.${assertion}()\` must be an expectation object, \`null\` or \`undefined\``,
+			message: `The second argument to \`t.${assertion}()\` must be an expectation object or \`undefined\``,
 			values: [formatWithLabel('Called with:', expectations)]
 		});
 	} else {


### PR DESCRIPTION
Fixes #2410

Second argument called `expectation` (in the documentation) of the `throws` and `throwsAsync` functions, in this change cannot be assigned as `null` (but can be assigned as `undefined`).
Also in the error throw message, I changed the text of `message`, removed `null` as one of the options for the `expectation` argument.