### PR TITLE
Add t.passed to execution contexts

### DIFF
--- a/docs/02-execution-context.md
+++ b/docs/02-execution-context.md
@@ -22,6 +22,10 @@ The test title.
 
 Contains shared state from hooks.
 
+## `t.passed`
+
+Whether a test has passed. This value is only accurate in the `test.afterEach()` and `test.afterEach.always()` hooks.
+
 ## `t.plan(count)`
 
 Plan how many assertion there are in the test. The test will fail if the actual assertion count doesn't match the number of planned assertions. See [assertion planning](./03-assertions.md#assertion-planning).
@@ -37,7 +41,3 @@ Log values contextually alongside the test result instead of immediately printin
 ## `t.timeout(ms)`
 
 Set a timeout for the test, in milliseconds. The test will fail if this timeout is exceeded. The timeout is reset each time an assertion is made.
-
-## `t.passed`
-
-Boolean read-only value indicating, if the test has passed. Is visible in the hook `test.afterEach.always`.

--- a/docs/02-execution-context.md
+++ b/docs/02-execution-context.md
@@ -37,3 +37,7 @@ Log values contextually alongside the test result instead of immediately printin
 ## `t.timeout(ms)`
 
 Set a timeout for the test, in milliseconds. The test will fail if this timeout is exceeded. The timeout is reset each time an assertion is made.
+
+## `t.passed`
+
+Boolean read-only value indicating, if the test has passed. Is visible in the hook `test.afterEach.always`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -308,6 +308,9 @@ export interface ExecutionContext<Context = unknown> extends Assertions {
 	/** Title of the test or hook. */
 	readonly title: string;
 
+	/** Whether the test has passed. Only accurate in afterEach hooks. */
+	readonly passed: boolean;
+
 	log: LogFn;
 	plan: PlanFn;
 	timeout: TimeoutFn;

--- a/lib/context-ref.js
+++ b/lib/context-ref.js
@@ -14,6 +14,10 @@ class ContextRef {
 		this.value = newValue;
 	}
 
+	setTestResult(result) {
+		this.passed = result.passed;
+	}
+
 	copy() {
 		return new LateBinding(this);
 	}

--- a/lib/context-ref.js
+++ b/lib/context-ref.js
@@ -14,10 +14,6 @@ class ContextRef {
 		this.value = newValue;
 	}
 
-	setTestResult(result) {
-		this.passed = result.passed;
-	}
-
 	copy() {
 		return new LateBinding(this);
 	}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -266,7 +266,7 @@ class Runner extends Emittery {
 		return result;
 	}
 
-	async runHooks(tasks, contextRef, titleSuffix) {
+	async runHooks(tasks, contextRef, titleSuffix, testPassed) {
 		const hooks = tasks.map(task => new Runnable({
 			contextRef,
 			experiments: this.experiments,
@@ -278,7 +278,8 @@ class Runner extends Emittery {
 			updateSnapshots: this.updateSnapshots,
 			metadata: task.metadata,
 			powerAssert: this.powerAssert,
-			title: `${task.title}${titleSuffix || ''}`
+			title: `${task.title}${titleSuffix || ''}`,
+			testPassed
 		}));
 		const outcome = await this.runMultiple(hooks, this.serial);
 		for (const result of outcome.storedResults) {
@@ -305,6 +306,7 @@ class Runner extends Emittery {
 
 	async runTest(task, contextRef) {
 		let hooksAndTestOk = false;
+		let result = {passed: false};
 
 		const hookSuffix = ` for ${task.title}`;
 		if (await this.runHooks(this.tasks.beforeEach, contextRef, hookSuffix)) {
@@ -324,8 +326,7 @@ class Runner extends Emittery {
 				registerUniqueTitle: this.registerUniqueTitle
 			});
 
-			const result = await this.runSingle(test);
-			contextRef.setTestResult(result);
+			result = await this.runSingle(test);
 			if (result.passed) {
 				this.emit('stateChange', {
 					type: 'test-passed',
@@ -334,7 +335,7 @@ class Runner extends Emittery {
 					knownFailing: result.metadata.failing,
 					logs: result.logs
 				});
-				hooksAndTestOk = await this.runHooks(this.tasks.afterEach, contextRef, hookSuffix);
+				hooksAndTestOk = await this.runHooks(this.tasks.afterEach, contextRef, hookSuffix, true);
 			} else {
 				this.emit('stateChange', {
 					type: 'test-failed',
@@ -348,7 +349,7 @@ class Runner extends Emittery {
 			}
 		}
 
-		const alwaysOk = await this.runHooks(this.tasks.afterEachAlways, contextRef, hookSuffix);
+		const alwaysOk = await this.runHooks(this.tasks.afterEachAlways, contextRef, hookSuffix, result.passed);
 		return hooksAndTestOk && alwaysOk;
 	}
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -305,11 +305,11 @@ class Runner extends Emittery {
 	}
 
 	async runTest(task, contextRef) {
-		let hooksAndTestOk = false;
-		let result = {passed: false};
-
 		const hookSuffix = ` for ${task.title}`;
-		if (await this.runHooks(this.tasks.beforeEach, contextRef, hookSuffix)) {
+		let hooksOk = await this.runHooks(this.tasks.beforeEach, contextRef, hookSuffix);
+
+		let testOk = false;
+		if (hooksOk) {
 			// Only run the test if all `beforeEach` hooks passed.
 			const test = new Runnable({
 				contextRef,
@@ -326,8 +326,10 @@ class Runner extends Emittery {
 				registerUniqueTitle: this.registerUniqueTitle
 			});
 
-			result = await this.runSingle(test);
-			if (result.passed) {
+			const result = await this.runSingle(test);
+			testOk = result.passed;
+
+			if (testOk) {
 				this.emit('stateChange', {
 					type: 'test-passed',
 					title: result.title,
@@ -335,7 +337,8 @@ class Runner extends Emittery {
 					knownFailing: result.metadata.failing,
 					logs: result.logs
 				});
-				hooksAndTestOk = await this.runHooks(this.tasks.afterEach, contextRef, hookSuffix, true);
+
+				hooksOk = await this.runHooks(this.tasks.afterEach, contextRef, hookSuffix, testOk);
 			} else {
 				this.emit('stateChange', {
 					type: 'test-failed',
@@ -349,8 +352,8 @@ class Runner extends Emittery {
 			}
 		}
 
-		const alwaysOk = await this.runHooks(this.tasks.afterEachAlways, contextRef, hookSuffix, result.passed);
-		return hooksAndTestOk && alwaysOk;
+		const alwaysOk = await this.runHooks(this.tasks.afterEachAlways, contextRef, hookSuffix, testOk);
+		return alwaysOk && hooksOk && testOk;
 	}
 
 	async start() {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -325,6 +325,7 @@ class Runner extends Emittery {
 			});
 
 			const result = await this.runSingle(test);
+			contextRef.setTestResult(result);
 			if (result.passed) {
 				this.emit('stateChange', {
 					type: 'test-passed',

--- a/lib/test.js
+++ b/lib/test.js
@@ -175,7 +175,7 @@ class ExecutionContext extends assert.Assertions {
 	}
 
 	get passed() {
-		return testMap.get(this).contextRef.passed;
+		return testMap.get(this).testPassed;
 	}
 
 	_throwsArgStart(assertion, file, line) {
@@ -196,6 +196,7 @@ class Test {
 		this.metadata = options.metadata;
 		this.powerAssert = options.powerAssert;
 		this.title = options.title;
+		this.testPassed = options.testPassed;
 		this.registerUniqueTitle = options.registerUniqueTitle;
 		this.logs = [];
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -174,6 +174,10 @@ class ExecutionContext extends assert.Assertions {
 		testMap.get(this).contextRef.set(context);
 	}
 
+	get passed() {
+		return testMap.get(this).contextRef.passed;
+	}
+
 	_throwsArgStart(assertion, file, line) {
 		testMap.get(this).trackThrows({assertion, file, line});
 	}

--- a/test-tap/hooks.js
+++ b/test-tap/hooks.js
@@ -371,6 +371,29 @@ test('afterEach.always run even if beforeEach failed', t => {
 	});
 });
 
+test('afterEach: property `passed` of execution-context is false when test failed and true when test passed', t => {
+	t.plan(1);
+
+	const passed = [];
+	let i;
+	return promiseEnd(new Runner(), runner => {
+		runner.chain.afterEach(a => {
+			passed[i] = a.passed;
+		});
+
+		runner.chain('failure', () => {
+			i = 0;
+			throw new Error('something went wrong');
+		});
+		runner.chain('pass', a => {
+			i = 1;
+			a.pass();
+		});
+	}).then(() => {
+		t.strictDeepEqual(passed, [undefined, true]);
+	});
+});
+
 test('afterEach.always: property `passed` of execution-context is false when test failed and true when test passed', t => {
 	t.plan(1);
 

--- a/test-tap/hooks.js
+++ b/test-tap/hooks.js
@@ -371,6 +371,29 @@ test('afterEach.always run even if beforeEach failed', t => {
 	});
 });
 
+test('afterEach.always: property `passed` of execution-context is false when test failed and true when test passed', t => {
+	t.plan(1);
+
+	const passed = [];
+	let i;
+	return promiseEnd(new Runner(), runner => {
+		runner.chain.afterEach.always(a => {
+			passed[i] = a.passed;
+		});
+
+		runner.chain('failure', () => {
+			i = 0;
+			throw new Error('something went wrong');
+		});
+		runner.chain('pass', a => {
+			i = 1;
+			a.pass();
+		});
+	}).then(() => {
+		t.strictDeepEqual(passed, [false, true]);
+	});
+});
+
 test('ensure hooks run only around tests', t => {
 	t.plan(1);
 

--- a/test-tap/hooks.js
+++ b/test-tap/hooks.js
@@ -417,6 +417,25 @@ test('afterEach.always: property `passed` of execution-context is false when tes
 	});
 });
 
+test('afterEach.always: property `passed` of execution-context is false when before hook failed', t => {
+	t.plan(1);
+
+	let passed;
+	return promiseEnd(new Runner(), runner => {
+		runner.chain.before(() => {
+			throw new Error('something went wrong');
+		});
+		runner.chain.afterEach.always(a => {
+			passed = a.passed;
+		});
+		runner.chain('pass', a => {
+			a.pass();
+		});
+	}).then(() => {
+		t.false(passed);
+	});
+});
+
 test('ensure hooks run only around tests', t => {
 	t.plan(1);
 

--- a/test-tap/hooks.js
+++ b/test-tap/hooks.js
@@ -436,6 +436,25 @@ test('afterEach.always: property `passed` of execution-context is false when bef
 	});
 });
 
+test('afterEach.always: property `passed` of execution-context is true when test passed and afterEach hook failed', t => {
+	t.plan(1);
+
+	let passed;
+	return promiseEnd(new Runner(), runner => {
+		runner.chain.afterEach(() => {
+			throw new Error('something went wrong');
+		});
+		runner.chain.afterEach.always(a => {
+			passed = a.passed;
+		});
+		runner.chain('pass', a => {
+			a.pass();
+		});
+	}).then(() => {
+		t.true(passed);
+	});
+});
+
 test('ensure hooks run only around tests', t => {
 	t.plan(1);
 


### PR DESCRIPTION
Instead of introducing the a new hook (PR #2427) the property `t.passed` is passed to the hook `afterEach.always`.

Fixes https://github.com/avajs/ava/issues/840.