### PR TITLE
Adjust type of t.fail to return never

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ export interface DeepEqualAssertion {
 
 export interface FailAssertion {
 	/** Fail the test. */
-	(message?: string): void;
+	(message?: string): never;
 
 	/** Skip this assertion. */
 	skip(message?: string): void;


### PR DESCRIPTION
Implements first suggestion from https://github.com/avajs/ava/issues/2449