### PR TITLE
Test our type definitions with multiple TS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,26 @@ jobs:
       - run: npm test
       - uses: codecov/codecov-action@v1
 
+  typescript:
+    name: TypeScript compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ts-version: [~3.7.5, ~3.8]
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ^12
+      - run: npm ci --no-audit
+      - run: npm i typescript@${TS_VERSION}
+        env:
+          TS_VERSION: ${{ matrix.ts-version }}
+      - run: npm ls typescript
+      - run: npx tsd
+
   lockfile_churn:
     name: Test package-lock for unexpected modifications
     runs-on: ubuntu-latest

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -6,7 +6,7 @@ AVA comes bundled with a TypeScript definition file. This allows developers to l
 
 Out of the box AVA does not load TypeScript test files, however. Rudimentary support is available via the [`@ava/typescript`] package. You can also use AVA with [`ts-node`]. Read on for details.
 
-This guide assumes you've already set up TypeScript for your project. Note that AVA's definition has been tested with version 3.7.5.
+This guide assumes you've already set up TypeScript for your project. Note that AVA's definition expects at least version 3.7.5.
 
 ## Enabling AVA's TypeScript support
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
 		"tempy": "^0.5.0",
 		"touch": "^3.1.0",
 		"tsd": "^0.11.0",
-		"typescript": "^3.7.5",
+		"typescript": "^3.8.3",
 		"xo": "^0.28.2",
 		"zen-observable": "^0.8.15"
 	},


### PR DESCRIPTION
To avoid accidentally breaking compatibility with older TypeScript versions, test with each supported version.