### PR TITLE
Support configuration via environment variables

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -106,6 +106,7 @@ exports.run = async () => { // eslint-disable-line complexity
 			'strip-aliased': true,
 			'unknown-options-as-args': false
 		})
+		.env('AVA')
 		.usage('$0 [<pattern>...]')
 		.usage('$0 debug [<pattern>...]')
 		.usage('$0 reset-cache')
@@ -335,7 +336,9 @@ exports.run = async () => { // eslint-disable-line complexity
 
 	let nodeArguments;
 	try {
-		nodeArguments = normalizeNodeArguments(conf.nodeArguments, argv['node-arguments']);
+		const nodeArgs = [argv['node-arguments'], argv.nodeArguments].filter(Boolean).join(' ');
+		// Using yargs env AVA_NODE_ARGS only sets nodeArguments, while cli args set node-arguments
+		nodeArguments = normalizeNodeArguments(conf.nodeArguments, nodeArgs);
 	} catch (error) {
 		exit(error.message);
 	}

--- a/test-tap/integration/assorted.js
+++ b/test-tap/integration/assorted.js
@@ -41,9 +41,25 @@ test('--match works', t => {
 	});
 });
 
+test('--match works from env variable', t => {
+	execCli(['matcher-skip.js'], {env: {AVA_MATCH: 'tests are fun'}}, err => {
+		t.ifError(err);
+		t.end();
+	});
+});
+
 for (const tapFlag of ['--tap', '-t']) {
 	test(`${tapFlag} should produce TAP output`, t => {
 		execCli([tapFlag, 'test.js'], {dirname: 'fixture/watcher'}, err => {
+			t.ok(!err);
+			t.end();
+		});
+	});
+}
+
+for (const tapEnv of ['AVA_TAP', 'AVA_T']) {
+	test(`${tapEnv}=true should produce TAP output`, t => {
+		execCli(['test.js'], {dirname: 'fixture/watcher', env: {[tapEnv]: 'true'}}, err => {
 			t.ok(!err);
 			t.end();
 		});

--- a/test-tap/integration/concurrency.js
+++ b/test-tap/integration/concurrency.js
@@ -40,3 +40,10 @@ test('works when --concurrency is provided with a value', t => {
 		t.end();
 	});
 });
+
+test('works when AVA_CONCURRENCY is provided with a value', t => {
+	execCli(['test.js'], {dirname: 'fixture/concurrency', env: {AVA_CONCURRENCY: '1'}}, err => {
+		t.ifError(err);
+		t.end();
+	});
+});

--- a/test-tap/integration/node-arguments.js
+++ b/test-tap/integration/node-arguments.js
@@ -8,6 +8,20 @@ test('passes node arguments to workers', t => {
 		(err, stdout, stderr) => t.ifError(err, null, {stdout, stderr}));
 });
 
+test('passes node arguments pass by ava env var to workers', t => {
+	t.plan(1);
+	execCli(['node-arguments.js'], {
+		env: {AVA_NODE_ARGUMENTS: '--throw-deprecation --zero-fill-buffers'}
+	}, (err, stdout, stderr) => t.ifError(err, null, {stdout, stderr}));
+});
+
+test('passes node arguments pass via env and cli to workers', t => {
+	t.plan(1);
+	execCli(['--node-arguments=--throw-deprecation', 'node-arguments.js'], {
+		env: {AVA_NODE_ARGUMENTS: '--zero-fill-buffers'}
+	}, (err, stdout, stderr) => t.ifError(err, null, {stdout, stderr}));
+});
+
 test('reads node arguments from config', t => {
 	t.plan(1);
 	execCli(['test.js'], {

--- a/test-tap/integration/snapshots.js
+++ b/test-tap/integration/snapshots.js
@@ -37,6 +37,30 @@ for (const obj of [
 	});
 }
 
+test('snapshots work (colocated) configured by env variables', t => {
+	const snapPath = path.join(__dirname, '..', 'fixture', 'snapshots', '', '', 'test.js.snap');
+	try {
+		fs.unlinkSync(snapPath);
+	} catch (error) {
+		if (error.code !== 'ENOENT') {
+			throw error;
+		}
+	}
+
+	const dirname = path.join('fixture/snapshots', '');
+	// Test should pass, and a snapshot gets written
+	execCli([], {dirname, env: {AVA_FORCE_CI: 'not-ci', AVA_VERBOSE: 'true', AVA_UPDATE_SNAPHSOTS: 'true'}}, error => {
+		t.ifError(error);
+		t.true(fs.existsSync(snapPath));
+
+		// Test should pass, and the snapshot gets used
+		execCli([], {dirname}, error => {
+			t.ifError(error);
+			t.end();
+		});
+	});
+});
+
 test('appends to existing snapshots', t => {
 	const cliPath = require.resolve('../../cli.js');
 	const avaPath = require.resolve('../../');


### PR DESCRIPTION
**Use yargs '.env()' mecanism to enable configuration via environment variables :gear:**

- Just configure `yargs` with a single option, `.env('AVA')`
- Added tests to ensure configuration is working. Made by cloning tests using the command line flags.
- A work around was needed to support both `--node-arguments` and `AVA_NODE_ARGUMENTS`

We can eventually consider hiding the feature behind some feature toggle, like using `AVA=true` or similar.

Also if this is to land, I'll be more than happy if possiblee to backport the feature on the `2.x` branch (as I still develop many libs still having node 8 support).

I'll wait for first feedbacks before to add the adequate documentation, of course 🙃 