### PR TITLE
Fix watch mode with mini reporter

### DIFF
--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -86,7 +86,7 @@ class MiniReporter {
 		this.spinner = ora({
 			isEnabled: true,
 			color: options.spinner ? options.spinner.color : 'gray',
-			discardStdin: false,
+			discardStdin: !options.watching,
 			hideCursor: false,
 			spinner: options.spinner || (process.platform === 'win32' ? 'line' : 'dots'),
 			stream: options.reportStream

--- a/lib/reporters/mini.js
+++ b/lib/reporters/mini.js
@@ -86,6 +86,7 @@ class MiniReporter {
 		this.spinner = ora({
 			isEnabled: true,
 			color: options.spinner ? options.spinner.color : 'gray',
+			discardStdin: false,
 			hideCursor: false,
 			spinner: options.spinner || (process.platform === 'win32' ? 'line' : 'dots'),
 			stream: options.reportStream


### PR DESCRIPTION
As title says, I solved the issue with the mini reporter + watch mode:

It turned out, the terminal spinner package, ora [doesn't pipes through the stdin by default][1], which was a [breaking change in its 4.0.0 relase][2]. I suppose during one of the dependency update the effect of this change was overlooked and caused the issue.

I ran the test locally on Linux, everything was green.

Please review and merge it accordingly!

Fixes #2458.

[1]: https://github.com/sindresorhus/ora#discardstdin
[2]: https://github.com/sindresorhus/ora/releases/tag/v4.0.0