### PR TITLE
Add hook `afterEachFailedTest`

### DIFF
--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -165,6 +165,8 @@ AVA lets you register hooks that are run before and after your tests. This allow
 
 `test.beforeEach()` registers a hook to be run before each test in your test file. Similarly `test.afterEach()` registers a hook to be run after each test. Use `test.afterEach.always()` to register an after hook that is called even if other test hooks, or the test itself, fail.
 
+`test.afterEachFailedTest()` registers a hook, which is run after each failed test. If a test is executed successfully, this hook is skipped.
+
 If a test is skipped with the `.skip` modifier, the respective `.beforeEach()`, `.afterEach()` and `.afterEach.always()` hooks are not run. Likewise, if all tests in a test file are skipped `.before()`, `.after()` and `.after.always()` hooks for the file are not run.
 
 Like `test()` these methods take an optional title and an implementation function. The title is shown if your hook fails to execute. The implementation is called with an [execution object](./02-execution-context.md). You can use assertions in your hooks. You can also pass a [macro function](#reusing-test-logic-through-macros) and additional arguments.
@@ -206,6 +208,10 @@ test.afterEach(t => {
 
 test.afterEach.always(t => {
 	// This runs after each test and other test hooks, even if they failed
+});
+
+test.afterEachFailedTest(t => {
+	// This runs after each failed test. Is skipped after a successful test.
 });
 
 test('title', t => {

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -95,11 +95,13 @@ function createChain(fn, defaults, meta) {
 
 	root.after = createHookChain(startChain('test.after', fn, {...defaults, type: 'after'}), true);
 	root.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, type: 'afterEach'}), true);
+	root.afterEachFailedTest = createHookChain(startChain('test.afterEachFailedTest', fn, {...defaults, type: 'afterEachFailedTest'}), false);
 	root.before = createHookChain(startChain('test.before', fn, {...defaults, type: 'before'}), false);
 	root.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, type: 'beforeEach'}), false);
 
 	root.serial.after = createHookChain(startChain('test.after', fn, {...defaults, serial: true, type: 'after'}), true);
 	root.serial.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, serial: true, type: 'afterEach'}), true);
+	root.serial.afterEachFailedTest = createHookChain(startChain('test.afterEachFailedTest', fn, {...defaults, serial: true, type: 'afterEachFailedTest'}), false);
 	root.serial.before = createHookChain(startChain('test.before', fn, {...defaults, serial: true, type: 'before'}), false);
 	root.serial.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, serial: true, type: 'beforeEach'}), false);
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -34,6 +34,7 @@ class Runner extends Emittery {
 			afterAlways: [],
 			afterEach: [],
 			afterEachAlways: [],
+			afterEachFailedTest: [],
 			before: [],
 			beforeEach: [],
 			concurrent: [],
@@ -343,7 +344,7 @@ class Runner extends Emittery {
 					knownFailing: result.metadata.failing,
 					logs: result.logs
 				});
-				// Don't run `afterEach` hooks if the test failed.
+				await this.runHooks(this.tasks.afterEachFailedTest, contextRef, hookSuffix);
 			}
 		}
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -371,6 +371,60 @@ test('afterEach.always run even if beforeEach failed', t => {
 	});
 });
 
+test('afterEachFailedTest only run if concurrent test failed', t => {
+	t.plan(2);
+
+	const arr = [];
+	return promiseEnd(new Runner(), runner => {
+		runner.on('stateChange', evt => {
+			if (evt.type === 'test-failed') {
+				t.pass();
+			}
+		});
+
+		runner.chain.afterEachFailedTest(() => {
+			arr.push('a');
+		});
+
+		runner.chain('fail', () => {
+			arr.push('b');
+			throw new Error('something went wrong');
+		});
+		runner.chain('pass', a => {
+			a.pass();
+		});
+	}).then(() => {
+		t.strictDeepEqual(arr, ['b', 'a']);
+	});
+});
+
+test('afterEachFailedTest only run if serial test failed', t => {
+	t.plan(2);
+
+	const arr = [];
+	return promiseEnd(new Runner(), runner => {
+		runner.on('stateChange', evt => {
+			if (evt.type === 'test-failed') {
+				t.pass();
+			}
+		});
+
+		runner.chain.afterEachFailedTest(() => {
+			arr.push('a');
+		});
+
+		runner.chain.serial('fail', () => {
+			arr.push('b');
+			throw new Error('something went wrong');
+		});
+		runner.chain.serial('pass', a => {
+			a.pass();
+		});
+	}).then(() => {
+		t.strictDeepEqual(arr, ['b', 'a']);
+	});
+});
+
 test('ensure hooks run only around tests', t => {
 	t.plan(1);
 


### PR DESCRIPTION
I liked the idea supposed in issue #840 [introducing a new hook](https://github.com/avajs/ava/issues/840#issuecomment-524370743). So in this PR i added the hook `afterEachFailedTest`


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#840: Is there a way to get test status on afterEach() method ?](https://issuehunt.io/repos/26820798/issues/840)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->