### PR TITLE
Experimental test interface

### DIFF
--- a/experimental.d.ts
+++ b/experimental.d.ts
@@ -343,8 +343,24 @@ export interface TodoDeclaration {
 	(title: string): void;
 }
 
+export interface ForkableSerialInterface<Context = unknown> extends SerialInterface<Context> {
+	/** Create a new serial() function with its own hooks. */
+	fork(): ForkableSerialInterface<Context>;
+}
+
+export interface ForkableTestInterface<Context = unknown> extends TestInterface<Context> {
+	/** Create a new test() function with its own hooks. */
+	fork(): ForkableTestInterface<Context>;
+
+	/** Declare tests and hooks that are run serially. */
+	serial: ForkableSerialInterface<Context>;
+}
+
 /** Call to declare a test, or chain to declare hooks or test modifiers */
-declare const test: TestInterface;
+declare const test: TestInterface & {
+	/** Create a new test() function with its own hooks. */
+	make(): ForkableTestInterface;
+};
 
 /** Call to declare a test, or chain to declare hooks or test modifiers */
 export default test;

--- a/experimental.d.ts
+++ b/experimental.d.ts
@@ -39,12 +39,34 @@ import {ExecutionContext, ImplementationResult, MetaInterface} from '.';
 export type Implementation<Context = unknown> = (t: ExecutionContext<Context>) => ImplementationResult;
 export type ImplementationWithArgs<Args extends any[], Context = unknown> = (t: ExecutionContext<Context>, ...args: Args) => ImplementationResult;
 
+export type Macro<Args extends any[] = [], Context = unknown> = {
+	exec (t: ExecutionContext<Context>, ...args: Args): ImplementationResult;
+	title? (providedTitle?: string, ...args: Args): string;
+};
+
+export interface MacroInterface<InheritedContext = unknown> {
+	<Args extends any[] = [], Context = InheritedContext> (implementation: ImplementationWithArgs<Args, Context>): Macro<Args, Context>;
+	<Args extends any[] = [], Context = InheritedContext> (macro: Macro<Args, Context>): Macro<Args, Context>;
+}
+
 export interface TestInterface<Context = unknown> {
 	/** Declare a concurrent test. */
 	(title: string, implementation: Implementation<Context>): void;
 
 	/** Declare a concurrent test. */
 	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a concurrent test. */
+	(title: string, macro: Macro<[], Context>): void;
+
+	/** Declare a concurrent test. */
+	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+
+	/** Declare a concurrent test. */
+	(macro: Macro<[], Context>): void;
+
+	/** Declare a concurrent test. */
+	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
 
 	/** Declare a hook that is run once, after all tests have passed. */
 	after: AfterInterface<Context>;
@@ -57,6 +79,9 @@ export interface TestInterface<Context = unknown> {
 
 	/** Declare a hook that is run before each test. */
 	beforeEach: BeforeInterface<Context>;
+
+	/** Create a macro you can reuse in multiple tests. */
+	macro: MacroInterface<Context>;
 
 	/** Declare a test that is expected to fail. */
 	failing: FailingInterface<Context>;
@@ -122,11 +147,23 @@ export interface BeforeInterface<Context = unknown> {
 }
 
 export interface FailingInterface<Context = unknown> {
-	/** Declare a concurrent test. The test is expected to fail. */
+	/** Declare a test that is is expected to fail. */
 	(title: string, implementation: Implementation<Context>): void;
 
-	/** Declare a concurrent test. The test is expected to fail. */
+	/** Declare a test that is is expected to fail. */
 	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a test that is is expected to fail. */
+	(title: string, macro: Macro<[], Context>): void;
+
+	/** Declare a test that is is expected to fail. */
+	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+
+	/** Declare a test that is is expected to fail. */
+	(macro: Macro<[], Context>): void;
+
+	/** Declare a test that is is expected to fail. */
+	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
 
 	only: OnlyInterface<Context>;
 	skip: SkipInterface<Context>;
@@ -152,6 +189,18 @@ export interface OnlyInterface<Context = unknown> {
 
 	/** Declare a test. Only this test and others declared with `.only()` are run. */
 	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a test. Only this test and others declared with `.only()` are run. */
+	(title: string, macro: Macro<[], Context>): void;
+
+	/** Declare a test. Only this test and others declared with `.only()` are run. */
+	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+
+	/** Declare a test. Only this test and others declared with `.only()` are run. */
+	(macro: Macro<[], Context>): void;
+
+	/** Declare a test. Only this test and others declared with `.only()` are run. */
+	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
 }
 
 export interface SerialInterface<Context = unknown> {
@@ -160,6 +209,18 @@ export interface SerialInterface<Context = unknown> {
 
 	/** Declare a serial test. */
 	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a serial test. */
+	(title: string, macro: Macro<[], Context>): void;
+
+	/** Declare a serial test. */
+	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+
+	/** Declare a serial test. */
+	(macro: Macro<[], Context>): void;
+
+	/** Declare a serial test. */
+	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
 
 	/** Declare a serial hook that is run once, after all tests have passed. */
 	after: AfterInterface<Context>;
@@ -172,6 +233,9 @@ export interface SerialInterface<Context = unknown> {
 
 	/** Declare a serial hook that is run before each test. */
 	beforeEach: BeforeInterface<Context>;
+
+	/** Create a macro you can reuse in multiple tests. */
+	macro: MacroInterface<Context>;
 
 	/** Declare a serial test that is expected to fail. */
 	failing: FailingInterface<Context>;
@@ -187,6 +251,18 @@ export interface SkipInterface<Context = unknown> {
 
 	/** Skip this test. */
 	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Skip this test. */
+	(title: string, macro: Macro<[], Context>): void;
+
+	/** Skip this test. */
+	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+
+	/** Skip this test. */
+	(macro: Macro<[], Context>): void;
+
+	/** Skip this test. */
+	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
 }
 
 export interface TodoDeclaration {

--- a/experimental.d.ts
+++ b/experimental.d.ts
@@ -5,7 +5,6 @@ export {
 	CommitDiscardOptions,
 	Constructor,
 	DeepEqualAssertion,
-	ExecutionContext,
 	FailAssertion,
 	FalseAssertion,
 	FalsyAssertion,
@@ -30,11 +29,85 @@ export {
 	TimeoutFn,
 	TrueAssertion,
 	TruthyAssertion,
-	TryFn,
 	TryResult
 } from '.';
 
-import {ExecutionContext, ImplementationResult, MetaInterface} from '.';
+import {
+	Assertions,
+	ImplementationResult,
+	MetaInterface,
+	LogFn,
+	PlanFn,
+	TimeoutFn,
+	TryResult
+} from '.';
+
+export interface ExecutionContext<Context = unknown> extends Assertions {
+	/** Test context, shared with hooks. */
+	context: Context;
+
+	/** Title of the test or hook. */
+	readonly title: string;
+
+	/** Whether the test has passed. Only accurate in afterEach hooks. */
+	readonly passed: boolean;
+
+	log: LogFn;
+	plan: PlanFn;
+	timeout: TimeoutFn;
+	try: TryFn<Context>;
+}
+
+export interface TryFn<Context = unknown> {
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail. The title may help distinguish attempts from one another.
+	 */
+	(title: string, implementation: Implementation<Context>): Promise<TryResult>;
+
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail. The title may help distinguish attempts from one another.
+	 */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): Promise<TryResult>;
+
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail. A macro may be provided. The title may help distinguish attempts from
+	 * one another.
+	 */
+	(title: string, macro: Macro<[], Context>): Promise<TryResult>;
+
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail. A macro may be provided.
+	 */
+	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): Promise<TryResult>;
+
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail.
+	 */
+	(implementation: Implementation<Context>): Promise<TryResult>;
+
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail.
+	 */
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): Promise<TryResult>;
+
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail. A macro may be provided.
+	 */
+	(macro: Macro<[], Context>): Promise<TryResult>;
+
+	/**
+	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
+	 * the test will fail. A macro may be provided.
+	 */
+	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): Promise<TryResult>;
+}
 
 export type Implementation<Context = unknown> = (t: ExecutionContext<Context>) => ImplementationResult;
 export type ImplementationWithArgs<Args extends any[], Context = unknown> = (t: ExecutionContext<Context>, ...args: Args) => ImplementationResult;

--- a/experimental.d.ts
+++ b/experimental.d.ts
@@ -1,0 +1,201 @@
+export {
+	AssertAssertion,
+	AssertionError,
+	Assertions,
+	CommitDiscardOptions,
+	Constructor,
+	DeepEqualAssertion,
+	ExecutionContext,
+	FailAssertion,
+	FalseAssertion,
+	FalsyAssertion,
+	ImplementationResult,
+	IsAssertion,
+	LogFn,
+	MetaInterface,
+	NotAssertion,
+	NotDeepEqualAssertion,
+	NotRegexAssertion,
+	NotThrowsAssertion,
+	NotThrowsAsyncAssertion,
+	PassAssertion,
+	PlanFn,
+	RegexAssertion,
+	SnapshotAssertion,
+	SnapshotOptions,
+	Subscribable,
+	ThrowsAssertion,
+	ThrowsAsyncAssertion,
+	ThrowsExpectation,
+	TimeoutFn,
+	TrueAssertion,
+	TruthyAssertion,
+	TryFn,
+	TryResult
+} from '.';
+
+import {ExecutionContext, ImplementationResult, MetaInterface} from '.';
+
+export type Implementation<Context = unknown> = (t: ExecutionContext<Context>) => ImplementationResult;
+export type ImplementationWithArgs<Args extends any[], Context = unknown> = (t: ExecutionContext<Context>, ...args: Args) => ImplementationResult;
+
+export interface TestInterface<Context = unknown> {
+	/** Declare a concurrent test. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Declare a concurrent test. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a hook that is run once, after all tests have passed. */
+	after: AfterInterface<Context>;
+
+	/** Declare a hook that is run after each passing test. */
+	afterEach: AfterInterface<Context>;
+
+	/** Declare a hook that is run once, before all tests. */
+	before: BeforeInterface<Context>;
+
+	/** Declare a hook that is run before each test. */
+	beforeEach: BeforeInterface<Context>;
+
+	/** Declare a test that is expected to fail. */
+	failing: FailingInterface<Context>;
+
+	/** Declare tests and hooks that are run serially. */
+	serial: SerialInterface<Context>;
+
+	only: OnlyInterface<Context>;
+	skip: SkipInterface<Context>;
+	todo: TodoDeclaration;
+	meta: MetaInterface;
+}
+
+export interface AfterInterface<Context = unknown> {
+	/** Declare a hook that is run once, after all tests have passed. */
+	(implementation: Implementation<Context>): void;
+
+	/** Declare a hook that is run once, after all tests have passed. */
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a hook that is run once, after all tests have passed. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Declare a hook that is run once, after all tests have passed. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a hook that is run once, after all tests are done. */
+	always: AlwaysInterface<Context>;
+
+	skip: HookSkipInterface<Context>;
+}
+
+export interface AlwaysInterface<Context = unknown> {
+	/** Declare a hook that is run once, after all tests are done. */
+	(implementation: Implementation<Context>): void;
+
+	/** Declare a hook that is run once, after all tests are done. */
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a hook that is run once, after all tests are done. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Declare a hook that is run once, after all tests are done. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	skip: HookSkipInterface<Context>;
+}
+
+export interface BeforeInterface<Context = unknown> {
+	/** Declare a hook that is run once, before all tests. */
+	(implementation: Implementation<Context>): void;
+
+	/** Declare a hook that is run once, before all tests. */
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a hook that is run once, before all tests. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Declare a hook that is run once, before all tests. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	skip: HookSkipInterface<Context>;
+}
+
+export interface FailingInterface<Context = unknown> {
+	/** Declare a concurrent test. The test is expected to fail. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Declare a concurrent test. The test is expected to fail. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	only: OnlyInterface<Context>;
+	skip: SkipInterface<Context>;
+}
+
+export interface HookSkipInterface<Context = unknown> {
+	/** Skip this hook. */
+	(implementation: Implementation<Context>): void;
+
+	/** Skip this hook. */
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Skip this hook. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Skip this hook. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+}
+
+export interface OnlyInterface<Context = unknown> {
+	/** Declare a test. Only this test and others declared with `.only()` are run. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Declare a test. Only this test and others declared with `.only()` are run. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+}
+
+export interface SerialInterface<Context = unknown> {
+	/** Declare a serial test. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Declare a serial test. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+
+	/** Declare a serial hook that is run once, after all tests have passed. */
+	after: AfterInterface<Context>;
+
+	/** Declare a serial hook that is run after each passing test. */
+	afterEach: AfterInterface<Context>;
+
+	/** Declare a serial hook that is run once, before all tests. */
+	before: BeforeInterface<Context>;
+
+	/** Declare a serial hook that is run before each test. */
+	beforeEach: BeforeInterface<Context>;
+
+	/** Declare a serial test that is expected to fail. */
+	failing: FailingInterface<Context>;
+
+	only: OnlyInterface<Context>;
+	skip: SkipInterface<Context>;
+	todo: TodoDeclaration;
+}
+
+export interface SkipInterface<Context = unknown> {
+	/** Skip this test. */
+	(title: string, implementation: Implementation<Context>): void;
+
+	/** Skip this test. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+}
+
+export interface TodoDeclaration {
+	/** Declare a test that should be implemented later. */
+	(title: string): void;
+}
+
+/** Call to declare a test, or chain to declare hooks or test modifiers */
+declare const test: TestInterface;
+
+/** Call to declare a test, or chain to declare hooks or test modifiers */
+export default test;

--- a/experimental.d.ts
+++ b/experimental.d.ts
@@ -42,7 +42,7 @@ import {
 	TryResult
 } from '.';
 
-export interface ExecutionContext<Context = unknown> extends Assertions {
+export type ExecutionContext<Context = unknown, ExtraAssertions = unknown> = Assertions & ExtraAssertions & {
 	/** Test context, shared with hooks. */
 	context: Context;
 
@@ -55,287 +55,287 @@ export interface ExecutionContext<Context = unknown> extends Assertions {
 	log: LogFn;
 	plan: PlanFn;
 	timeout: TimeoutFn;
-	try: TryFn<Context>;
-}
+	try: TryFn<Context, ExtraAssertions>;
+};
 
-export interface TryFn<Context = unknown> {
+export interface TryFn<Context = unknown, ExtraAssertions = unknown> {
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail. The title may help distinguish attempts from one another.
 	 */
-	(title: string, implementation: Implementation<Context>): Promise<TryResult>;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): Promise<TryResult>;
 
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail. The title may help distinguish attempts from one another.
 	 */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): Promise<TryResult>;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): Promise<TryResult>;
 
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail. A macro may be provided. The title may help distinguish attempts from
 	 * one another.
 	 */
-	(title: string, macro: Macro<[], Context>): Promise<TryResult>;
+	(title: string, macro: Macro<[], Context, ExtraAssertions>): Promise<TryResult>;
 
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail. A macro may be provided.
 	 */
-	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): Promise<TryResult>;
+	<Args extends any[]> (title: string, macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): Promise<TryResult>;
 
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail.
 	 */
-	(implementation: Implementation<Context>): Promise<TryResult>;
+	(implementation: Implementation<Context, ExtraAssertions>): Promise<TryResult>;
 
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail.
 	 */
-	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): Promise<TryResult>;
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): Promise<TryResult>;
 
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail. A macro may be provided.
 	 */
-	(macro: Macro<[], Context>): Promise<TryResult>;
+	(macro: Macro<[], Context, ExtraAssertions>): Promise<TryResult>;
 
 	/**
 	 * Attempt to run some assertions. The result must be explicitly committed or discarded or else
 	 * the test will fail. A macro may be provided.
 	 */
-	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): Promise<TryResult>;
+	<Args extends any[]> (macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): Promise<TryResult>;
 }
 
-export type Implementation<Context = unknown> = (t: ExecutionContext<Context>) => ImplementationResult;
-export type ImplementationWithArgs<Args extends any[], Context = unknown> = (t: ExecutionContext<Context>, ...args: Args) => ImplementationResult;
+export type Implementation<Context = unknown, ExtraAssertions = unknown> = (t: ExecutionContext<Context, ExtraAssertions>) => ImplementationResult;
+export type ImplementationWithArgs<Args extends any[], Context = unknown, ExtraAssertions = unknown> = (t: ExecutionContext<Context, ExtraAssertions>, ...args: Args) => ImplementationResult;
 
-export type Macro<Args extends any[] = [], Context = unknown> = {
-	exec (t: ExecutionContext<Context>, ...args: Args): ImplementationResult;
+export type Macro<Args extends any[] = [], Context = unknown, ExtraAssertions = unknown> = {
+	exec (t: ExecutionContext<Context, ExtraAssertions>, ...args: Args): ImplementationResult;
 	title? (providedTitle?: string, ...args: Args): string;
 };
 
-export interface MacroInterface<InheritedContext = unknown> {
-	<Args extends any[] = [], Context = InheritedContext> (implementation: ImplementationWithArgs<Args, Context>): Macro<Args, Context>;
-	<Args extends any[] = [], Context = InheritedContext> (macro: Macro<Args, Context>): Macro<Args, Context>;
+export interface MacroInterface<InheritedContext = unknown, ExtraAssertions = unknown> {
+	<Args extends any[] = [], Context = InheritedContext> (implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>): Macro<Args, Context, ExtraAssertions>;
+	<Args extends any[] = [], Context = InheritedContext> (macro: Macro<Args, Context, ExtraAssertions>): Macro<Args, Context, ExtraAssertions>;
 }
 
-export interface TestInterface<Context = unknown> {
+export interface TestInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Declare a concurrent test. */
-	(title: string, implementation: Implementation<Context>): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a concurrent test. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a concurrent test. */
-	(title: string, macro: Macro<[], Context>): void;
+	(title: string, macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a concurrent test. */
-	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a concurrent test. */
-	(macro: Macro<[], Context>): void;
+	(macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a concurrent test. */
-	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a hook that is run once, after all tests have passed. */
-	after: AfterInterface<Context>;
+	after: AfterInterface<Context, ExtraAssertions>;
 
 	/** Declare a hook that is run after each passing test. */
-	afterEach: AfterInterface<Context>;
+	afterEach: AfterInterface<Context, ExtraAssertions>;
 
 	/** Declare a hook that is run once, before all tests. */
-	before: BeforeInterface<Context>;
+	before: BeforeInterface<Context, ExtraAssertions>;
 
 	/** Declare a hook that is run before each test. */
-	beforeEach: BeforeInterface<Context>;
+	beforeEach: BeforeInterface<Context, ExtraAssertions>;
 
 	/** Create a macro you can reuse in multiple tests. */
-	macro: MacroInterface<Context>;
+	macro: MacroInterface<Context, ExtraAssertions>;
 
 	/** Declare a test that is expected to fail. */
-	failing: FailingInterface<Context>;
+	failing: FailingInterface<Context, ExtraAssertions>;
 
 	/** Declare tests and hooks that are run serially. */
-	serial: SerialInterface<Context>;
+	serial: SerialInterface<Context, ExtraAssertions>;
 
-	only: OnlyInterface<Context>;
-	skip: SkipInterface<Context>;
+	only: OnlyInterface<Context, ExtraAssertions>;
+	skip: SkipInterface<Context, ExtraAssertions>;
 	todo: TodoDeclaration;
 	meta: MetaInterface;
 }
 
-export interface AfterInterface<Context = unknown> {
+export interface AfterInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Declare a hook that is run once, after all tests have passed. */
-	(implementation: Implementation<Context>): void;
-
-	/** Declare a hook that is run once, after all tests have passed. */
-	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	(implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a hook that is run once, after all tests have passed. */
-	(title: string, implementation: Implementation<Context>): void;
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a hook that is run once, after all tests have passed. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
+
+	/** Declare a hook that is run once, after all tests have passed. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a hook that is run once, after all tests are done. */
-	always: AlwaysInterface<Context>;
+	always: AlwaysInterface<Context, ExtraAssertions>;
 
-	skip: HookSkipInterface<Context>;
+	skip: HookSkipInterface<Context, ExtraAssertions>;
 }
 
-export interface AlwaysInterface<Context = unknown> {
+export interface AlwaysInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Declare a hook that is run once, after all tests are done. */
-	(implementation: Implementation<Context>): void;
+	(implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a hook that is run once, after all tests are done. */
-	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a hook that is run once, after all tests are done. */
-	(title: string, implementation: Implementation<Context>): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a hook that is run once, after all tests are done. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
-	skip: HookSkipInterface<Context>;
+	skip: HookSkipInterface<Context, ExtraAssertions>;
 }
 
-export interface BeforeInterface<Context = unknown> {
+export interface BeforeInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Declare a hook that is run once, before all tests. */
-	(implementation: Implementation<Context>): void;
-
-	/** Declare a hook that is run once, before all tests. */
-	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
-
-	/** Declare a hook that is run once, before all tests. */
-	(title: string, implementation: Implementation<Context>): void;
+	(implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a hook that is run once, before all tests. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
-	skip: HookSkipInterface<Context>;
+	/** Declare a hook that is run once, before all tests. */
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
+
+	/** Declare a hook that is run once, before all tests. */
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
+
+	skip: HookSkipInterface<Context, ExtraAssertions>;
 }
 
-export interface FailingInterface<Context = unknown> {
+export interface FailingInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Declare a test that is is expected to fail. */
-	(title: string, implementation: Implementation<Context>): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a test that is is expected to fail. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a test that is is expected to fail. */
-	(title: string, macro: Macro<[], Context>): void;
+	(title: string, macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a test that is is expected to fail. */
-	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a test that is is expected to fail. */
-	(macro: Macro<[], Context>): void;
+	(macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a test that is is expected to fail. */
-	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
-	only: OnlyInterface<Context>;
-	skip: SkipInterface<Context>;
+	only: OnlyInterface<Context, ExtraAssertions>;
+	skip: SkipInterface<Context, ExtraAssertions>;
 }
 
-export interface HookSkipInterface<Context = unknown> {
+export interface HookSkipInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Skip this hook. */
-	(implementation: Implementation<Context>): void;
+	(implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Skip this hook. */
-	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Skip this hook. */
-	(title: string, implementation: Implementation<Context>): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Skip this hook. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 }
 
-export interface OnlyInterface<Context = unknown> {
+export interface OnlyInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Declare a test. Only this test and others declared with `.only()` are run. */
-	(title: string, implementation: Implementation<Context>): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a test. Only this test and others declared with `.only()` are run. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a test. Only this test and others declared with `.only()` are run. */
-	(title: string, macro: Macro<[], Context>): void;
+	(title: string, macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a test. Only this test and others declared with `.only()` are run. */
-	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a test. Only this test and others declared with `.only()` are run. */
-	(macro: Macro<[], Context>): void;
+	(macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a test. Only this test and others declared with `.only()` are run. */
-	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 }
 
-export interface SerialInterface<Context = unknown> {
+export interface SerialInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Declare a serial test. */
-	(title: string, implementation: Implementation<Context>): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Declare a serial test. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a serial test. */
-	(title: string, macro: Macro<[], Context>): void;
+	(title: string, macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a serial test. */
-	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a serial test. */
-	(macro: Macro<[], Context>): void;
+	(macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Declare a serial test. */
-	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Declare a serial hook that is run once, after all tests have passed. */
-	after: AfterInterface<Context>;
+	after: AfterInterface<Context, ExtraAssertions>;
 
 	/** Declare a serial hook that is run after each passing test. */
-	afterEach: AfterInterface<Context>;
+	afterEach: AfterInterface<Context, ExtraAssertions>;
 
 	/** Declare a serial hook that is run once, before all tests. */
-	before: BeforeInterface<Context>;
+	before: BeforeInterface<Context, ExtraAssertions>;
 
 	/** Declare a serial hook that is run before each test. */
-	beforeEach: BeforeInterface<Context>;
+	beforeEach: BeforeInterface<Context, ExtraAssertions>;
 
 	/** Create a macro you can reuse in multiple tests. */
-	macro: MacroInterface<Context>;
+	macro: MacroInterface<Context, ExtraAssertions>;
 
 	/** Declare a serial test that is expected to fail. */
-	failing: FailingInterface<Context>;
+	failing: FailingInterface<Context, ExtraAssertions>;
 
-	only: OnlyInterface<Context>;
-	skip: SkipInterface<Context>;
+	only: OnlyInterface<Context, ExtraAssertions>;
+	skip: SkipInterface<Context, ExtraAssertions>;
 	todo: TodoDeclaration;
 }
 
-export interface SkipInterface<Context = unknown> {
+export interface SkipInterface<Context = unknown, ExtraAssertions = unknown> {
 	/** Skip this test. */
-	(title: string, implementation: Implementation<Context>): void;
+	(title: string, implementation: Implementation<Context, ExtraAssertions>): void;
 
 	/** Skip this test. */
-	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, implementation: ImplementationWithArgs<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Skip this test. */
-	(title: string, macro: Macro<[], Context>): void;
+	(title: string, macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Skip this test. */
-	<Args extends any[]> (title: string, macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (title: string, macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 
 	/** Skip this test. */
-	(macro: Macro<[], Context>): void;
+	(macro: Macro<[], Context, ExtraAssertions>): void;
 
 	/** Skip this test. */
-	<Args extends any[]> (macro: Macro<Args, Context>, ...args: Args): void;
+	<Args extends any[]> (macro: Macro<Args, Context, ExtraAssertions>, ...args: Args): void;
 }
 
 export interface TodoDeclaration {
@@ -343,17 +343,17 @@ export interface TodoDeclaration {
 	(title: string): void;
 }
 
-export interface ForkableSerialInterface<Context = unknown> extends SerialInterface<Context> {
+export interface ForkableSerialInterface<Context = unknown, ExtraAssertions = unknown> extends SerialInterface<Context> {
 	/** Create a new serial() function with its own hooks. */
-	fork(): ForkableSerialInterface<Context>;
+	fork(): ForkableSerialInterface<Context, ExtraAssertions>;
 }
 
-export interface ForkableTestInterface<Context = unknown> extends TestInterface<Context> {
+export interface ForkableTestInterface<Context = unknown, ExtraAssertions = unknown> extends TestInterface<Context> {
 	/** Create a new test() function with its own hooks. */
-	fork(): ForkableTestInterface<Context>;
+	fork(): ForkableTestInterface<Context, ExtraAssertions>;
 
 	/** Declare tests and hooks that are run serially. */
-	serial: ForkableSerialInterface<Context>;
+	serial: ForkableSerialInterface<Context, ExtraAssertions>;
 }
 
 /** Call to declare a test, or chain to declare hooks or test modifiers */

--- a/experimental.js
+++ b/experimental.js
@@ -1,8 +1,9 @@
 'use strict';
+const path = require('path');
 
 // Ensure the same AVA install is loaded by the test file as by the test worker
 if (process.env.AVA_PATH && process.env.AVA_PATH !== __dirname) {
-	module.exports = require(process.env.AVA_PATH);
+	module.exports = require(path.join(process.env.AVA_PATH, 'experimental.js'));
 } else {
-	module.exports = require('./lib/worker/main').ava3();
+	module.exports = require('./lib/worker/main').experimental();
 }

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -64,12 +64,13 @@ function createHookChain({allowCallbacks, isAfterHook = false}, hook) {
 
 function createChain({
 	allowCallbacks = true,
+	allowImplementationTitleFns = true,
 	allowMultipleImplementations = true,
 	annotations,
 	declare: declareWithOptions,
 	meta
 }) {
-	const options = {allowCallbacks, allowMultipleImplementations};
+	const options = {allowCallbacks, allowImplementationTitleFns, allowMultipleImplementations};
 	const declare = (declaredAnnotations, args) => {
 		declareWithOptions({
 			annotations: {...annotations, ...declaredAnnotations},

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -64,11 +64,12 @@ function createHookChain({allowCallbacks, isAfterHook = false}, hook) {
 
 function createChain({
 	allowCallbacks = true,
+	allowMultipleImplementations = true,
 	annotations,
 	declare: declareWithOptions,
 	meta
 }) {
-	const options = {allowCallbacks};
+	const options = {allowCallbacks, allowMultipleImplementations};
 	const declare = (declaredAnnotations, args) => {
 		declareWithOptions({
 			annotations: {...annotations, ...declaredAnnotations},

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -1,13 +1,18 @@
 'use strict';
 const chainRegistry = new WeakMap();
 
-function startChain(name, declare, annotations) {
+function startChain(name, {annotations, declare, type}) {
 	const fn = (...args) => {
-		declare(annotations, args);
+		declare(type, annotations, args);
 	};
 
 	Object.defineProperty(fn, 'name', {value: name});
-	chainRegistry.set(fn, {annotations, declare, fullName: name});
+	chainRegistry.set(fn, {
+		declare(flags, args) {
+			declare(type, {...annotations, ...flags}, args);
+		},
+		fullName: name
+	});
 	return fn;
 }
 
@@ -32,7 +37,7 @@ function declareWithFlag(previous, flag, args) {
 			combinedFlags[step.flag] = true;
 			previous = step.previous;
 		} else {
-			step.declare({...step.annotations, ...combinedFlags}, args);
+			step.declare(combinedFlags, args);
 			break;
 		}
 	} while (previous);
@@ -78,11 +83,12 @@ function createChain({
 		allowMultipleImplementations
 	};
 
-	const declare = (declaredAnnotations, args) => {
+	const declare = (type, declaredAnnotations, args) => {
 		declareWithOptions({
 			annotations: {...annotations, ...declaredAnnotations},
 			args,
-			options
+			options,
+			type
 		});
 	};
 
@@ -111,7 +117,7 @@ function createChain({
 	// * `failing` must come at the end, but can be followed by `only` and `skip`
 	// * `only` and `skip` cannot be chained together
 	// * no repeating
-	const root = startChain('test', declare, {type: 'test'});
+	const root = startChain('test', {declare, type: 'test'});
 	extendChain(root, 'failing');
 	extendChain(root, 'only', 'exclusive');
 	extendChain(root, 'serial');
@@ -139,21 +145,21 @@ function createChain({
 		extendChain(root.serial.cb.failing, 'skip', 'skipped');
 	}
 
-	root.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {type: 'after'}));
-	root.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {type: 'afterEach'}));
-	root.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {type: 'before'}));
-	root.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {type: 'beforeEach'}));
+	root.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', {declare, type: 'after'}));
+	root.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', {declare, type: 'afterEach'}));
+	root.before = createHookChain({allowCallbacks}, startChain('test.before', {declare, type: 'before'}));
+	root.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', {declare, type: 'beforeEach'}));
 
-	root.serial.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {serial: true, type: 'after'}));
-	root.serial.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {serial: true, type: 'afterEach'}));
-	root.serial.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {serial: true, type: 'before'}));
-	root.serial.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {serial: true, type: 'beforeEach'}));
+	root.serial.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', {annotations: {serial: true}, declare, type: 'after'}));
+	root.serial.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', {annotations: {serial: true}, declare, type: 'afterEach'}));
+	root.serial.before = createHookChain({allowCallbacks}, startChain('test.before', {annotations: {serial: true}, declare, type: 'before'}));
+	root.serial.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', {annotations: {serial: true}, declare, type: 'beforeEach'}));
 	root.serial.macro = macro;
 
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.
-	root.todo = startChain('test.todo', declare, {type: 'test', todo: true});
-	root.serial.todo = startChain('test.serial.todo', declare, {serial: true, type: 'test', todo: true});
+	root.todo = startChain('test.todo', {declare, type: 'todo'});
+	root.serial.todo = startChain('test.serial.todo', {annotations: {serial: true}, declare, type: 'todo'});
 
 	root.macro = macro;
 	root.meta = meta;

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -64,19 +64,45 @@ function createHookChain({allowCallbacks, isAfterHook = false}, hook) {
 
 function createChain({
 	allowCallbacks = true,
+	allowExperimentalMacros = false,
 	allowImplementationTitleFns = true,
 	allowMultipleImplementations = true,
 	annotations,
 	declare: declareWithOptions,
 	meta
 }) {
-	const options = {allowCallbacks, allowImplementationTitleFns, allowMultipleImplementations};
+	const options = {
+		allowCallbacks,
+		allowExperimentalMacros,
+		allowImplementationTitleFns,
+		allowMultipleImplementations
+	};
+
 	const declare = (declaredAnnotations, args) => {
 		declareWithOptions({
 			annotations: {...annotations, ...declaredAnnotations},
 			args,
 			options
 		});
+	};
+
+	const macro = definition => {
+		if (typeof definition === 'function') {
+			return {exec: definition};
+		}
+
+		if (typeof definition === 'object' && definition !== null) {
+			const {exec, title} = definition;
+			if (typeof exec !== 'function') {
+				throw new TypeError('Macro object must have an exec() function');
+			}
+
+			if (title !== undefined && typeof title !== 'function') {
+				throw new Error('’title’ property of macro object must be a function');
+			}
+
+			return {exec, title};
+		}
 	};
 
 	// Test chaining rules:
@@ -122,12 +148,14 @@ function createChain({
 	root.serial.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {serial: true, type: 'afterEach'}));
 	root.serial.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {serial: true, type: 'before'}));
 	root.serial.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {serial: true, type: 'beforeEach'}));
+	root.serial.macro = macro;
 
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.
 	root.todo = startChain('test.todo', declare, {type: 'test', todo: true});
 	root.serial.todo = startChain('test.serial.todo', declare, {serial: true, type: 'test', todo: true});
 
+	root.macro = macro;
 	root.meta = meta;
 
 	return root;

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -1,43 +1,39 @@
 'use strict';
 const chainRegistry = new WeakMap();
 
-function startChain(name, call, defaults) {
+function startChain(name, declare, annotations) {
 	const fn = (...args) => {
-		call({...defaults}, args);
+		declare(annotations, args);
 	};
 
 	Object.defineProperty(fn, 'name', {value: name});
-	chainRegistry.set(fn, {call, defaults, fullName: name});
+	chainRegistry.set(fn, {annotations, declare, fullName: name});
 	return fn;
 }
 
-function extendChain(previous, name, flag) {
-	if (!flag) {
-		flag = name;
-	}
-
+function extendChain(previous, name, flag = name) {
 	const fn = (...args) => {
-		callWithFlag(previous, flag, args);
+		declareWithFlag(previous, flag, args);
 	};
 
 	const fullName = `${chainRegistry.get(previous).fullName}.${name}`;
 	Object.defineProperty(fn, 'name', {value: fullName});
 	previous[name] = fn;
 
-	chainRegistry.set(fn, {flag, fullName, prev: previous});
+	chainRegistry.set(fn, {flag, fullName, previous});
 	return fn;
 }
 
-function callWithFlag(previous, flag, args) {
+function declareWithFlag(previous, flag, args) {
 	const combinedFlags = {[flag]: true};
 	do {
 		const step = chainRegistry.get(previous);
-		if (step.call) {
-			step.call({...step.defaults, ...combinedFlags}, args);
-			previous = null;
-		} else {
+		if (step.flag) {
 			combinedFlags[step.flag] = true;
-			previous = step.prev;
+			previous = step.previous;
+		} else {
+			step.declare({...step.annotations, ...combinedFlags}, args);
+			break;
 		}
 	} while (previous);
 }
@@ -66,14 +62,28 @@ function createHookChain({allowCallbacks, isAfterHook = false}, hook) {
 	return hook;
 }
 
-function createChain({allowCallbacks = true, declare, defaults, meta}) {
+function createChain({
+	allowCallbacks = true,
+	annotations,
+	declare: declareWithOptions,
+	meta
+}) {
+	const options = {allowCallbacks};
+	const declare = (declaredAnnotations, args) => {
+		declareWithOptions({
+			annotations: {...annotations, ...declaredAnnotations},
+			args,
+			options
+		});
+	};
+
 	// Test chaining rules:
 	// * `serial` must come at the start
 	// * `only` and `skip` must come at the end
 	// * `failing` must come at the end, but can be followed by `only` and `skip`
 	// * `only` and `skip` cannot be chained together
 	// * no repeating
-	const root = startChain('test', declare, {...defaults, type: 'test'});
+	const root = startChain('test', declare, {type: 'test'});
 	extendChain(root, 'failing');
 	extendChain(root, 'only', 'exclusive');
 	extendChain(root, 'serial');
@@ -101,20 +111,20 @@ function createChain({allowCallbacks = true, declare, defaults, meta}) {
 		extendChain(root.serial.cb.failing, 'skip', 'skipped');
 	}
 
-	root.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {...defaults, type: 'after'}));
-	root.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {...defaults, type: 'afterEach'}));
-	root.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {...defaults, type: 'before'}));
-	root.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {...defaults, type: 'beforeEach'}));
+	root.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {type: 'after'}));
+	root.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {type: 'afterEach'}));
+	root.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {type: 'before'}));
+	root.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {type: 'beforeEach'}));
 
-	root.serial.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {...defaults, serial: true, type: 'after'}));
-	root.serial.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {...defaults, serial: true, type: 'afterEach'}));
-	root.serial.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {...defaults, serial: true, type: 'before'}));
-	root.serial.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {...defaults, serial: true, type: 'beforeEach'}));
+	root.serial.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {serial: true, type: 'after'}));
+	root.serial.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {serial: true, type: 'afterEach'}));
+	root.serial.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {serial: true, type: 'before'}));
+	root.serial.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {serial: true, type: 'beforeEach'}));
 
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.
-	root.todo = startChain('test.todo', declare, {...defaults, type: 'test', todo: true});
-	root.serial.todo = startChain('test.serial.todo', declare, {...defaults, serial: true, type: 'test', todo: true});
+	root.todo = startChain('test.todo', declare, {type: 'test', todo: true});
+	root.serial.todo = startChain('test.serial.todo', declare, {serial: true, type: 'test', todo: true});
 
 	root.meta = meta;
 

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -42,71 +42,79 @@ function callWithFlag(previous, flag, args) {
 	} while (previous);
 }
 
-function createHookChain(hook, isAfterHook) {
+function createHookChain({allowCallbacks, isAfterHook = false}, hook) {
 	// Hook chaining rules:
 	// * `always` comes immediately after "after hooks"
 	// * `skip` must come at the end
 	// * no `only`
 	// * no repeating
-	extendChain(hook, 'cb', 'callback');
 	extendChain(hook, 'skip', 'skipped');
-	extendChain(hook.cb, 'skip', 'skipped');
 	if (isAfterHook) {
 		extendChain(hook, 'always');
-		extendChain(hook.always, 'cb', 'callback');
 		extendChain(hook.always, 'skip', 'skipped');
-		extendChain(hook.always.cb, 'skip', 'skipped');
+	}
+
+	if (allowCallbacks) {
+		extendChain(hook, 'cb', 'callback');
+		extendChain(hook.cb, 'skip', 'skipped');
+		if (isAfterHook) {
+			extendChain(hook.always, 'cb', 'callback');
+			extendChain(hook.always.cb, 'skip', 'skipped');
+		}
 	}
 
 	return hook;
 }
 
-function createChain(fn, defaults, meta) {
+function createChain({allowCallbacks = true, declare, defaults, meta}) {
 	// Test chaining rules:
 	// * `serial` must come at the start
 	// * `only` and `skip` must come at the end
 	// * `failing` must come at the end, but can be followed by `only` and `skip`
 	// * `only` and `skip` cannot be chained together
 	// * no repeating
-	const root = startChain('test', fn, {...defaults, type: 'test'});
-	extendChain(root, 'cb', 'callback');
+	const root = startChain('test', declare, {...defaults, type: 'test'});
 	extendChain(root, 'failing');
 	extendChain(root, 'only', 'exclusive');
 	extendChain(root, 'serial');
 	extendChain(root, 'skip', 'skipped');
-	extendChain(root.cb, 'failing');
-	extendChain(root.cb, 'only', 'exclusive');
-	extendChain(root.cb, 'skip', 'skipped');
-	extendChain(root.cb.failing, 'only', 'exclusive');
-	extendChain(root.cb.failing, 'skip', 'skipped');
 	extendChain(root.failing, 'only', 'exclusive');
 	extendChain(root.failing, 'skip', 'skipped');
-	extendChain(root.serial, 'cb', 'callback');
 	extendChain(root.serial, 'failing');
 	extendChain(root.serial, 'only', 'exclusive');
 	extendChain(root.serial, 'skip', 'skipped');
-	extendChain(root.serial.cb, 'failing');
-	extendChain(root.serial.cb, 'only', 'exclusive');
-	extendChain(root.serial.cb, 'skip', 'skipped');
-	extendChain(root.serial.cb.failing, 'only', 'exclusive');
-	extendChain(root.serial.cb.failing, 'skip', 'skipped');
 	extendChain(root.serial.failing, 'only', 'exclusive');
 	extendChain(root.serial.failing, 'skip', 'skipped');
 
-	root.after = createHookChain(startChain('test.after', fn, {...defaults, type: 'after'}), true);
-	root.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, type: 'afterEach'}), true);
-	root.before = createHookChain(startChain('test.before', fn, {...defaults, type: 'before'}), false);
-	root.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, type: 'beforeEach'}), false);
+	if (allowCallbacks) {
+		extendChain(root, 'cb', 'callback');
+		extendChain(root.cb, 'failing');
+		extendChain(root.cb, 'only', 'exclusive');
+		extendChain(root.cb, 'skip', 'skipped');
+		extendChain(root.cb.failing, 'only', 'exclusive');
+		extendChain(root.cb.failing, 'skip', 'skipped');
+		extendChain(root.serial, 'cb', 'callback');
+		extendChain(root.serial.cb, 'failing');
+		extendChain(root.serial.cb, 'only', 'exclusive');
+		extendChain(root.serial.cb, 'skip', 'skipped');
+		extendChain(root.serial.cb.failing, 'only', 'exclusive');
+		extendChain(root.serial.cb.failing, 'skip', 'skipped');
+	}
 
-	root.serial.after = createHookChain(startChain('test.after', fn, {...defaults, serial: true, type: 'after'}), true);
-	root.serial.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, serial: true, type: 'afterEach'}), true);
-	root.serial.before = createHookChain(startChain('test.before', fn, {...defaults, serial: true, type: 'before'}), false);
-	root.serial.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, serial: true, type: 'beforeEach'}), false);
+	root.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {...defaults, type: 'after'}));
+	root.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {...defaults, type: 'afterEach'}));
+	root.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {...defaults, type: 'before'}));
+	root.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {...defaults, type: 'beforeEach'}));
+
+	root.serial.after = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.after', declare, {...defaults, serial: true, type: 'after'}));
+	root.serial.afterEach = createHookChain({allowCallbacks, isAfterHook: true}, startChain('test.afterEach', declare, {...defaults, serial: true, type: 'afterEach'}));
+	root.serial.before = createHookChain({allowCallbacks}, startChain('test.before', declare, {...defaults, serial: true, type: 'before'}));
+	root.serial.beforeEach = createHookChain({allowCallbacks}, startChain('test.beforeEach', declare, {...defaults, serial: true, type: 'beforeEach'}));
 
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.
-	root.todo = startChain('test.todo', fn, {...defaults, type: 'test', todo: true});
-	root.serial.todo = startChain('test.serial.todo', fn, {...defaults, serial: true, type: 'test', todo: true});
+	root.todo = startChain('test.todo', declare, {...defaults, type: 'test', todo: true});
+	root.serial.todo = startChain('test.serial.todo', declare, {...defaults, serial: true, type: 'test', todo: true});
 
 	root.meta = meta;
 

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -7,7 +7,7 @@ const pkgConf = require('pkg-conf');
 
 const NO_SUCH_FILE = Symbol('no ava.config.js file');
 const MISSING_DEFAULT_EXPORT = Symbol('missing default export');
-const EXPERIMENTS = new Set();
+const EXPERIMENTS = new Set(['experimentalTestInterfaces']);
 
 // *Very* rudimentary support for loading ava.config.js files containing an `export default` statement.
 const evaluateJsConfig = configFile => {

--- a/lib/parse-test-args.js
+++ b/lib/parse-test-args.js
@@ -1,8 +1,12 @@
 'use strict';
-function parseTestArgs(args) {
+function parseTestArgs(args, {allowMultipleImplementations}) {
 	const rawTitle = typeof args[0] === 'string' ? args.shift() : undefined;
 	const receivedImplementationArray = Array.isArray(args[0]);
 	const implementations = receivedImplementationArray ? args.shift() : args.splice(0, 1);
+
+	if (receivedImplementationArray && !allowMultipleImplementations) {
+		throw new Error('test(), test.serial() and hooks no longer take arrays of implementations or macros');
+	}
 
 	const buildTitle = implementation => {
 		const title = implementation.title ? implementation.title(rawTitle, ...args) : rawTitle;

--- a/lib/parse-test-args.js
+++ b/lib/parse-test-args.js
@@ -1,5 +1,5 @@
 'use strict';
-function parseTestArgs(args, {allowMultipleImplementations}) {
+function parseTestArgs(args, {allowImplementationTitleFns, allowMultipleImplementations}) {
 	const rawTitle = typeof args[0] === 'string' ? args.shift() : undefined;
 	const receivedImplementationArray = Array.isArray(args[0]);
 	const implementations = receivedImplementationArray ? args.shift() : args.splice(0, 1);
@@ -9,7 +9,15 @@ function parseTestArgs(args, {allowMultipleImplementations}) {
 	}
 
 	const buildTitle = implementation => {
-		const title = implementation.title ? implementation.title(rawTitle, ...args) : rawTitle;
+		let title = rawTitle;
+		if (implementation.title) {
+			if (!allowImplementationTitleFns) {
+				throw new Error('Test and hook implementations can no longer have a title function');
+			}
+
+			title = implementation.title(rawTitle, ...args);
+		}
+
 		return {title, isSet: typeof title !== 'undefined', isValid: typeof title === 'string', isEmpty: !title};
 	};
 

--- a/lib/parse-test-args.js
+++ b/lib/parse-test-args.js
@@ -1,11 +1,34 @@
 'use strict';
-function parseTestArgs(args, {allowImplementationTitleFns, allowMultipleImplementations}) {
+const macroTitleFns = new WeakMap();
+
+function parseTestArgs(args, {
+	allowExperimentalMacros,
+	allowImplementationTitleFns,
+	allowMultipleImplementations
+}) {
 	const rawTitle = typeof args[0] === 'string' ? args.shift() : undefined;
 	const receivedImplementationArray = Array.isArray(args[0]);
 	const implementations = receivedImplementationArray ? args.shift() : args.splice(0, 1);
 
 	if (receivedImplementationArray && !allowMultipleImplementations) {
 		throw new Error('test(), test.serial() and hooks no longer take arrays of implementations or macros');
+	}
+
+	if (allowExperimentalMacros) {
+		// TODO: Clean this up after removing the legacy implementation which
+		// allows multiple implementations.
+		const [possibleMacro] = implementations;
+		if (possibleMacro !== null && typeof possibleMacro === 'object' && typeof possibleMacro.exec === 'function') {
+			// Never call exec() on the macro object.
+			let {exec} = possibleMacro;
+			if (typeof possibleMacro.title === 'function') {
+				// Wrap so we can store the title function against *this use* of the macro.
+				exec = exec.bind(null);
+				macroTitleFns.set(exec, possibleMacro.title);
+			}
+
+			implementations[0] = exec;
+		}
 	}
 
 	const buildTitle = implementation => {
@@ -16,6 +39,8 @@ function parseTestArgs(args, {allowImplementationTitleFns, allowMultipleImplemen
 			}
 
 			title = implementation.title(rawTitle, ...args);
+		} else if (macroTitleFns.has(implementation)) {
+			title = macroTitleFns.get(implementation)(rawTitle, ...args);
 		}
 
 		return {title, isSet: typeof title !== 'undefined', isValid: typeof title === 'string', isEmpty: !title};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -71,7 +71,7 @@ class Runner extends Emittery {
 					return snapshotManager.determineSnapshotDir({file, fixedLocation, projectDir});
 				}
 			}),
-			declare: ({annotations, args: declarationArguments, options: {allowMultipleImplementations}}) => { // eslint-disable-line complexity
+			declare: ({annotations, args: declarationArguments, options: {allowImplementationTitleFns, allowMultipleImplementations}}) => { // eslint-disable-line complexity
 				if (hasStarted) {
 					throw new Error('All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.');
 				}
@@ -84,7 +84,7 @@ class Runner extends Emittery {
 					});
 				}
 
-				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments, {allowMultipleImplementations});
+				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments, {allowImplementationTitleFns, allowMultipleImplementations});
 
 				if (annotations.todo) {
 					if (implementations.length > 0) {
@@ -141,6 +141,7 @@ class Runner extends Emittery {
 						}
 
 						const task = {
+							allowImplementationTitleFns,
 							allowMultipleImplementations,
 							annotations: {...annotations},
 							args,
@@ -175,6 +176,7 @@ class Runner extends Emittery {
 
 		this.chain = createChain({
 			allowCallbacks: true,
+			allowImplementationTitleFns: true,
 			allowMultipleImplementations: true,
 			...chainOptions
 		});
@@ -182,6 +184,7 @@ class Runner extends Emittery {
 		if (this.experiments.experimentalTestInterfaces) {
 			this.experimentalChain = createChain({
 				allowCallbacks: false,
+				allowImplementationTitleFns: false,
 				allowMultipleImplementations: false,
 				...chainOptions
 			});
@@ -290,6 +293,7 @@ class Runner extends Emittery {
 
 	async runHooks(tasks, contextRef, titleSuffix, testPassed) {
 		const hooks = tasks.map(task => new Runnable({
+			allowImplementationTitleFns: task.allowImplementationTitleFns,
 			allowMultipleImplementations: task.allowMultipleImplementations,
 			annotations: task.annotations,
 			contextRef,
@@ -335,6 +339,7 @@ class Runner extends Emittery {
 		if (hooksOk) {
 			// Only run the test if all `beforeEach` hooks passed.
 			const test = new Runnable({
+				allowImplementationTitleFns: task.allowImplementationTitleFns,
 				allowMultipleImplementations: task.allowMultipleImplementations,
 				annotations: task.annotations,
 				contextRef,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -71,7 +71,14 @@ class Runner extends Emittery {
 					return snapshotManager.determineSnapshotDir({file, fixedLocation, projectDir});
 				}
 			}),
-			declare: ({annotations, args: declarationArguments, options: {allowImplementationTitleFns, allowMultipleImplementations}}) => { // eslint-disable-line complexity
+			declare: ({ // eslint-disable-line complexity
+				annotations,
+				args: declarationArguments,
+				options: {
+					allowExperimentalMacros,
+					allowImplementationTitleFns,
+					allowMultipleImplementations
+				}}) => {
 				if (hasStarted) {
 					throw new Error('All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.');
 				}
@@ -84,7 +91,11 @@ class Runner extends Emittery {
 					});
 				}
 
-				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments, {allowImplementationTitleFns, allowMultipleImplementations});
+				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments, {
+					allowExperimentalMacros,
+					allowImplementationTitleFns,
+					allowMultipleImplementations
+				});
 
 				if (annotations.todo) {
 					if (implementations.length > 0) {
@@ -141,6 +152,7 @@ class Runner extends Emittery {
 						}
 
 						const task = {
+							allowExperimentalMacros,
 							allowImplementationTitleFns,
 							allowMultipleImplementations,
 							annotations: {...annotations},
@@ -176,6 +188,7 @@ class Runner extends Emittery {
 
 		this.chain = createChain({
 			allowCallbacks: true,
+			allowExperimentalMacros: false,
 			allowImplementationTitleFns: true,
 			allowMultipleImplementations: true,
 			...chainOptions
@@ -184,6 +197,7 @@ class Runner extends Emittery {
 		if (this.experiments.experimentalTestInterfaces) {
 			this.experimentalChain = createChain({
 				allowCallbacks: false,
+				allowExperimentalMacros: true,
 				allowImplementationTitleFns: false,
 				allowMultipleImplementations: false,
 				...chainOptions
@@ -293,6 +307,7 @@ class Runner extends Emittery {
 
 	async runHooks(tasks, contextRef, titleSuffix, testPassed) {
 		const hooks = tasks.map(task => new Runnable({
+			allowExperimentalMacros: task.allowExperimentalMacros,
 			allowImplementationTitleFns: task.allowImplementationTitleFns,
 			allowMultipleImplementations: task.allowMultipleImplementations,
 			annotations: task.annotations,
@@ -339,6 +354,7 @@ class Runner extends Emittery {
 		if (hooksOk) {
 			// Only run the test if all `beforeEach` hooks passed.
 			const test = new Runnable({
+				allowExperimentalMacros: task.allowExperimentalMacros,
 				allowImplementationTitleFns: task.allowImplementationTitleFns,
 				allowMultipleImplementations: task.allowMultipleImplementations,
 				annotations: task.annotations,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -53,121 +53,136 @@ class Runner extends Emittery {
 
 		let hasStarted = false;
 		let scheduledStart = false;
-		const meta = Object.freeze({
-			file: options.file,
-			get snapshotDirectory() {
-				const {file, snapshotDir: fixedLocation, projectDir} = options;
-				return snapshotManager.determineSnapshotDir({file, fixedLocation, projectDir});
-			}
-		});
-		this.chain = createChain((metadata, testArgs) => { // eslint-disable-line complexity
-			if (hasStarted) {
-				throw new Error('All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.');
-			}
-
-			if (!scheduledStart) {
-				scheduledStart = true;
-				process.nextTick(() => {
-					hasStarted = true;
-					this.start();
-				});
-			}
-
-			const {args, buildTitle, implementations, rawTitle} = parseTestArgs(testArgs);
-
-			if (metadata.todo) {
-				if (implementations.length > 0) {
-					throw new TypeError('`todo` tests are not allowed to have an implementation. Use `test.skip()` for tests with an implementation.');
+		const chainOptions = {
+			declare: (metadata, testArgs) => { // eslint-disable-line complexity
+				if (hasStarted) {
+					throw new Error('All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.');
 				}
 
-				if (!rawTitle) { // Either undefined or a string.
-					throw new TypeError('`todo` tests require a title');
+				if (!scheduledStart) {
+					scheduledStart = true;
+					process.nextTick(() => {
+						hasStarted = true;
+						this.start();
+					});
 				}
 
-				if (!this.registerUniqueTitle(rawTitle)) {
-					throw new Error(`Duplicate test title: ${rawTitle}`);
-				}
+				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(testArgs);
 
-				if (this.match.length > 0) {
-					// --match selects TODO tests.
-					if (matcher([rawTitle], this.match).length === 1) {
-						metadata.exclusive = true;
-						this.runOnlyExclusive = true;
-					}
-				}
-
-				this.tasks.todo.push({title: rawTitle, metadata});
-				this.emit('stateChange', {
-					type: 'declared-test',
-					title: rawTitle,
-					knownFailing: false,
-					todo: true
-				});
-			} else {
-				if (implementations.length === 0) {
-					throw new TypeError('Expected an implementation. Use `test.todo()` for tests without an implementation.');
-				}
-
-				for (const implementation of implementations) {
-					let {title, isSet, isValid, isEmpty} = buildTitle(implementation);
-
-					if (isSet && !isValid) {
-						throw new TypeError('Test & hook titles must be strings');
+				if (metadata.todo) {
+					if (implementations.length > 0) {
+						throw new TypeError('`todo` tests are not allowed to have an implementation. Use `test.skip()` for tests with an implementation.');
 					}
 
-					if (isEmpty) {
-						if (metadata.type === 'test') {
-							throw new TypeError('Tests must have a title');
-						} else if (metadata.always) {
-							title = `${metadata.type}.always hook`;
-						} else {
-							title = `${metadata.type} hook`;
-						}
+					if (!rawTitle) { // Either undefined or a string.
+						throw new TypeError('`todo` tests require a title');
 					}
 
-					if (metadata.type === 'test' && !this.registerUniqueTitle(title)) {
-						throw new Error(`Duplicate test title: ${title}`);
+					if (!this.registerUniqueTitle(rawTitle)) {
+						throw new Error(`Duplicate test title: ${rawTitle}`);
 					}
 
-					const task = {
-						title,
-						implementation,
-						args,
-						metadata: {...metadata}
-					};
-
-					if (metadata.type === 'test') {
-						if (this.match.length > 0) {
-							// --match overrides .only()
-							task.metadata.exclusive = matcher([title], this.match).length === 1;
-						}
-
-						if (task.metadata.exclusive) {
+					if (this.match.length > 0) {
+						// --match selects TODO tests.
+						if (matcher([rawTitle], this.match).length === 1) {
+							metadata.exclusive = true;
 							this.runOnlyExclusive = true;
 						}
+					}
 
-						this.tasks[metadata.serial ? 'serial' : 'concurrent'].push(task);
-						this.emit('stateChange', {
-							type: 'declared-test',
+					this.tasks.todo.push({title: rawTitle, metadata});
+					this.emit('stateChange', {
+						type: 'declared-test',
+						title: rawTitle,
+						knownFailing: false,
+						todo: true
+					});
+				} else {
+					if (implementations.length === 0) {
+						throw new TypeError('Expected an implementation. Use `test.todo()` for tests without an implementation.');
+					}
+
+					for (const implementation of implementations) {
+						let {title, isSet, isValid, isEmpty} = buildTitle(implementation);
+
+						if (isSet && !isValid) {
+							throw new TypeError('Test & hook titles must be strings');
+						}
+
+						if (isEmpty) {
+							if (metadata.type === 'test') {
+								throw new TypeError('Tests must have a title');
+							} else if (metadata.always) {
+								title = `${metadata.type}.always hook`;
+							} else {
+								title = `${metadata.type} hook`;
+							}
+						}
+
+						if (metadata.type === 'test' && !this.registerUniqueTitle(title)) {
+							throw new Error(`Duplicate test title: ${title}`);
+						}
+
+						const task = {
 							title,
-							knownFailing: metadata.failing,
-							todo: false
-						});
-					} else if (!metadata.skipped) {
-						this.tasks[metadata.type + (metadata.always ? 'Always' : '')].push(task);
+							implementation,
+							args,
+							metadata: {...metadata}
+						};
+
+						if (metadata.type === 'test') {
+							if (this.match.length > 0) {
+								// --match overrides .only()
+								task.metadata.exclusive = matcher([title], this.match).length === 1;
+							}
+
+							if (task.metadata.exclusive) {
+								this.runOnlyExclusive = true;
+							}
+
+							this.tasks[metadata.serial ? 'serial' : 'concurrent'].push(task);
+							this.emit('stateChange', {
+								type: 'declared-test',
+								title,
+								knownFailing: metadata.failing,
+								todo: false
+							});
+						} else if (!metadata.skipped) {
+							this.tasks[metadata.type + (metadata.always ? 'Always' : '')].push(task);
+						}
 					}
 				}
-			}
-		}, {
-			serial: false,
-			exclusive: false,
-			skipped: false,
-			todo: false,
-			failing: false,
-			callback: false,
-			inline: false, // Set for attempt metadata created by `t.try()`
-			always: false
-		}, meta);
+			},
+			defaults: {
+				always: false,
+				callback: false,
+				exclusive: false,
+				failing: false,
+				inline: false, // Set for attempt metadata created by `t.try()`
+				serial: false,
+				skipped: false,
+				todo: false
+			},
+			meta: Object.freeze({
+				file: options.file,
+				get snapshotDirectory() {
+					const {file, snapshotDir: fixedLocation, projectDir} = options;
+					return snapshotManager.determineSnapshotDir({file, fixedLocation, projectDir});
+				}
+			})
+		};
+
+		this.chain = createChain({
+			allowCallbacks: true,
+			...chainOptions
+		});
+
+		if (this.experiments.experimentalTestInterfaces) {
+			this.experimentalChain = createChain({
+				allowCallbacks: false,
+				...chainOptions
+			});
+		}
 	}
 
 	compareTestSnapshot(options) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -71,7 +71,7 @@ class Runner extends Emittery {
 					return snapshotManager.determineSnapshotDir({file, fixedLocation, projectDir});
 				}
 			}),
-			declare: ({annotations, args: declarationArguments}) => { // eslint-disable-line complexity
+			declare: ({annotations, args: declarationArguments, options: {allowMultipleImplementations}}) => { // eslint-disable-line complexity
 				if (hasStarted) {
 					throw new Error('All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.');
 				}
@@ -84,7 +84,7 @@ class Runner extends Emittery {
 					});
 				}
 
-				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments);
+				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments, {allowMultipleImplementations});
 
 				if (annotations.todo) {
 					if (implementations.length > 0) {
@@ -141,6 +141,7 @@ class Runner extends Emittery {
 						}
 
 						const task = {
+							allowMultipleImplementations,
 							annotations: {...annotations},
 							args,
 							implementation,
@@ -174,12 +175,14 @@ class Runner extends Emittery {
 
 		this.chain = createChain({
 			allowCallbacks: true,
+			allowMultipleImplementations: true,
 			...chainOptions
 		});
 
 		if (this.experiments.experimentalTestInterfaces) {
 			this.experimentalChain = createChain({
 				allowCallbacks: false,
+				allowMultipleImplementations: false,
 				...chainOptions
 			});
 		}
@@ -287,6 +290,7 @@ class Runner extends Emittery {
 
 	async runHooks(tasks, contextRef, titleSuffix, testPassed) {
 		const hooks = tasks.map(task => new Runnable({
+			allowMultipleImplementations: task.allowMultipleImplementations,
 			annotations: task.annotations,
 			contextRef,
 			experiments: this.experiments,
@@ -331,6 +335,7 @@ class Runner extends Emittery {
 		if (hooksOk) {
 			// Only run the test if all `beforeEach` hooks passed.
 			const test = new Runnable({
+				allowMultipleImplementations: task.allowMultipleImplementations,
 				annotations: task.annotations,
 				contextRef,
 				experiments: this.experiments,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -54,7 +54,24 @@ class Runner extends Emittery {
 		let hasStarted = false;
 		let scheduledStart = false;
 		const chainOptions = {
-			declare: (metadata, testArgs) => { // eslint-disable-line complexity
+			annotations: {
+				always: false,
+				callback: false,
+				exclusive: false,
+				failing: false,
+				inline: false, // Default value; only attempts created by `t.try()` have this annotation set to `true`.
+				serial: false,
+				skipped: false,
+				todo: false
+			},
+			meta: Object.freeze({
+				file: options.file,
+				get snapshotDirectory() {
+					const {file, snapshotDir: fixedLocation, projectDir} = options;
+					return snapshotManager.determineSnapshotDir({file, fixedLocation, projectDir});
+				}
+			}),
+			declare: ({annotations, args: declarationArguments}) => { // eslint-disable-line complexity
 				if (hasStarted) {
 					throw new Error('All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.');
 				}
@@ -67,9 +84,9 @@ class Runner extends Emittery {
 					});
 				}
 
-				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(testArgs);
+				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments);
 
-				if (metadata.todo) {
+				if (annotations.todo) {
 					if (implementations.length > 0) {
 						throw new TypeError('`todo` tests are not allowed to have an implementation. Use `test.skip()` for tests with an implementation.');
 					}
@@ -85,12 +102,12 @@ class Runner extends Emittery {
 					if (this.match.length > 0) {
 						// --match selects TODO tests.
 						if (matcher([rawTitle], this.match).length === 1) {
-							metadata.exclusive = true;
+							annotations.exclusive = true;
 							this.runOnlyExclusive = true;
 						}
 					}
 
-					this.tasks.todo.push({title: rawTitle, metadata});
+					this.tasks.todo.push({title: rawTitle, annotations});
 					this.emit('stateChange', {
 						type: 'declared-test',
 						title: rawTitle,
@@ -110,66 +127,49 @@ class Runner extends Emittery {
 						}
 
 						if (isEmpty) {
-							if (metadata.type === 'test') {
+							if (annotations.type === 'test') {
 								throw new TypeError('Tests must have a title');
-							} else if (metadata.always) {
-								title = `${metadata.type}.always hook`;
+							} else if (annotations.always) {
+								title = `${annotations.type}.always hook`;
 							} else {
-								title = `${metadata.type} hook`;
+								title = `${annotations.type} hook`;
 							}
 						}
 
-						if (metadata.type === 'test' && !this.registerUniqueTitle(title)) {
+						if (annotations.type === 'test' && !this.registerUniqueTitle(title)) {
 							throw new Error(`Duplicate test title: ${title}`);
 						}
 
 						const task = {
-							title,
-							implementation,
+							annotations: {...annotations},
 							args,
-							metadata: {...metadata}
+							implementation,
+							title
 						};
 
-						if (metadata.type === 'test') {
+						if (annotations.type === 'test') {
 							if (this.match.length > 0) {
 								// --match overrides .only()
-								task.metadata.exclusive = matcher([title], this.match).length === 1;
+								task.annotations.exclusive = matcher([title], this.match).length === 1;
 							}
 
-							if (task.metadata.exclusive) {
+							if (task.annotations.exclusive) {
 								this.runOnlyExclusive = true;
 							}
 
-							this.tasks[metadata.serial ? 'serial' : 'concurrent'].push(task);
+							this.tasks[annotations.serial ? 'serial' : 'concurrent'].push(task);
 							this.emit('stateChange', {
 								type: 'declared-test',
 								title,
-								knownFailing: metadata.failing,
+								knownFailing: annotations.failing,
 								todo: false
 							});
-						} else if (!metadata.skipped) {
-							this.tasks[metadata.type + (metadata.always ? 'Always' : '')].push(task);
+						} else if (!annotations.skipped) {
+							this.tasks[annotations.type + (annotations.always ? 'Always' : '')].push(task);
 						}
 					}
 				}
-			},
-			defaults: {
-				always: false,
-				callback: false,
-				exclusive: false,
-				failing: false,
-				inline: false, // Set for attempt metadata created by `t.try()`
-				serial: false,
-				skipped: false,
-				todo: false
-			},
-			meta: Object.freeze({
-				file: options.file,
-				get snapshotDirectory() {
-					const {file, snapshotDir: fixedLocation, projectDir} = options;
-					return snapshotManager.determineSnapshotDir({file, fixedLocation, projectDir});
-				}
-			})
+			}
 		};
 
 		this.chain = createChain({
@@ -252,11 +252,11 @@ class Runner extends Emittery {
 
 		let waitForSerial = Promise.resolve();
 		await runnables.reduce((previous, runnable) => {
-			if (runnable.metadata.serial || this.serial) {
+			if (runnable.annotations.serial || this.serial) {
 				waitForSerial = previous.then(() => {
 					// Serial runnables run as long as there was no previous failure, unless
 					// the runnable should always be run.
-					return (allPassed || runnable.metadata.always) && runAndStoreResult(runnable);
+					return (allPassed || runnable.annotations.always) && runAndStoreResult(runnable);
 				});
 				return waitForSerial;
 			}
@@ -268,7 +268,7 @@ class Runner extends Emittery {
 					// runnables have completed, as long as there was no previous failure
 					// (or if the runnable should always be run). One concurrent runnable's
 					// failure does not prevent the next runnable from running.
-					return (allPassed || runnable.metadata.always) && runAndStoreResult(runnable);
+					return (allPassed || runnable.annotations.always) && runAndStoreResult(runnable);
 				})
 			]);
 		}, waitForSerial);
@@ -287,6 +287,7 @@ class Runner extends Emittery {
 
 	async runHooks(tasks, contextRef, titleSuffix, testPassed) {
 		const hooks = tasks.map(task => new Runnable({
+			annotations: task.annotations,
 			contextRef,
 			experiments: this.experiments,
 			failWithoutAssertions: false,
@@ -295,7 +296,6 @@ class Runner extends Emittery {
 				t => task.implementation.apply(null, [t].concat(task.args)),
 			compareTestSnapshot: this.boundCompareTestSnapshot,
 			updateSnapshots: this.updateSnapshots,
-			metadata: task.metadata,
 			powerAssert: this.powerAssert,
 			title: `${task.title}${titleSuffix || ''}`,
 			testPassed
@@ -331,6 +331,7 @@ class Runner extends Emittery {
 		if (hooksOk) {
 			// Only run the test if all `beforeEach` hooks passed.
 			const test = new Runnable({
+				annotations: task.annotations,
 				contextRef,
 				experiments: this.experiments,
 				failWithoutAssertions: this.failWithoutAssertions,
@@ -339,7 +340,6 @@ class Runner extends Emittery {
 					t => task.implementation.apply(null, [t].concat(task.args)),
 				compareTestSnapshot: this.boundCompareTestSnapshot,
 				updateSnapshots: this.updateSnapshots,
-				metadata: task.metadata,
 				powerAssert: this.powerAssert,
 				title: task.title,
 				registerUniqueTitle: this.registerUniqueTitle
@@ -353,7 +353,7 @@ class Runner extends Emittery {
 					type: 'test-passed',
 					title: result.title,
 					duration: result.duration,
-					knownFailing: result.metadata.failing,
+					knownFailing: result.annotations.failing,
 					logs: result.logs
 				});
 
@@ -364,7 +364,7 @@ class Runner extends Emittery {
 					title: result.title,
 					err: serializeError('Test failure', true, result.error),
 					duration: result.duration,
-					knownFailing: result.metadata.failing,
+					knownFailing: result.annotations.failing,
 					logs: result.logs
 				});
 				// Don't run `afterEach` hooks if the test failed.
@@ -379,37 +379,37 @@ class Runner extends Emittery {
 		const concurrentTests = [];
 		const serialTests = [];
 		for (const task of this.tasks.serial) {
-			if (this.runOnlyExclusive && !task.metadata.exclusive) {
+			if (this.runOnlyExclusive && !task.annotations.exclusive) {
 				continue;
 			}
 
 			this.emit('stateChange', {
 				type: 'selected-test',
 				title: task.title,
-				knownFailing: task.metadata.failing,
-				skip: task.metadata.skipped,
+				knownFailing: task.annotations.failing,
+				skip: task.annotations.skipped,
 				todo: false
 			});
 
-			if (!task.metadata.skipped) {
+			if (!task.annotations.skipped) {
 				serialTests.push(task);
 			}
 		}
 
 		for (const task of this.tasks.concurrent) {
-			if (this.runOnlyExclusive && !task.metadata.exclusive) {
+			if (this.runOnlyExclusive && !task.annotations.exclusive) {
 				continue;
 			}
 
 			this.emit('stateChange', {
 				type: 'selected-test',
 				title: task.title,
-				knownFailing: task.metadata.failing,
-				skip: task.metadata.skipped,
+				knownFailing: task.annotations.failing,
+				skip: task.annotations.skipped,
 				todo: false
 			});
 
-			if (!task.metadata.skipped) {
+			if (!task.annotations.skipped) {
 				if (this.serial) {
 					serialTests.push(task);
 				} else {
@@ -419,7 +419,7 @@ class Runner extends Emittery {
 		}
 
 		for (const task of this.tasks.todo) {
-			if (this.runOnlyExclusive && !task.metadata.exclusive) {
+			if (this.runOnlyExclusive && !task.annotations.exclusive) {
 				continue;
 			}
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -7,6 +7,7 @@ const parseTestArgs = require('./parse-test-args');
 const snapshotManager = require('./snapshot-manager');
 const serializeError = require('./serialize-error');
 const Runnable = require('./test');
+const {Task, TaskList} = require('./task-list');
 
 class Runner extends Emittery {
 	constructor(options = {}) {
@@ -29,17 +30,7 @@ class Runner extends Emittery {
 		this.boundCompareTestSnapshot = this.compareTestSnapshot.bind(this);
 		this.interrupted = false;
 		this.snapshots = null;
-		this.tasks = {
-			after: [],
-			afterAlways: [],
-			afterEach: [],
-			afterEachAlways: [],
-			before: [],
-			beforeEach: [],
-			concurrent: [],
-			serial: [],
-			todo: []
-		};
+		this.tasks = new TaskList();
 
 		const uniqueTestTitles = new Set();
 		this.registerUniqueTitle = title => {
@@ -61,8 +52,7 @@ class Runner extends Emittery {
 				failing: false,
 				inline: false, // Default value; only attempts created by `t.try()` have this annotation set to `true`.
 				serial: false,
-				skipped: false,
-				todo: false
+				skipped: false
 			},
 			meta: Object.freeze({
 				file: options.file,
@@ -74,11 +64,9 @@ class Runner extends Emittery {
 			declare: ({ // eslint-disable-line complexity
 				annotations,
 				args: declarationArguments,
-				options: {
-					allowExperimentalMacros,
-					allowImplementationTitleFns,
-					allowMultipleImplementations
-				}}) => {
+				options,
+				type
+			}) => {
 				if (hasStarted) {
 					throw new Error('All tests and hooks must be declared synchronously in your test file, and cannot be nested within other tests or hooks.');
 				}
@@ -91,13 +79,9 @@ class Runner extends Emittery {
 					});
 				}
 
-				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments, {
-					allowExperimentalMacros,
-					allowImplementationTitleFns,
-					allowMultipleImplementations
-				});
+				const {args, buildTitle, implementations, rawTitle} = parseTestArgs(declarationArguments, options);
 
-				if (annotations.todo) {
+				if (type === 'todo') {
 					if (implementations.length > 0) {
 						throw new TypeError('`todo` tests are not allowed to have an implementation. Use `test.skip()` for tests with an implementation.');
 					}
@@ -118,7 +102,7 @@ class Runner extends Emittery {
 						}
 					}
 
-					this.tasks.todo.push({title: rawTitle, annotations});
+					this.tasks.add(Task.todo({annotations, title: rawTitle}));
 					this.emit('stateChange', {
 						type: 'declared-test',
 						title: rawTitle,
@@ -138,48 +122,51 @@ class Runner extends Emittery {
 						}
 
 						if (isEmpty) {
-							if (annotations.type === 'test') {
+							if (type === 'test') {
 								throw new TypeError('Tests must have a title');
 							} else if (annotations.always) {
-								title = `${annotations.type}.always hook`;
+								title = `${type}.always hook`;
 							} else {
-								title = `${annotations.type} hook`;
+								title = `${type} hook`;
 							}
 						}
 
-						if (annotations.type === 'test' && !this.registerUniqueTitle(title)) {
+						if (type === 'test' && !this.registerUniqueTitle(title)) {
 							throw new Error(`Duplicate test title: ${title}`);
 						}
 
-						const task = {
-							allowExperimentalMacros,
-							allowImplementationTitleFns,
-							allowMultipleImplementations,
-							annotations: {...annotations},
-							args,
-							implementation,
-							title
-						};
-
-						if (annotations.type === 'test') {
+						if (type === 'test') {
+							let {exclusive} = annotations;
 							if (this.match.length > 0) {
 								// --match overrides .only()
-								task.annotations.exclusive = matcher([title], this.match).length === 1;
+								exclusive = matcher([title], this.match).length === 1;
 							}
 
-							if (task.annotations.exclusive) {
+							if (exclusive) {
 								this.runOnlyExclusive = true;
 							}
 
-							this.tasks[annotations.serial ? 'serial' : 'concurrent'].push(task);
+							this.tasks.add(Task.test({
+								annotations: {...annotations, exclusive},
+								args,
+								implementation,
+								options,
+								title
+							}));
 							this.emit('stateChange', {
 								type: 'declared-test',
 								title,
 								knownFailing: annotations.failing,
 								todo: false
 							});
-						} else if (!annotations.skipped) {
-							this.tasks[annotations.type + (annotations.always ? 'Always' : '')].push(task);
+						} else {
+							this.tasks.add(Task[type]({
+								annotations,
+								args,
+								implementation,
+								options,
+								title
+							}));
 						}
 					}
 				}
@@ -305,11 +292,9 @@ class Runner extends Emittery {
 		return result;
 	}
 
-	async runHooks(tasks, contextRef, titleSuffix, testPassed) {
-		const hooks = tasks.map(task => new Runnable({
-			allowExperimentalMacros: task.allowExperimentalMacros,
-			allowImplementationTitleFns: task.allowImplementationTitleFns,
-			allowMultipleImplementations: task.allowMultipleImplementations,
+	async runHooks(type, contextRef, titleSuffix, testPassed) {
+		const hooks = [...this.tasks.select(type)].map(task => new Runnable({
+			...task.options,
 			annotations: task.annotations,
 			contextRef,
 			experiments: this.experiments,
@@ -348,7 +333,7 @@ class Runner extends Emittery {
 
 	async runTest(task, contextRef) {
 		const hookSuffix = ` for ${task.title}`;
-		let hooksOk = await this.runHooks(this.tasks.beforeEach, contextRef, hookSuffix);
+		let hooksOk = await this.runHooks('beforeEach', contextRef, hookSuffix);
 
 		let testOk = false;
 		if (hooksOk) {
@@ -383,7 +368,7 @@ class Runner extends Emittery {
 					logs: result.logs
 				});
 
-				hooksOk = await this.runHooks(this.tasks.afterEach, contextRef, hookSuffix, testOk);
+				hooksOk = await this.runHooks('afterEach', contextRef, hookSuffix, testOk);
 			} else {
 				this.emit('stateChange', {
 					type: 'test-failed',
@@ -397,14 +382,14 @@ class Runner extends Emittery {
 			}
 		}
 
-		const alwaysOk = await this.runHooks(this.tasks.afterEachAlways, contextRef, hookSuffix, testOk);
+		const alwaysOk = await this.runHooks('afterEachAlways', contextRef, hookSuffix, testOk);
 		return alwaysOk && hooksOk && testOk;
 	}
 
 	async start() {
-		const concurrentTests = [];
-		const serialTests = [];
-		for (const task of this.tasks.serial) {
+		let concurrentTests = [];
+		let serialTests = [];
+		for (const task of this.tasks.select('test')) {
 			if (this.runOnlyExclusive && !task.annotations.exclusive) {
 				continue;
 			}
@@ -417,34 +402,25 @@ class Runner extends Emittery {
 				todo: false
 			});
 
-			if (!task.annotations.skipped) {
+			if (task.annotations.skipped) {
+				continue;
+			}
+
+			if (task.annotations.serial) {
 				serialTests.push(task);
+			} else {
+				concurrentTests.push(task);
 			}
 		}
 
-		for (const task of this.tasks.concurrent) {
-			if (this.runOnlyExclusive && !task.annotations.exclusive) {
-				continue;
-			}
-
-			this.emit('stateChange', {
-				type: 'selected-test',
-				title: task.title,
-				knownFailing: task.annotations.failing,
-				skip: task.annotations.skipped,
-				todo: false
-			});
-
-			if (!task.annotations.skipped) {
-				if (this.serial) {
-					serialTests.push(task);
-				} else {
-					concurrentTests.push(task);
-				}
-			}
+		// Reassign the concurrent tasks, but always run them after the explicitly
+		// serial ones.
+		if (this.serial) {
+			serialTests = [...serialTests, ...concurrentTests];
+			concurrentTests = [];
 		}
 
-		for (const task of this.tasks.todo) {
+		for (const task of this.tasks.select('todo')) {
 			if (this.runOnlyExclusive && !task.annotations.exclusive) {
 				continue;
 			}
@@ -467,7 +443,7 @@ class Runner extends Emittery {
 		const contextRef = new ContextRef();
 
 		// Note that the hooks and tests always begin running asynchronously.
-		const beforePromise = this.runHooks(this.tasks.before, contextRef);
+		const beforePromise = this.runHooks('before', contextRef);
 		const serialPromise = beforePromise.then(beforeHooksOk => { // eslint-disable-line promise/prefer-await-to-then
 			// Don't run tests if a `before` hook failed.
 			if (!beforeHooksOk) {
@@ -517,11 +493,11 @@ class Runner extends Emittery {
 			const ok = await concurrentPromise;
 			// Only run `after` hooks if all hooks and tests passed.
 			if (ok) {
-				await this.runHooks(this.tasks.after, contextRef);
+				await this.runHooks('after', contextRef);
 			}
 
 			// Always run `after.always` hooks.
-			await this.runHooks(this.tasks.afterAlways, contextRef);
+			await this.runHooks('afterAlways', contextRef);
 			process.removeListener('beforeExit', beforeExitHandler);
 			await this.emit('finish');
 		} catch (error) {

--- a/lib/task-list.js
+++ b/lib/task-list.js
@@ -1,0 +1,143 @@
+class Task {
+	static after({annotations, args, implementation, options, title}) {
+		return new Task(annotations.always ? 'afterAlways' : 'after', {annotations, args, implementation, options, title});
+	}
+
+	static afterEach({annotations, args, implementation, options, title}) {
+		return new Task(annotations.always ? 'afterEachAlways' : 'afterEach', {annotations, args, implementation, options, title});
+	}
+
+	static before({annotations, args, implementation, options, title}) {
+		return new Task('before', {annotations, args, implementation, options, title});
+	}
+
+	static beforeEach({annotations, args, implementation, options, title}) {
+		return new Task('beforeEach', {annotations, args, implementation, options, title});
+	}
+
+	static test({annotations, args, implementation, options, title}) {
+		return new Task('test', {annotations, args, implementation, options, title});
+	}
+
+	static todo({annotations, title}) {
+		return new Task('todo', {annotations, title});
+	}
+
+	constructor(type, {annotations, args, implementation, options, title}) {
+		this.annotations = annotations;
+		this.args = args;
+		this.implementation = implementation;
+		this.options = options;
+		this.title = title;
+		this.type = type;
+
+		this.previous = null;
+	}
+}
+
+exports.Task = Task;
+
+class TaskList {
+	constructor(forkedFrom) {
+		// Hooks are kept as a reverse linked list, so that forks can easily extend them.
+		this.lastAfter = forkedFrom ? forkedFrom.lastAfter : null;
+		this.lastAfterAlways = forkedFrom ? forkedFrom.lastAfterAlways : null;
+		this.lastAfterEach = forkedFrom ? forkedFrom.lastAfterEach : null;
+		this.lastAfterEachAlways = forkedFrom ? forkedFrom.lastAfterEachAlways : null;
+		this.lastBefore = forkedFrom ? forkedFrom.lastBefore : null;
+		this.lastBeforeEach = forkedFrom ? forkedFrom.lastBeforeEach : null;
+
+		this.test = [];
+		this.todo = [];
+	}
+
+	add(task) {
+		switch (task.type) {
+			case 'after':
+				task.previous = this.lastAfter;
+				this.lastAfter = task;
+				break;
+			case 'afterAlways':
+				task.previous = this.lastAfterAlways;
+				this.lastAfterAlways = task;
+				break;
+			case 'afterEach':
+				task.previous = this.lastAfterEach;
+				this.lastAfterEach = task;
+				break;
+			case 'afterEachAlways':
+				task.previous = this.lastAfterEachAlways;
+				this.lastAfterEachAlways = task;
+				break;
+			case 'before':
+				task.previous = this.lastBefore;
+				this.lastBefore = task;
+				break;
+			case 'beforeEach':
+				task.previous = this.lastBeforeEach;
+				this.lastBeforeEach = task;
+				break;
+			case 'test':
+				this.test.push(task);
+				break;
+			case 'todo':
+				this.todo.push(task);
+				break;
+			default:
+				throw new TypeError(`Unhandled type ${task.type}`);
+		}
+	}
+
+	fork() {
+		return new TaskList(this);
+	}
+
+	* select(type) {
+		if (type === 'test' || type === 'todo') {
+			for (const task of this[type]) {
+				yield task;
+			}
+
+			return;
+		}
+
+		let last;
+		switch (type) {
+			case 'after':
+				last = this.lastAfter;
+				break;
+			case 'afterAlways':
+				last = this.lastAfterAlways;
+				break;
+			case 'afterEach':
+				last = this.lastAfterEach;
+				break;
+			case 'afterEachAlways':
+				last = this.lastAfterEachAlways;
+				break;
+			case 'before':
+				last = this.lastBefore;
+				break;
+			case 'beforeEach':
+				last = this.lastBeforeEach;
+				break;
+			default:
+				throw new TypeError(`Unknown type ${type}`);
+		}
+
+		const collected = [];
+		while (last !== null) {
+			if (!last.annotations.skipped) {
+				collected.push(last);
+			}
+
+			last = last.previous;
+		}
+
+		for (let i = collected.length - 1; i >= 0; i--) {
+			yield collected[i];
+		}
+	}
+}
+
+exports.TaskList = TaskList;

--- a/lib/test.js
+++ b/lib/test.js
@@ -189,23 +189,54 @@ class ExecutionContext extends assert.Assertions {
 
 class Test {
 	constructor(options) {
-		this.annotations = options.annotations;
-		this.contextRef = options.contextRef;
-		this.experiments = options.experiments || {};
-		this.failWithoutAssertions = options.failWithoutAssertions;
-		this.fn = options.fn;
-		this.powerAssert = options.powerAssert;
-		this.title = options.title;
-		this.testPassed = options.testPassed;
-		this.registerUniqueTitle = options.registerUniqueTitle;
+		const {
+			annotations,
+			compareTestSnapshot,
+			contextRef,
+			experiments = {},
+			failWithoutAssertions = true,
+			fn,
+			nextSnapshotIndex = 0,
+			powerAssert,
+			registerUniqueTitle,
+			testPassed = false,
+			title,
+			updateSnapshots = false
+		} = options;
+		const {snapshotBelongsTo = title} = options;
+
+		this.annotations = annotations;
+		this.assertCount = 0;
+		this.assertError = undefined;
+		this.attemptCount = 0;
+		this.calledEnd = false;
+		this.contextRef = contextRef;
+		this.duration = null;
+		this.endCallbackFinisher = null;
+		this.experiments = experiments;
+		this.failWithoutAssertions = failWithoutAssertions;
+		this.finishDueToAttributedError = null;
+		this.finishDueToInactivity = null;
+		this.finishDueToTimeout = null;
+		this.finishing = false;
+		this.fn = fn;
 		this.logs = [];
-
-		const {snapshotBelongsTo = this.title, nextSnapshotIndex = 0} = options;
-		this.snapshotBelongsTo = snapshotBelongsTo;
 		this.nextSnapshotIndex = nextSnapshotIndex;
+		this.pendingAssertionCount = 0;
+		this.pendingAttemptCount = 0;
+		this.pendingThrowsAssertion = null;
+		this.planCount = null;
+		this.powerAssert = powerAssert;
+		this.registerUniqueTitle = registerUniqueTitle;
+		this.snapshotBelongsTo = snapshotBelongsTo;
 		this.snapshotCount = 0;
+		this.startedAt = 0;
+		this.testPassed = testPassed;
+		this.timeoutMs = 0;
+		this.timeoutTimer = null;
+		this.title = title;
 
-		const deferRecording = this.annotations.inline;
+		const {inline: deferRecording} = this.annotations;
 		this.deferredSnapshotRecordings = [];
 		this.compareWithSnapshot = ({expected, id, message}) => {
 			this.snapshotCount++;
@@ -215,7 +246,7 @@ class Test {
 			const index = id ? 0 : this.nextSnapshotIndex++;
 			const label = id ? '' : message || `Snapshot ${index + 1}`; // Human-readable labels start counting at 1.
 
-			const {record, ...result} = options.compareTestSnapshot({belongsTo, deferRecording, expected, index, label});
+			const {record, ...result} = compareTestSnapshot({belongsTo, deferRecording, expected, index, label});
 			if (record) {
 				this.deferredSnapshotRecordings.push(record);
 			}
@@ -224,7 +255,7 @@ class Test {
 		};
 
 		this.skipSnapshot = () => {
-			if (options.updateSnapshots) {
+			if (updateSnapshots) {
 				this.addFailedAssertion(new Error('Snapshot assertions cannot be skipped when updating snapshots'));
 			} else {
 				this.nextSnapshotIndex++;
@@ -244,11 +275,11 @@ class Test {
 			const {contextRef, snapshotBelongsTo, nextSnapshotIndex, snapshotCount: startingSnapshotCount} = this;
 			const attempt = new Test({
 				...options,
-				fn,
-				annotations: {...options.annotations, callback: false, failing: false, inline: true},
+				annotations: {...annotations, callback: false, failing: false, inline: true},
 				contextRef: contextRef.copy(),
-				snapshotBelongsTo,
+				fn,
 				nextSnapshotIndex,
+				snapshotBelongsTo,
 				title
 			});
 
@@ -256,24 +287,6 @@ class Test {
 			const errors = error ? [error] : [];
 			return {assertCount, deferredSnapshotRecordings, errors, logs, passed, snapshotCount, startingSnapshotCount};
 		};
-
-		this.assertCount = 0;
-		this.assertError = undefined;
-		this.attemptCount = 0;
-		this.calledEnd = false;
-		this.duration = null;
-		this.endCallbackFinisher = null;
-		this.finishDueToAttributedError = null;
-		this.finishDueToInactivity = null;
-		this.finishDueToTimeout = null;
-		this.finishing = false;
-		this.pendingAssertionCount = 0;
-		this.pendingAttemptCount = 0;
-		this.pendingThrowsAssertion = null;
-		this.planCount = null;
-		this.startedAt = 0;
-		this.timeoutMs = 0;
-		this.timeoutTimer = null;
 	}
 
 	bindEndCallback() {

--- a/lib/test.js
+++ b/lib/test.js
@@ -70,6 +70,7 @@ class ExecutionContext extends assert.Assertions {
 
 		this.try = async (...attemptArgs) => {
 			const {args, buildTitle, implementations, receivedImplementationArray} = parseTestArgs(attemptArgs, {
+				allowExperimentalMacros: test.allowExperimentalMacros,
 				allowImplementationTitleFns: test.allowImplementationTitleFns,
 				allowMultipleImplementations: test.allowMultipleImplementations
 			});
@@ -193,6 +194,7 @@ class ExecutionContext extends assert.Assertions {
 class Test {
 	constructor(options) {
 		const {
+			allowExperimentalMacros = false,
 			allowImplementationTitleFns = true,
 			allowMultipleImplementations = true,
 			annotations,
@@ -210,6 +212,7 @@ class Test {
 		} = options;
 		const {snapshotBelongsTo = title} = options;
 
+		this.allowExperimentalMacros = allowExperimentalMacros;
 		this.allowImplementationTitleFns = allowImplementationTitleFns;
 		this.allowMultipleImplementations = allowMultipleImplementations;
 		this.annotations = annotations;

--- a/lib/test.js
+++ b/lib/test.js
@@ -69,7 +69,10 @@ class ExecutionContext extends assert.Assertions {
 		};
 
 		this.try = async (...attemptArgs) => {
-			const {args, buildTitle, implementations, receivedImplementationArray} = parseTestArgs(attemptArgs, {allowMultipleImplementations: test.allowMultipleImplementations});
+			const {args, buildTitle, implementations, receivedImplementationArray} = parseTestArgs(attemptArgs, {
+				allowImplementationTitleFns: test.allowImplementationTitleFns,
+				allowMultipleImplementations: test.allowMultipleImplementations
+			});
 
 			if (implementations.length === 0) {
 				throw new TypeError('Expected an implementation.');
@@ -190,6 +193,7 @@ class ExecutionContext extends assert.Assertions {
 class Test {
 	constructor(options) {
 		const {
+			allowImplementationTitleFns = true,
 			allowMultipleImplementations = true,
 			annotations,
 			compareTestSnapshot,
@@ -206,6 +210,7 @@ class Test {
 		} = options;
 		const {snapshotBelongsTo = title} = options;
 
+		this.allowImplementationTitleFns = allowImplementationTitleFns;
 		this.allowMultipleImplementations = allowMultipleImplementations;
 		this.annotations = annotations;
 		this.assertCount = 0;

--- a/lib/test.js
+++ b/lib/test.js
@@ -69,7 +69,7 @@ class ExecutionContext extends assert.Assertions {
 		};
 
 		this.try = async (...attemptArgs) => {
-			const {args, buildTitle, implementations, receivedImplementationArray} = parseTestArgs(attemptArgs);
+			const {args, buildTitle, implementations, receivedImplementationArray} = parseTestArgs(attemptArgs, {allowMultipleImplementations: test.allowMultipleImplementations});
 
 			if (implementations.length === 0) {
 				throw new TypeError('Expected an implementation.');
@@ -190,6 +190,7 @@ class ExecutionContext extends assert.Assertions {
 class Test {
 	constructor(options) {
 		const {
+			allowMultipleImplementations = true,
 			annotations,
 			compareTestSnapshot,
 			contextRef,
@@ -205,6 +206,7 @@ class Test {
 		} = options;
 		const {snapshotBelongsTo = title} = options;
 
+		this.allowMultipleImplementations = allowMultipleImplementations;
 		this.annotations = annotations;
 		this.assertCount = 0;
 		this.assertError = undefined;

--- a/lib/test.js
+++ b/lib/test.js
@@ -189,11 +189,11 @@ class ExecutionContext extends assert.Assertions {
 
 class Test {
 	constructor(options) {
+		this.annotations = options.annotations;
 		this.contextRef = options.contextRef;
 		this.experiments = options.experiments || {};
 		this.failWithoutAssertions = options.failWithoutAssertions;
 		this.fn = options.fn;
-		this.metadata = options.metadata;
 		this.powerAssert = options.powerAssert;
 		this.title = options.title;
 		this.testPassed = options.testPassed;
@@ -205,7 +205,7 @@ class Test {
 		this.nextSnapshotIndex = nextSnapshotIndex;
 		this.snapshotCount = 0;
 
-		const deferRecording = this.metadata.inline;
+		const deferRecording = this.annotations.inline;
 		this.deferredSnapshotRecordings = [];
 		this.compareWithSnapshot = ({expected, id, message}) => {
 			this.snapshotCount++;
@@ -245,7 +245,7 @@ class Test {
 			const attempt = new Test({
 				...options,
 				fn,
-				metadata: {...options.metadata, callback: false, failing: false, inline: true},
+				annotations: {...options.annotations, callback: false, failing: false, inline: true},
 				contextRef: contextRef.copy(),
 				snapshotBelongsTo,
 				nextSnapshotIndex,
@@ -277,13 +277,13 @@ class Test {
 	}
 
 	bindEndCallback() {
-		if (this.metadata.callback) {
+		if (this.annotations.callback) {
 			return (error, savedError) => {
 				this.endCallback(error, savedError);
 			};
 		}
 
-		if (this.metadata.inline) {
+		if (this.annotations.inline) {
 			throw new Error('`t.end()` is not supported inside `t.try()`');
 		} else {
 			throw new Error('`t.end()` is not supported in this context. To use `t.end()` as a callback, you must use "callback mode" via `test.cb(testName, fn)`');
@@ -594,7 +594,7 @@ class Test {
 			promise = Promise.resolve(result.retval);
 		}
 
-		if (this.metadata.callback) {
+		if (this.annotations.callback) {
 			if (returnedObservable || returnedPromise) {
 				const asyncType = returnedObservable ? 'observables' : 'promises';
 				this.saveFirstError(new Error(`Do not return ${asyncType} from tests declared via \`test.cb(…)\`. Use \`test.cb(…)\` for legacy callback APIs. When using promises, observables or async functions, use \`test(…)\`.`));
@@ -676,7 +676,7 @@ class Test {
 		let error = this.assertError;
 		let passed = !error;
 
-		if (this.metadata.failing) {
+		if (this.annotations.failing) {
 			passed = !passed;
 
 			if (passed) {
@@ -687,11 +687,11 @@ class Test {
 		}
 
 		return {
+			annotations: this.annotations,
 			deferredSnapshotRecordings: this.deferredSnapshotRecordings,
 			duration: this.duration,
 			error,
 			logs: this.logs,
-			metadata: this.metadata,
 			passed,
 			snapshotCount: this.snapshotCount,
 			assertCount: this.assertCount,

--- a/lib/worker/main.js
+++ b/lib/worker/main.js
@@ -1,18 +1,28 @@
 'use strict';
 const runner = require('./subprocess').getRunner();
 
-const makeCjsExport = () => {
+const makeCjsExport = (chain = runner.chain) => {
 	function test(...args) {
-		return runner.chain(...args);
+		return chain(...args);
 	}
 
-	return Object.assign(test, runner.chain);
+	return Object.assign(test, chain);
 };
 
 // Support CommonJS modules by exporting a test function that can be fully
 // chained. Also support ES module loaders by exporting __esModule and a
 // default.
-module.exports = Object.assign(makeCjsExport(), {
+exports.ava3 = () => Object.assign(makeCjsExport(), {
 	__esModule: true,
-	default: runner.chain
+	default: makeCjsExport()
 });
+
+// Only export a test function that can be fully chained. This will be the
+// behavior in AVA 4.
+exports.experimental = () => {
+	if (!runner.experimentalChain) {
+		throw new Error('You must enable the ’experimentalTestInterfaces’ experiment');
+	}
+
+	return makeCjsExport(runner.experimentalChain);
+};

--- a/lib/worker/main.js
+++ b/lib/worker/main.js
@@ -11,10 +11,7 @@ const makeCjsExport = () => {
 
 // Support CommonJS modules by exporting a test function that can be fully
 // chained. Also support ES module loaders by exporting __esModule and a
-// default. Support `import * as ava from 'ava'` use cases by exporting a
-// `test` member. Do all this whilst preventing `test.test.test() or
-// `test.default.test()` chains, though in CommonJS `test.test()` is
-// unavoidable.
+// default.
 module.exports = Object.assign(makeCjsExport(), {
 	__esModule: true,
 	default: runner.chain

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"lib",
 		"*.js",
 		"!*.config.js",
-		"index.d.ts"
+		"index.d.ts",
+		"experimental.d.ts"
 	],
 	"keywords": [
 		"🦄",

--- a/test-d/experimental-forkable.ts
+++ b/test-d/experimental-forkable.ts
@@ -1,0 +1,13 @@
+import {expectType} from 'tsd';
+import test, {ForkableTestInterface, ForkableSerialInterface} from '../experimental';
+
+const foo = test.make();
+expectType<ForkableTestInterface>(foo);
+
+const bar = foo.fork();
+expectType<ForkableTestInterface>(bar);
+
+const baz = foo.serial.fork();
+expectType<ForkableSerialInterface>(baz);
+const thud = baz.fork();
+expectType<ForkableSerialInterface>(thud);

--- a/test-d/experimental-macro.ts
+++ b/test-d/experimental-macro.ts
@@ -1,0 +1,80 @@
+import {expectError} from 'tsd';
+import test, {TestInterface} from '../experimental';
+
+{
+	const macro = test.macro(t => t.pass());
+	test(macro);
+	test('title', macro);
+	test.serial(macro);
+	test.serial('title', macro);
+	expectError(test(macro, 'foo'));
+	expectError(test('title', macro, 'foo'));
+	expectError(test.serial(macro, 'foo'));
+	expectError(test.serial('title', macro, 'foo'));
+}
+
+{
+	const macro = test.serial.macro(t => t.pass());
+	test(macro);
+	test.serial(macro);
+}
+
+{
+	const macro = test.macro<[string]>((t, string) => t.is(string, 'foo'));
+	test(macro, 'foo');
+	test('title', macro, 'foo');
+	test.serial(macro, 'foo');
+	test.serial('title', macro, 'foo');
+	expectError(test(macro));
+	expectError(test('title', macro));
+	expectError(test.serial(macro));
+	expectError(test.serial('title', macro));
+}
+
+{
+	const macro = test.macro<[string]>({
+		exec: (t, string) => t.is(string, 'foo')
+	});
+	test(macro, 'foo');
+	test('title', macro, 'foo');
+	test.serial(macro, 'foo');
+	test.serial('title', macro, 'foo');
+	expectError(test.serial(macro));
+	expectError(test.serial('title', macro));
+}
+
+{
+	const macro = test.macro<[string]>({
+		exec: (t, string) => t.is(string, 'foo'),
+		title: (prefix, string) => `${prefix ?? 'title'} ${string}`
+	});
+	test(macro, 'foo');
+	test('title', macro, 'foo');
+	test.serial(macro, 'foo');
+	test.serial('title', macro, 'foo');
+	expectError(test(macro));
+	expectError(test('title', macro));
+	expectError(test.serial(macro));
+	expectError(test.serial('title', macro));
+}
+
+test.serial.macro<[], { str: string }>(t => t.is(t.context.str, 'foo'));
+test.serial.macro<[string], { str: string }>((t, string) => t.is(t.context.str, string));
+(test as TestInterface<{ str: string }>).macro(t => t.is(t.context.str, 'foo'));
+(test as TestInterface<{ str: string }>).macro<[string]>((t, string) => t.is(t.context.str, string));
+
+{
+	const macro = test.macro<[], { foo: string }>(t => t.is(t.context.foo, 'foo'));
+	// ;(test as TestInterface<{foo: string, bar: string}>)(macro)
+	expectError((test as TestInterface<{bar: string}>)(macro));
+}
+
+{
+	const macro = test.macro(t => t.pass());
+	expectError(test.before(macro));
+	expectError(test.beforeEach(macro));
+	expectError(test.after(macro));
+	expectError(test.after.always(macro));
+	expectError(test.afterEach(macro));
+	expectError(test.afterEach.always(macro));
+}

--- a/test-d/experimental-try-commit.ts
+++ b/test-d/experimental-try-commit.ts
@@ -1,0 +1,66 @@
+import {expectType} from 'tsd';
+import test, {ExecutionContext, Macro} from '../experimental';
+
+test('attempt', async t => {
+	const attempt = await t.try(
+		(u, a, b) => {
+			expectType<ExecutionContext>(u);
+			expectType<string>(a);
+			expectType<number>(b);
+		},
+		'string',
+		6
+	);
+	attempt.commit();
+});
+
+test('attempt with title', async t => {
+	const attempt = await t.try(
+		'attempt title',
+		(u, a, b) => {
+			expectType<ExecutionContext>(u);
+			expectType<string>(a);
+			expectType<number>(b);
+		},
+		'string',
+		6
+	);
+	attempt.commit();
+});
+
+{
+	const lengthCheck = (t: ExecutionContext, a: string, b: number): void => {
+		t.is(a.length, b);
+	};
+
+	test('attempt with helper', async t => {
+		const attempt = await t.try(lengthCheck, 'string', 6);
+		attempt.commit();
+	});
+
+	test('attempt with title', async t => {
+		const attempt = await t.try('title', lengthCheck, 'string', 6);
+		attempt.commit();
+	});
+}
+
+test('all possible variants to pass to t.try', async t => {
+	// No params
+	t.try(tt => tt.pass());
+
+	t.try('test', tt => tt.pass());
+
+	// Some params
+	t.try((tt, a, b) => tt.is(a.length, b), 'hello', 5);
+
+	t.try('test', (tt, a, b) => tt.is(a.length, b), 'hello', 5);
+
+	// Macro with title
+	const macro1 = test.macro({
+		exec: (tt, a, b) => tt.is(a.length, b),
+		title: (title, a, b) => `${title ? `${String(title)} ` : ''}str: "${String(a)}" with len: "${String(b)}"`
+	});
+
+	t.try(macro1, 'hello', 5);
+	t.try('title', macro1, 'hello', 5);
+});

--- a/test-d/experimental.ts
+++ b/test-d/experimental.ts
@@ -1,0 +1,106 @@
+import {expectError} from 'tsd';
+import test, {ExecutionContext, Implementation, ImplementationWithArgs} from '../experimental';
+
+test('title', t => t.pass());
+
+expectError(test<[string]>('explicit argument type', t => t.pass(), 42));
+
+expectError(test<[string]>('missing argument', (t: ExecutionContext) => t.pass()));
+
+test<string[]>('optional arguments', t => t.pass());
+test<string[]>('optional arguments, with values', t => t.pass(), 'foo', 'bar');
+
+expectError(test('argument type inferred from implementation', (t, string) => t.is(string, 'foo'), 42));
+
+expectError(test('argument type inferred in implementation', (t, string) => t.is(string, 'foo'), 42));
+
+{
+	const implementation: Implementation = t => t.pass();
+	expectError(test('unexpected arguments', implementation, 'foo'));
+}
+
+{
+	const implementation: ImplementationWithArgs<[string]> = (t, string) => t.is(string, 'foo');
+	test('unexpected arguments', implementation, 'foo');
+}
+
+test.failing<[string]>('failing test with arguments', (t, string) => t.is(string, 'foo'), 'foo');
+test.only<[string]>('only test with arguments', (t, string) => t.is(string, 'foo'), 'foo');
+test.skip<[string]>('serial test with arguments', (t, string) => t.is(string, 'foo'), 'foo');
+
+test.after.always.skip<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.after.always.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.after.always<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.after.always<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.after.skip<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.after.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.after<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.after<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach.always.skip<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach.always.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach.always<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach.always<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach.skip<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.afterEach<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.before.skip<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.before.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.before<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.before<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.beforeEach.skip<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.beforeEach.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.beforeEach<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.beforeEach<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+
+test.serial('title', t => t.pass());
+
+expectError(test.serial<[string]>('explicit argument type', t => t.pass(), 42));
+
+expectError(test.serial<[string]>('missing argument', (t: ExecutionContext) => t.pass()));
+
+test.serial<string[]>('optional arguments', t => t.pass());
+test.serial<string[]>('optional arguments, with values', t => t.pass(), 'foo', 'bar');
+
+expectError(test.serial('argument type inferred from implementation', (t, string) => t.is(string, 'foo'), 42));
+
+expectError(test.serial('argument type inferred in implementation', (t, string) => t.is(string, 'foo'), 42));
+
+{
+	const implementation: Implementation = t => t.pass();
+	expectError(test.serial('unexpected arguments', implementation, 'foo'));
+}
+
+{
+	const implementation: ImplementationWithArgs<[string]> = (t, string) => t.is(string, 'foo');
+	test.serial('unexpected arguments', implementation, 'foo');
+}
+
+test.serial.failing<[string]>('failing test with arguments', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.only<[string]>('only test with arguments', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.skip<[string]>('serial test with arguments', (t, string) => t.is(string, 'foo'), 'foo');
+
+test.serial.after.always.skip<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.after.always.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.after.always<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.after.always<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.after.skip<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.after.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.after<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.after<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach.always.skip<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach.always.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach.always<[string]>('after.always hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach.always<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach.skip<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach<[string]>('after hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.afterEach<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.before.skip<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.before.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.before<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.before<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.beforeEach.skip<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.beforeEach.skip<[string]>((t, string) => t.is(string, 'foo'), 'foo');
+test.serial.beforeEach<[string]>('before hook with args', (t, string) => t.is(string, 'foo'), 'foo');
+test.serial.beforeEach<[string]>((t, string) => t.is(string, 'foo'), 'foo');

--- a/test-tap/helper/ava-test.js
+++ b/test-tap/helper/ava-test.js
@@ -14,48 +14,48 @@ function withExperiments(experiments = {}) {
 
 	function ava(fn, contextRef, title = 'test') {
 		return new Test({
+			annotations: {type: 'test', callback: false},
 			contextRef: contextRef || new ContextRef(),
 			experiments,
 			failWithoutAssertions: true,
 			fn,
 			registerUniqueTitle,
-			metadata: {type: 'test', callback: false},
 			title
 		});
 	}
 
 	ava.failing = (fn, contextRef) => {
 		return new Test({
+			annotations: {type: 'test', callback: false, failing: true},
 			contextRef: contextRef || new ContextRef(),
 			experiments,
 			failWithoutAssertions: true,
 			fn,
 			registerUniqueTitle,
-			metadata: {type: 'test', callback: false, failing: true},
 			title: 'test.failing'
 		});
 	};
 
 	ava.cb = (fn, contextRef) => {
 		return new Test({
+			annotations: {type: 'test', callback: true},
 			contextRef: contextRef || new ContextRef(),
 			experiments,
 			failWithoutAssertions: true,
 			fn,
 			registerUniqueTitle,
-			metadata: {type: 'test', callback: true},
 			title: 'test.cb'
 		});
 	};
 
 	ava.cb.failing = (fn, contextRef) => {
 		return new Test({
+			annotations: {type: 'test', callback: true, failing: true},
 			contextRef: contextRef || new ContextRef(),
 			experiments,
 			failWithoutAssertions: true,
 			fn,
 			registerUniqueTitle,
-			metadata: {type: 'test', callback: true, failing: true},
 			title: 'test.cb.failing'
 		});
 	};

--- a/test-tap/observable.js
+++ b/test-tap/observable.js
@@ -8,20 +8,20 @@ const Test = require('../lib/test');
 
 function ava(fn) {
 	return new Test({
+		annotations: {type: 'test', callback: false},
 		contextRef: null,
 		failWithoutAssertions: true,
 		fn,
-		metadata: {type: 'test', callback: false},
 		title: '[anonymous]'
 	});
 }
 
 ava.cb = function (fn) {
 	return new Test({
+		annotations: {type: 'test', callback: true},
 		contextRef: null,
 		failWithoutAssertions: true,
 		fn,
-		metadata: {type: 'test', callback: true},
 		title: '[anonymous]'
 	});
 };

--- a/test-tap/promise.js
+++ b/test-tap/promise.js
@@ -7,20 +7,20 @@ const Test = require('../lib/test');
 
 function ava(fn) {
 	return new Test({
+		annotations: {type: 'test', callback: false},
 		contextRef: null,
 		failWithoutAssertions: true,
 		fn,
-		metadata: {type: 'test', callback: false},
 		title: '[anonymous]'
 	});
 }
 
 ava.cb = function (fn) {
 	return new Test({
+		annotations: {type: 'test', callback: true},
 		contextRef: null,
 		failWithoutAssertions: true,
 		fn,
-		metadata: {type: 'test', callback: true},
 		title: '[anonymous]'
 	});
 };

--- a/test-tap/test.js
+++ b/test-tap/test.js
@@ -162,11 +162,11 @@ test('end can be used as callback with a non-error as its error argument', t => 
 test('title returns the test title', t => {
 	t.plan(1);
 	return new Test({
+		annotations: {type: 'test', callback: false},
 		fn(a) {
 			t.is(a.title, 'foo');
 			a.pass();
 		},
-		metadata: {type: 'test', callback: false},
 		title: 'foo'
 	}).run();
 });
@@ -535,6 +535,7 @@ test('no crash when adding assertions after the test has ended', t => {
 
 test('contextRef', t => {
 	new Test({
+		annotations: {type: 'test'},
 		contextRef: {
 			get() {
 				return {foo: 'bar'};
@@ -546,7 +547,6 @@ test('contextRef', t => {
 			t.strictDeepEqual(a.context, {foo: 'bar'});
 			t.end();
 		},
-		metadata: {type: 'test'},
 		onResult() {},
 		title: 'foo'
 	}).run();
@@ -678,9 +678,9 @@ test('snapshot assertion can be skipped', t => {
 	});
 
 	return new Test({
+		annotations: {},
 		compareTestSnapshot: options => manager.compare(options),
 		updateSnapshots: false,
-		metadata: {},
 		title: 'passes',
 		fn(t) {
 			t.snapshot.skip({not: {a: 'match'}});
@@ -694,8 +694,8 @@ test('snapshot assertion can be skipped', t => {
 
 test('snapshot assertion cannot be skipped when updating snapshots', t => {
 	return new Test({
+		annotations: {},
 		updateSnapshots: true,
-		metadata: {},
 		title: 'passes',
 		fn(t) {
 			t.snapshot.skip({not: {a: 'match'}});

--- a/test-tap/try-snapshot.js
+++ b/test-tap/try-snapshot.js
@@ -10,10 +10,10 @@ const ContextRef = require('../lib/context-ref');
 
 function setup(title, manager, fn) {
 	return new Test({
+		annotations: {type: 'test', callback: false},
 		experiments: {},
 		fn,
 		failWithoutAssertions: true,
-		metadata: {type: 'test', callback: false},
 		contextRef: new ContextRef(),
 		registerUniqueTitle: () => true,
 		title,


### PR DESCRIPTION
This kicks off some experimental changes to AVA's test interface. That is, the `const test = require('ava')` stuff. Eventually this will be come AVA 4, but initially it'll be available through importing `ava/experimental`. You'll also have to enable the `experimentalTestInterfaces` experiment.

Summary of (planned) changes:

* AVA is now just a CJS module with a single export: the `test` function. If you're transpiling ESM, you'll no longer be able to `import { serial } from 'ava'`. This never worked anyway with proper ESM.
* Test implementations can no longer have `title` functions.
* You'll no longer be able to pass an array of macros (or implementations), when declaring tests or with `t.try()`.
* Speaking of macros, if you want them to have a `title` function you'll need to use `test.macro({ exec (t) { … }, title () { return 'title' })`.
* If you're writing tests using TypeScript, the `Macro` type has changed.
* But, on the plus side, `test.macro()` automatically uses the `t.context` type from `test`.

I tend to write service integration tests using AVA, which involve stubbing several APIs, managing database access and launching child processes. Crafting `t.context` for these tests is rather complicated.

I'm tinkering with a "forkable test interface". You'd start off calling `test.make()`. This gives you an entirely new test chain, say `test2`. You can define hooks and whatnot, and then call `test2.fork()` to create yet another test chain, which will use the hooks defined on `test2` before forking.

You'll be able to pass some options to `make()` and `fork()` to construct `t.context`, along the lines of what you'd do using `test.before()` and `test.beforeEach()`. But, for TypeScript users, the context type will be inferable.

We could also use this to create a test chain that always executes serially, or limits concurrency, or runs in isolation from other test chains in the same test file, or [executes conditionally](https://github.com/avajs/ava/issues/2602).

More to come!