### PR TITLE
Use configured depth limit for diffs in assertion failures

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -3,11 +3,10 @@ const concordance = require('concordance');
 const isError = require('is-error');
 const isPromise = require('is-promise');
 const concordanceOptions = require('./concordance-options').default;
-const concordanceDiffOptions = require('./concordance-options').diff;
 const snapshotManager = require('./snapshot-manager');
 
 function formatDescriptorDiff(actualDescriptor, expectedDescriptor, options) {
-	options = {...options, ...concordanceDiffOptions};
+	options = {...options, ...concordanceOptions};
 	return {
 		label: 'Difference:',
 		formatted: concordance.diffDescriptors(actualDescriptor, expectedDescriptor, options)

--- a/lib/concordance-options.js
+++ b/lib/concordance-options.js
@@ -135,5 +135,4 @@ exports.default = {
 	theme
 };
 
-exports.diff = {maxDepth: 1, plugins, theme};
 exports.snapshotManager = {plugins, theme: plainTheme};

--- a/test-tap/fixture/report/regular/nested-objects.js
+++ b/test-tap/fixture/report/regular/nested-objects.js
@@ -1,0 +1,29 @@
+const test = require('../../../..');
+const util = require('util');
+
+util.inspect.defaultOptions.depth = 4;
+
+test('format with max depth 4', t => {
+	const exp = {
+		a: {
+			b: {
+				foo: 'bar'
+			}
+		}
+	};
+	const act = {
+		a: {
+			b: {
+				foo: 'bar'
+			}
+		},
+		c: {
+			d: {
+				e: {
+					foo: 'bar'
+				}
+			}
+		}
+	};
+	t.deepEqual(exp, act);
+});

--- a/test-tap/reporters/mini.regular.v10.log
+++ b/test-tap/reporters/mini.regular.v10.log
@@ -3,26 +3,31 @@
 ---tty-stream-chunk-separator
 * ---tty-stream-chunk-separator
 [2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m passing test
+* nested-objects [90m[2m›[22m[39m format with max depth 4
 
-  [32m1 passed[39m---tty-stream-chunk-separator
+  [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m failing test
+* output-in-hook [90m[2m›[22m[39m passing test
 
   [32m1 passed[39m
   [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
+* output-in-hook [90m[2m›[22m[39m failing test
+
+  [32m1 passed[39m
+  [31m2 tests failed[39m---tty-stream-chunk-separator
+[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m passes
 
   [32m2 passed[39m
-  [31m1 test failed[39m
+  [31m2 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m fails
 
   [32m2 passed[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -30,7 +35,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -38,7 +43,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m3 tests failed[39m
+  [31m4 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -46,7 +51,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m4 tests failed[39m
+  [31m5 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -54,7 +59,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m5 tests failed[39m
+  [31m6 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -62,7 +67,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m6 tests failed[39m
+  [31m7 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -70,7 +75,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m7 tests failed[39m
+  [31m8 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -78,7 +83,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m8 tests failed[39m
+  [31m9 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -86,7 +91,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m9 tests failed[39m
+  [31m10 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -94,7 +99,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m10 tests failed[39m
+  [31m11 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -102,7 +107,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m11 tests failed[39m
+  [31m12 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -110,7 +115,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m12 tests failed[39m
+  [31m13 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -118,7 +123,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m13 tests failed[39m
+  [31m14 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -126,7 +131,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -134,7 +139,7 @@
 
   [32m3 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -142,7 +147,7 @@
 
   [32m4 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -150,14 +155,14 @@
 
   [32m5 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 [?25h
   [31m✖ No tests found in bad-test-chain.js[39m
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -165,6 +170,36 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› t (test-tap/fixture/report/regular/nested-objects.js:28:4)[39m
+  [90m[2m› process._tickCallback (internal/process/next_tick.js:68:7)[22m[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 

--- a/test-tap/reporters/mini.regular.v12.log
+++ b/test-tap/reporters/mini.regular.v12.log
@@ -3,26 +3,31 @@
 ---tty-stream-chunk-separator
 * ---tty-stream-chunk-separator
 [2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m passing test
+* nested-objects [90m[2m›[22m[39m format with max depth 4
 
-  [32m1 passed[39m---tty-stream-chunk-separator
+  [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m failing test
+* output-in-hook [90m[2m›[22m[39m passing test
 
   [32m1 passed[39m
   [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
+* output-in-hook [90m[2m›[22m[39m failing test
+
+  [32m1 passed[39m
+  [31m2 tests failed[39m---tty-stream-chunk-separator
+[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m passes
 
   [32m2 passed[39m
-  [31m1 test failed[39m
+  [31m2 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m fails
 
   [32m2 passed[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -30,7 +35,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -38,7 +43,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m3 tests failed[39m
+  [31m4 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -46,7 +51,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m4 tests failed[39m
+  [31m5 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -54,7 +59,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m5 tests failed[39m
+  [31m6 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -62,7 +67,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m6 tests failed[39m
+  [31m7 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -70,7 +75,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m7 tests failed[39m
+  [31m8 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -78,7 +83,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m8 tests failed[39m
+  [31m9 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -86,7 +91,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m9 tests failed[39m
+  [31m10 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -94,7 +99,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m10 tests failed[39m
+  [31m11 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -102,7 +107,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m11 tests failed[39m
+  [31m12 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -110,7 +115,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m12 tests failed[39m
+  [31m13 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -118,7 +123,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m13 tests failed[39m
+  [31m14 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -126,7 +131,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -134,7 +139,7 @@
 
   [32m3 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -142,7 +147,7 @@
 
   [32m4 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -150,14 +155,14 @@
 
   [32m5 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 [?25h
   [31m✖ No tests found in bad-test-chain.js[39m
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -165,6 +170,35 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› test-tap/fixture/report/regular/nested-objects.js:28:4[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 

--- a/test-tap/reporters/mini.regular.v13.log
+++ b/test-tap/reporters/mini.regular.v13.log
@@ -3,26 +3,31 @@
 ---tty-stream-chunk-separator
 * ---tty-stream-chunk-separator
 [2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m passing test
+* nested-objects [90m[2m›[22m[39m format with max depth 4
 
-  [32m1 passed[39m---tty-stream-chunk-separator
+  [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m failing test
+* output-in-hook [90m[2m›[22m[39m passing test
 
   [32m1 passed[39m
   [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
+* output-in-hook [90m[2m›[22m[39m failing test
+
+  [32m1 passed[39m
+  [31m2 tests failed[39m---tty-stream-chunk-separator
+[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m passes
 
   [32m2 passed[39m
-  [31m1 test failed[39m
+  [31m2 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m fails
 
   [32m2 passed[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -30,7 +35,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -38,7 +43,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m3 tests failed[39m
+  [31m4 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -46,7 +51,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m4 tests failed[39m
+  [31m5 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -54,7 +59,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m5 tests failed[39m
+  [31m6 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -62,7 +67,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m6 tests failed[39m
+  [31m7 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -70,7 +75,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m7 tests failed[39m
+  [31m8 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -78,7 +83,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m8 tests failed[39m
+  [31m9 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -86,7 +91,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m9 tests failed[39m
+  [31m10 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -94,7 +99,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m10 tests failed[39m
+  [31m11 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -102,7 +107,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m11 tests failed[39m
+  [31m12 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -110,7 +115,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m12 tests failed[39m
+  [31m13 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -118,7 +123,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m13 tests failed[39m
+  [31m14 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -126,7 +131,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -134,7 +139,7 @@
 
   [32m3 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -142,7 +147,7 @@
 
   [32m4 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -150,14 +155,14 @@
 
   [32m5 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 [?25h
   [31m✖ No tests found in bad-test-chain.js[39m
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -165,6 +170,35 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› test-tap/fixture/report/regular/nested-objects.js:28:4[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 

--- a/test-tap/reporters/mini.regular.v14.log
+++ b/test-tap/reporters/mini.regular.v14.log
@@ -3,26 +3,31 @@
 ---tty-stream-chunk-separator
 * ---tty-stream-chunk-separator
 [2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m passing test
+* nested-objects [90m[2m›[22m[39m format with max depth 4
 
-  [32m1 passed[39m---tty-stream-chunk-separator
+  [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
-* output-in-hook [90m[2m›[22m[39m failing test
+* output-in-hook [90m[2m›[22m[39m passing test
 
   [32m1 passed[39m
   [31m1 test failed[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
+* output-in-hook [90m[2m›[22m[39m failing test
+
+  [32m1 passed[39m
+  [31m2 tests failed[39m---tty-stream-chunk-separator
+[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m passes
 
   [32m2 passed[39m
-  [31m1 test failed[39m
+  [31m2 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 * test [90m[2m›[22m[39m fails
 
   [32m2 passed[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -30,7 +35,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m2 tests failed[39m
+  [31m3 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -38,7 +43,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m3 tests failed[39m
+  [31m4 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -46,7 +51,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m4 tests failed[39m
+  [31m5 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -54,7 +59,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m5 tests failed[39m
+  [31m6 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -62,7 +67,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m6 tests failed[39m
+  [31m7 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -70,7 +75,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m7 tests failed[39m
+  [31m8 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -78,7 +83,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m8 tests failed[39m
+  [31m9 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -86,7 +91,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m9 tests failed[39m
+  [31m10 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -94,7 +99,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m10 tests failed[39m
+  [31m11 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -102,7 +107,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m11 tests failed[39m
+  [31m12 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -110,7 +115,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m12 tests failed[39m
+  [31m13 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -118,7 +123,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m13 tests failed[39m
+  [31m14 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -126,7 +131,7 @@
 
   [32m2 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -134,7 +139,7 @@
 
   [32m3 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -142,7 +147,7 @@
 
   [32m4 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
@@ -150,14 +155,14 @@
 
   [32m5 passed[39m
   [31m1 known failure[39m
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [33m1 skipped[39m
   [34m1 todo[39m---tty-stream-chunk-separator
 [2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G[1A[2K[1G---tty-stream-chunk-separator
 [?25h
   [31m✖ No tests found in bad-test-chain.js[39m
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -165,6 +170,35 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› test-tap/fixture/report/regular/nested-objects.js:28:4[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 

--- a/test-tap/reporters/tap.regular.v10.log
+++ b/test-tap/reporters/tap.regular.v10.log
@@ -11,6 +11,32 @@ not ok 1 - TypeError: test.serial.test is not a function
 # bad-test-chain.js exited with a non-zero exit code: 1
 not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
+# nested-objects › format with max depth 4
+not ok 3 - nested-objects [90m[2m›[22m[39m format with max depth 4
+  ---
+    name: AssertionError
+    assertion: deepEqual
+    values:
+      'Difference:': |2-
+          {
+            a: {
+              b: {
+                foo: 'bar',
+              },
+            },
+        +   c: {
+        +     d: {
+        +       e: {
+        +         foo: 'bar',
+        +       },
+        +     },
+        +   },
+          }
+    at: |-
+      t (test-tap/fixture/report/regular/nested-objects.js:28:4)
+      process._tickCallback (internal/process/next_tick.js:68:7)
+  ...
+---tty-stream-chunk-separator
 # output-in-hook › before hook
 ---tty-stream-chunk-separator
 # output-in-hook › before hook
@@ -26,10 +52,10 @@ not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
   # beforeEach
 ---tty-stream-chunk-separator
 # output-in-hook › passing test
-ok 3 - output-in-hook [90m[2m›[22m[39m passing test
+ok 4 - output-in-hook [90m[2m›[22m[39m passing test
 ---tty-stream-chunk-separator
 # output-in-hook › failing test
-not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
+not ok 5 - output-in-hook [90m[2m›[22m[39m failing test
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -56,16 +82,16 @@ not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
   # afterAlways
 ---tty-stream-chunk-separator
 # test › skip
-ok 5 - test [90m[2m›[22m[39m skip # SKIP
+ok 6 - test [90m[2m›[22m[39m skip # SKIP
 ---tty-stream-chunk-separator
 # test › todo
-not ok 6 - test [90m[2m›[22m[39m todo # TODO
+not ok 7 - test [90m[2m›[22m[39m todo # TODO
 ---tty-stream-chunk-separator
 # test › passes
-ok 7 - test [90m[2m›[22m[39m passes
+ok 8 - test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # test › fails
-not ok 8 - test [90m[2m›[22m[39m fails
+not ok 9 - test [90m[2m›[22m[39m fails
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -76,10 +102,10 @@ not ok 8 - test [90m[2m›[22m[39m fails
   ...
 ---tty-stream-chunk-separator
 # test › known failure
-ok 9 - test [90m[2m›[22m[39m known failure
+ok 10 - test [90m[2m›[22m[39m known failure
 ---tty-stream-chunk-separator
 # test › no longer failing
-not ok 10 - test [90m[2m›[22m[39m no longer failing
+not ok 11 - test [90m[2m›[22m[39m no longer failing
   ---
     name: Error
     message: >-
@@ -89,7 +115,7 @@ not ok 10 - test [90m[2m›[22m[39m no longer failing
   ...
 ---tty-stream-chunk-separator
 # test › logs
-not ok 11 - test [90m[2m›[22m[39m logs
+not ok 12 - test [90m[2m›[22m[39m logs
   * hello
   * world
   ---
@@ -102,7 +128,7 @@ not ok 11 - test [90m[2m›[22m[39m logs
   ...
 ---tty-stream-chunk-separator
 # test › formatted
-not ok 12 - test [90m[2m›[22m[39m formatted
+not ok 13 - test [90m[2m›[22m[39m formatted
   ---
     name: AssertionError
     assertion: deepEqual
@@ -116,7 +142,7 @@ not ok 12 - test [90m[2m›[22m[39m formatted
   ...
 ---tty-stream-chunk-separator
 # test › power-assert
-not ok 13 - test [90m[2m›[22m[39m power-assert
+not ok 14 - test [90m[2m›[22m[39m power-assert
   ---
     name: AssertionError
     assertion: assert
@@ -129,7 +155,7 @@ not ok 13 - test [90m[2m›[22m[39m power-assert
   ...
 ---tty-stream-chunk-separator
 # test › bad throws
-not ok 14 - test [90m[2m›[22m[39m bad throws
+not ok 15 - test [90m[2m›[22m[39m bad throws
   ---
     name: AssertionError
     message: Improper usage of `t.throws()` detected
@@ -146,7 +172,7 @@ not ok 14 - test [90m[2m›[22m[39m bad throws
   ...
 ---tty-stream-chunk-separator
 # test › bad notThrows
-not ok 15 - test [90m[2m›[22m[39m bad notThrows
+not ok 16 - test [90m[2m›[22m[39m bad notThrows
   ---
     name: AssertionError
     message: Improper usage of `t.notThrows()` detected
@@ -163,7 +189,7 @@ not ok 15 - test [90m[2m›[22m[39m bad notThrows
   ...
 ---tty-stream-chunk-separator
 # test › implementation throws non-error
-not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
+not ok 17 - test [90m[2m›[22m[39m implementation throws non-error
   ---
     name: AssertionError
     message: Error thrown in test
@@ -173,7 +199,7 @@ not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throws
-not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
+not ok 18 - traces-in-t-throws [90m[2m›[22m[39m throws
   ---
     name: AssertionError
     assertion: throws
@@ -195,7 +221,7 @@ not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrows
-not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
+not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ---
     name: AssertionError
     assertion: notThrows
@@ -216,7 +242,7 @@ not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrowsAsync
-not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
+not ok 20 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ---
     name: AssertionError
     assertion: notThrowsAsync
@@ -233,7 +259,7 @@ not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync
-not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
+not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -250,7 +276,7 @@ not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync different error
-not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
+not ok 22 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -270,10 +296,10 @@ not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different erro
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception › passes
-ok 22 - uncaught-exception [90m[2m›[22m[39m passes
+ok 23 - uncaught-exception [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 23 - Error: Can’t catch me
+not ok 24 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -281,16 +307,16 @@ not ok 23 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception.js exited with a non-zero exit code: 1
-not ok 24 - uncaught-exception.js exited with a non-zero exit code: 1
+not ok 25 - uncaught-exception.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
 # unhandled-rejection › passes
-ok 25 - unhandled-rejection [90m[2m›[22m[39m passes
+ok 26 - unhandled-rejection [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # unhandled-rejection › unhandled non-error rejection
-ok 26 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
+ok 27 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 27 - Error: Can’t catch me
+not ok 28 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -300,17 +326,17 @@ not ok 27 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # unhandled-rejection
-not ok 28 - unhandled-rejection
+not ok 29 - unhandled-rejection
   ---
     message: Non-error object
     formatted: 'null'
   ...
 ---tty-stream-chunk-separator
 
-1..22
-# tests 21
+1..23
+# tests 22
 # pass 6
 # skip 1
-# fail 21
+# fail 22
 
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/tap.regular.v12.log
+++ b/test-tap/reporters/tap.regular.v12.log
@@ -11,6 +11,30 @@ not ok 1 - TypeError: test.serial.test is not a function
 # bad-test-chain.js exited with a non-zero exit code: 1
 not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
+# nested-objects › format with max depth 4
+not ok 3 - nested-objects [90m[2m›[22m[39m format with max depth 4
+  ---
+    name: AssertionError
+    assertion: deepEqual
+    values:
+      'Difference:': |2-
+          {
+            a: {
+              b: {
+                foo: 'bar',
+              },
+            },
+        +   c: {
+        +     d: {
+        +       e: {
+        +         foo: 'bar',
+        +       },
+        +     },
+        +   },
+          }
+    at: 'test-tap/fixture/report/regular/nested-objects.js:28:4'
+  ...
+---tty-stream-chunk-separator
 # output-in-hook › before hook
 ---tty-stream-chunk-separator
 # output-in-hook › before hook
@@ -26,10 +50,10 @@ not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
   # beforeEach
 ---tty-stream-chunk-separator
 # output-in-hook › passing test
-ok 3 - output-in-hook [90m[2m›[22m[39m passing test
+ok 4 - output-in-hook [90m[2m›[22m[39m passing test
 ---tty-stream-chunk-separator
 # output-in-hook › failing test
-not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
+not ok 5 - output-in-hook [90m[2m›[22m[39m failing test
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -54,16 +78,16 @@ not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
   # afterAlways
 ---tty-stream-chunk-separator
 # test › skip
-ok 5 - test [90m[2m›[22m[39m skip # SKIP
+ok 6 - test [90m[2m›[22m[39m skip # SKIP
 ---tty-stream-chunk-separator
 # test › todo
-not ok 6 - test [90m[2m›[22m[39m todo # TODO
+not ok 7 - test [90m[2m›[22m[39m todo # TODO
 ---tty-stream-chunk-separator
 # test › passes
-ok 7 - test [90m[2m›[22m[39m passes
+ok 8 - test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # test › fails
-not ok 8 - test [90m[2m›[22m[39m fails
+not ok 9 - test [90m[2m›[22m[39m fails
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -72,10 +96,10 @@ not ok 8 - test [90m[2m›[22m[39m fails
   ...
 ---tty-stream-chunk-separator
 # test › known failure
-ok 9 - test [90m[2m›[22m[39m known failure
+ok 10 - test [90m[2m›[22m[39m known failure
 ---tty-stream-chunk-separator
 # test › no longer failing
-not ok 10 - test [90m[2m›[22m[39m no longer failing
+not ok 11 - test [90m[2m›[22m[39m no longer failing
   ---
     name: Error
     message: >-
@@ -85,7 +109,7 @@ not ok 10 - test [90m[2m›[22m[39m no longer failing
   ...
 ---tty-stream-chunk-separator
 # test › logs
-not ok 11 - test [90m[2m›[22m[39m logs
+not ok 12 - test [90m[2m›[22m[39m logs
   * hello
   * world
   ---
@@ -96,7 +120,7 @@ not ok 11 - test [90m[2m›[22m[39m logs
   ...
 ---tty-stream-chunk-separator
 # test › formatted
-not ok 12 - test [90m[2m›[22m[39m formatted
+not ok 13 - test [90m[2m›[22m[39m formatted
   ---
     name: AssertionError
     assertion: deepEqual
@@ -108,7 +132,7 @@ not ok 12 - test [90m[2m›[22m[39m formatted
   ...
 ---tty-stream-chunk-separator
 # test › power-assert
-not ok 13 - test [90m[2m›[22m[39m power-assert
+not ok 14 - test [90m[2m›[22m[39m power-assert
   ---
     name: AssertionError
     assertion: assert
@@ -119,7 +143,7 @@ not ok 13 - test [90m[2m›[22m[39m power-assert
   ...
 ---tty-stream-chunk-separator
 # test › bad throws
-not ok 14 - test [90m[2m›[22m[39m bad throws
+not ok 15 - test [90m[2m›[22m[39m bad throws
   ---
     name: AssertionError
     message: Improper usage of `t.throws()` detected
@@ -135,7 +159,7 @@ not ok 14 - test [90m[2m›[22m[39m bad throws
   ...
 ---tty-stream-chunk-separator
 # test › bad notThrows
-not ok 15 - test [90m[2m›[22m[39m bad notThrows
+not ok 16 - test [90m[2m›[22m[39m bad notThrows
   ---
     name: AssertionError
     message: Improper usage of `t.notThrows()` detected
@@ -151,7 +175,7 @@ not ok 15 - test [90m[2m›[22m[39m bad notThrows
   ...
 ---tty-stream-chunk-separator
 # test › implementation throws non-error
-not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
+not ok 17 - test [90m[2m›[22m[39m implementation throws non-error
   ---
     name: AssertionError
     message: Error thrown in test
@@ -161,7 +185,7 @@ not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throws
-not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
+not ok 18 - traces-in-t-throws [90m[2m›[22m[39m throws
   ---
     name: AssertionError
     assertion: throws
@@ -178,7 +202,7 @@ not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrows
-not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
+not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ---
     name: AssertionError
     assertion: notThrows
@@ -194,7 +218,7 @@ not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrowsAsync
-not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
+not ok 20 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ---
     name: AssertionError
     assertion: notThrowsAsync
@@ -210,7 +234,7 @@ not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync
-not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
+not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -229,7 +253,7 @@ not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync different error
-not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
+not ok 22 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -247,10 +271,10 @@ not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different erro
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception › passes
-ok 22 - uncaught-exception [90m[2m›[22m[39m passes
+ok 23 - uncaught-exception [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 23 - Error: Can’t catch me
+not ok 24 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -261,16 +285,16 @@ not ok 23 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception.js exited with a non-zero exit code: 1
-not ok 24 - uncaught-exception.js exited with a non-zero exit code: 1
+not ok 25 - uncaught-exception.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
 # unhandled-rejection › passes
-ok 25 - unhandled-rejection [90m[2m›[22m[39m passes
+ok 26 - unhandled-rejection [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # unhandled-rejection › unhandled non-error rejection
-ok 26 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
+ok 27 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 27 - Error: Can’t catch me
+not ok 28 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -278,17 +302,17 @@ not ok 27 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # unhandled-rejection
-not ok 28 - unhandled-rejection
+not ok 29 - unhandled-rejection
   ---
     message: Non-error object
     formatted: 'null'
   ...
 ---tty-stream-chunk-separator
 
-1..22
-# tests 21
+1..23
+# tests 22
 # pass 6
 # skip 1
-# fail 21
+# fail 22
 
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/tap.regular.v13.log
+++ b/test-tap/reporters/tap.regular.v13.log
@@ -11,6 +11,30 @@ not ok 1 - TypeError: test.serial.test is not a function
 # bad-test-chain.js exited with a non-zero exit code: 1
 not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
+# nested-objects › format with max depth 4
+not ok 3 - nested-objects [90m[2m›[22m[39m format with max depth 4
+  ---
+    name: AssertionError
+    assertion: deepEqual
+    values:
+      'Difference:': |2-
+          {
+            a: {
+              b: {
+                foo: 'bar',
+              },
+            },
+        +   c: {
+        +     d: {
+        +       e: {
+        +         foo: 'bar',
+        +       },
+        +     },
+        +   },
+          }
+    at: 'test-tap/fixture/report/regular/nested-objects.js:28:4'
+  ...
+---tty-stream-chunk-separator
 # output-in-hook › before hook
 ---tty-stream-chunk-separator
 # output-in-hook › before hook
@@ -26,10 +50,10 @@ not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
   # beforeEach
 ---tty-stream-chunk-separator
 # output-in-hook › passing test
-ok 3 - output-in-hook [90m[2m›[22m[39m passing test
+ok 4 - output-in-hook [90m[2m›[22m[39m passing test
 ---tty-stream-chunk-separator
 # output-in-hook › failing test
-not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
+not ok 5 - output-in-hook [90m[2m›[22m[39m failing test
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -54,16 +78,16 @@ not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
   # afterAlways
 ---tty-stream-chunk-separator
 # test › skip
-ok 5 - test [90m[2m›[22m[39m skip # SKIP
+ok 6 - test [90m[2m›[22m[39m skip # SKIP
 ---tty-stream-chunk-separator
 # test › todo
-not ok 6 - test [90m[2m›[22m[39m todo # TODO
+not ok 7 - test [90m[2m›[22m[39m todo # TODO
 ---tty-stream-chunk-separator
 # test › passes
-ok 7 - test [90m[2m›[22m[39m passes
+ok 8 - test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # test › fails
-not ok 8 - test [90m[2m›[22m[39m fails
+not ok 9 - test [90m[2m›[22m[39m fails
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -72,10 +96,10 @@ not ok 8 - test [90m[2m›[22m[39m fails
   ...
 ---tty-stream-chunk-separator
 # test › known failure
-ok 9 - test [90m[2m›[22m[39m known failure
+ok 10 - test [90m[2m›[22m[39m known failure
 ---tty-stream-chunk-separator
 # test › no longer failing
-not ok 10 - test [90m[2m›[22m[39m no longer failing
+not ok 11 - test [90m[2m›[22m[39m no longer failing
   ---
     name: Error
     message: >-
@@ -85,7 +109,7 @@ not ok 10 - test [90m[2m›[22m[39m no longer failing
   ...
 ---tty-stream-chunk-separator
 # test › logs
-not ok 11 - test [90m[2m›[22m[39m logs
+not ok 12 - test [90m[2m›[22m[39m logs
   * hello
   * world
   ---
@@ -96,7 +120,7 @@ not ok 11 - test [90m[2m›[22m[39m logs
   ...
 ---tty-stream-chunk-separator
 # test › formatted
-not ok 12 - test [90m[2m›[22m[39m formatted
+not ok 13 - test [90m[2m›[22m[39m formatted
   ---
     name: AssertionError
     assertion: deepEqual
@@ -108,7 +132,7 @@ not ok 12 - test [90m[2m›[22m[39m formatted
   ...
 ---tty-stream-chunk-separator
 # test › power-assert
-not ok 13 - test [90m[2m›[22m[39m power-assert
+not ok 14 - test [90m[2m›[22m[39m power-assert
   ---
     name: AssertionError
     assertion: assert
@@ -119,7 +143,7 @@ not ok 13 - test [90m[2m›[22m[39m power-assert
   ...
 ---tty-stream-chunk-separator
 # test › bad throws
-not ok 14 - test [90m[2m›[22m[39m bad throws
+not ok 15 - test [90m[2m›[22m[39m bad throws
   ---
     name: AssertionError
     message: Improper usage of `t.throws()` detected
@@ -135,7 +159,7 @@ not ok 14 - test [90m[2m›[22m[39m bad throws
   ...
 ---tty-stream-chunk-separator
 # test › bad notThrows
-not ok 15 - test [90m[2m›[22m[39m bad notThrows
+not ok 16 - test [90m[2m›[22m[39m bad notThrows
   ---
     name: AssertionError
     message: Improper usage of `t.notThrows()` detected
@@ -151,7 +175,7 @@ not ok 15 - test [90m[2m›[22m[39m bad notThrows
   ...
 ---tty-stream-chunk-separator
 # test › implementation throws non-error
-not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
+not ok 17 - test [90m[2m›[22m[39m implementation throws non-error
   ---
     name: AssertionError
     message: Error thrown in test
@@ -161,7 +185,7 @@ not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throws
-not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
+not ok 18 - traces-in-t-throws [90m[2m›[22m[39m throws
   ---
     name: AssertionError
     assertion: throws
@@ -178,7 +202,7 @@ not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrows
-not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
+not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ---
     name: AssertionError
     assertion: notThrows
@@ -194,7 +218,7 @@ not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrowsAsync
-not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
+not ok 20 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ---
     name: AssertionError
     assertion: notThrowsAsync
@@ -210,7 +234,7 @@ not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync
-not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
+not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -229,7 +253,7 @@ not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync different error
-not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
+not ok 22 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -247,10 +271,10 @@ not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different erro
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception › passes
-ok 22 - uncaught-exception [90m[2m›[22m[39m passes
+ok 23 - uncaught-exception [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 23 - Error: Can’t catch me
+not ok 24 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -261,16 +285,16 @@ not ok 23 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception.js exited with a non-zero exit code: 1
-not ok 24 - uncaught-exception.js exited with a non-zero exit code: 1
+not ok 25 - uncaught-exception.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
 # unhandled-rejection › passes
-ok 25 - unhandled-rejection [90m[2m›[22m[39m passes
+ok 26 - unhandled-rejection [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # unhandled-rejection › unhandled non-error rejection
-ok 26 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
+ok 27 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 27 - Error: Can’t catch me
+not ok 28 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -278,17 +302,17 @@ not ok 27 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # unhandled-rejection
-not ok 28 - unhandled-rejection
+not ok 29 - unhandled-rejection
   ---
     message: Non-error object
     formatted: 'null'
   ...
 ---tty-stream-chunk-separator
 
-1..22
-# tests 21
+1..23
+# tests 22
 # pass 6
 # skip 1
-# fail 21
+# fail 22
 
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/tap.regular.v14.log
+++ b/test-tap/reporters/tap.regular.v14.log
@@ -11,6 +11,30 @@ not ok 1 - TypeError: test.serial.test is not a function
 # bad-test-chain.js exited with a non-zero exit code: 1
 not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
+# nested-objects › format with max depth 4
+not ok 3 - nested-objects [90m[2m›[22m[39m format with max depth 4
+  ---
+    name: AssertionError
+    assertion: deepEqual
+    values:
+      'Difference:': |2-
+          {
+            a: {
+              b: {
+                foo: 'bar',
+              },
+            },
+        +   c: {
+        +     d: {
+        +       e: {
+        +         foo: 'bar',
+        +       },
+        +     },
+        +   },
+          }
+    at: 'test-tap/fixture/report/regular/nested-objects.js:28:4'
+  ...
+---tty-stream-chunk-separator
 # output-in-hook › before hook
 ---tty-stream-chunk-separator
 # output-in-hook › before hook
@@ -26,10 +50,10 @@ not ok 2 - bad-test-chain.js exited with a non-zero exit code: 1
   # beforeEach
 ---tty-stream-chunk-separator
 # output-in-hook › passing test
-ok 3 - output-in-hook [90m[2m›[22m[39m passing test
+ok 4 - output-in-hook [90m[2m›[22m[39m passing test
 ---tty-stream-chunk-separator
 # output-in-hook › failing test
-not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
+not ok 5 - output-in-hook [90m[2m›[22m[39m failing test
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -54,16 +78,16 @@ not ok 4 - output-in-hook [90m[2m›[22m[39m failing test
   # afterAlways
 ---tty-stream-chunk-separator
 # test › skip
-ok 5 - test [90m[2m›[22m[39m skip # SKIP
+ok 6 - test [90m[2m›[22m[39m skip # SKIP
 ---tty-stream-chunk-separator
 # test › todo
-not ok 6 - test [90m[2m›[22m[39m todo # TODO
+not ok 7 - test [90m[2m›[22m[39m todo # TODO
 ---tty-stream-chunk-separator
 # test › passes
-ok 7 - test [90m[2m›[22m[39m passes
+ok 8 - test [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # test › fails
-not ok 8 - test [90m[2m›[22m[39m fails
+not ok 9 - test [90m[2m›[22m[39m fails
   ---
     name: AssertionError
     message: Test failed via `t.fail()`
@@ -72,10 +96,10 @@ not ok 8 - test [90m[2m›[22m[39m fails
   ...
 ---tty-stream-chunk-separator
 # test › known failure
-ok 9 - test [90m[2m›[22m[39m known failure
+ok 10 - test [90m[2m›[22m[39m known failure
 ---tty-stream-chunk-separator
 # test › no longer failing
-not ok 10 - test [90m[2m›[22m[39m no longer failing
+not ok 11 - test [90m[2m›[22m[39m no longer failing
   ---
     name: Error
     message: >-
@@ -85,7 +109,7 @@ not ok 10 - test [90m[2m›[22m[39m no longer failing
   ...
 ---tty-stream-chunk-separator
 # test › logs
-not ok 11 - test [90m[2m›[22m[39m logs
+not ok 12 - test [90m[2m›[22m[39m logs
   * hello
   * world
   ---
@@ -96,7 +120,7 @@ not ok 11 - test [90m[2m›[22m[39m logs
   ...
 ---tty-stream-chunk-separator
 # test › formatted
-not ok 12 - test [90m[2m›[22m[39m formatted
+not ok 13 - test [90m[2m›[22m[39m formatted
   ---
     name: AssertionError
     assertion: deepEqual
@@ -108,7 +132,7 @@ not ok 12 - test [90m[2m›[22m[39m formatted
   ...
 ---tty-stream-chunk-separator
 # test › power-assert
-not ok 13 - test [90m[2m›[22m[39m power-assert
+not ok 14 - test [90m[2m›[22m[39m power-assert
   ---
     name: AssertionError
     assertion: assert
@@ -119,7 +143,7 @@ not ok 13 - test [90m[2m›[22m[39m power-assert
   ...
 ---tty-stream-chunk-separator
 # test › bad throws
-not ok 14 - test [90m[2m›[22m[39m bad throws
+not ok 15 - test [90m[2m›[22m[39m bad throws
   ---
     name: AssertionError
     message: Improper usage of `t.throws()` detected
@@ -135,7 +159,7 @@ not ok 14 - test [90m[2m›[22m[39m bad throws
   ...
 ---tty-stream-chunk-separator
 # test › bad notThrows
-not ok 15 - test [90m[2m›[22m[39m bad notThrows
+not ok 16 - test [90m[2m›[22m[39m bad notThrows
   ---
     name: AssertionError
     message: Improper usage of `t.notThrows()` detected
@@ -151,7 +175,7 @@ not ok 15 - test [90m[2m›[22m[39m bad notThrows
   ...
 ---tty-stream-chunk-separator
 # test › implementation throws non-error
-not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
+not ok 17 - test [90m[2m›[22m[39m implementation throws non-error
   ---
     name: AssertionError
     message: Error thrown in test
@@ -161,7 +185,7 @@ not ok 16 - test [90m[2m›[22m[39m implementation throws non-error
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throws
-not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
+not ok 18 - traces-in-t-throws [90m[2m›[22m[39m throws
   ---
     name: AssertionError
     assertion: throws
@@ -178,7 +202,7 @@ not ok 17 - traces-in-t-throws [90m[2m›[22m[39m throws
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrows
-not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
+not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ---
     name: AssertionError
     assertion: notThrows
@@ -194,7 +218,7 @@ not ok 18 - traces-in-t-throws [90m[2m›[22m[39m notThrows
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › notThrowsAsync
-not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
+not ok 20 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ---
     name: AssertionError
     assertion: notThrowsAsync
@@ -210,7 +234,7 @@ not ok 19 - traces-in-t-throws [90m[2m›[22m[39m notThrowsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync
-not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
+not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -229,7 +253,7 @@ not ok 20 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync
   ...
 ---tty-stream-chunk-separator
 # traces-in-t-throws › throwsAsync different error
-not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
+not ok 22 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different error
   ---
     name: AssertionError
     assertion: throwsAsync
@@ -247,10 +271,10 @@ not ok 21 - traces-in-t-throws [90m[2m›[22m[39m throwsAsync different erro
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception › passes
-ok 22 - uncaught-exception [90m[2m›[22m[39m passes
+ok 23 - uncaught-exception [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 23 - Error: Can’t catch me
+not ok 24 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -261,16 +285,16 @@ not ok 23 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception.js exited with a non-zero exit code: 1
-not ok 24 - uncaught-exception.js exited with a non-zero exit code: 1
+not ok 25 - uncaught-exception.js exited with a non-zero exit code: 1
 ---tty-stream-chunk-separator
 # unhandled-rejection › passes
-ok 25 - unhandled-rejection [90m[2m›[22m[39m passes
+ok 26 - unhandled-rejection [90m[2m›[22m[39m passes
 ---tty-stream-chunk-separator
 # unhandled-rejection › unhandled non-error rejection
-ok 26 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
+ok 27 - unhandled-rejection [90m[2m›[22m[39m unhandled non-error rejection
 ---tty-stream-chunk-separator
 # Error: Can’t catch me
-not ok 27 - Error: Can’t catch me
+not ok 28 - Error: Can’t catch me
   ---
     name: Error
     message: Can’t catch me
@@ -278,17 +302,17 @@ not ok 27 - Error: Can’t catch me
   ...
 ---tty-stream-chunk-separator
 # unhandled-rejection
-not ok 28 - unhandled-rejection
+not ok 29 - unhandled-rejection
   ---
     message: Non-error object
     formatted: 'null'
   ...
 ---tty-stream-chunk-separator
 
-1..22
-# tests 21
+1..23
+# tests 22
 # pass 6
 # skip 1
-# fail 21
+# fail 22
 
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/verbose.regular.v10.log
+++ b/test-tap/reporters/verbose.regular.v10.log
@@ -15,6 +15,8 @@
 ---tty-stream-chunk-separator
   [31m✖ bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
+  [31m✖[39m nested-objects [90m[2m›[22m[39m format with max depth 4 
+---tty-stream-chunk-separator
     output-in-hook [90m[2m›[22m[39m before hook
     [35mℹ[39m [90mbefore[39m
 ---tty-stream-chunk-separator
@@ -119,7 +121,7 @@
 
 ---tty-stream-chunk-separator
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -127,6 +129,36 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› t (test-tap/fixture/report/regular/nested-objects.js:28:4)[39m
+  [90m[2m› process._tickCallback (internal/process/next_tick.js:68:7)[22m[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 

--- a/test-tap/reporters/verbose.regular.v12.log
+++ b/test-tap/reporters/verbose.regular.v12.log
@@ -15,6 +15,8 @@
 ---tty-stream-chunk-separator
   [31m✖ bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
+  [31m✖[39m nested-objects [90m[2m›[22m[39m format with max depth 4 
+---tty-stream-chunk-separator
     output-in-hook [90m[2m›[22m[39m before hook
     [35mℹ[39m [90mbefore[39m
 ---tty-stream-chunk-separator
@@ -120,7 +122,7 @@
 
 ---tty-stream-chunk-separator
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -128,6 +130,35 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› test-tap/fixture/report/regular/nested-objects.js:28:4[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 

--- a/test-tap/reporters/verbose.regular.v13.log
+++ b/test-tap/reporters/verbose.regular.v13.log
@@ -15,6 +15,8 @@
 ---tty-stream-chunk-separator
   [31m✖ bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
+  [31m✖[39m nested-objects [90m[2m›[22m[39m format with max depth 4 
+---tty-stream-chunk-separator
     output-in-hook [90m[2m›[22m[39m before hook
     [35mℹ[39m [90mbefore[39m
 ---tty-stream-chunk-separator
@@ -120,7 +122,7 @@
 
 ---tty-stream-chunk-separator
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -128,6 +130,35 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› test-tap/fixture/report/regular/nested-objects.js:28:4[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 

--- a/test-tap/reporters/verbose.regular.v14.log
+++ b/test-tap/reporters/verbose.regular.v14.log
@@ -15,6 +15,8 @@
 ---tty-stream-chunk-separator
   [31m✖ bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
+  [31m✖[39m nested-objects [90m[2m›[22m[39m format with max depth 4 
+---tty-stream-chunk-separator
     output-in-hook [90m[2m›[22m[39m before hook
     [35mℹ[39m [90mbefore[39m
 ---tty-stream-chunk-separator
@@ -120,7 +122,7 @@
 
 ---tty-stream-chunk-separator
 
-  [31m14 tests failed[39m
+  [31m15 tests failed[39m
   [31m1 known failure[39m
   [33m1 test skipped[39m
   [34m1 test todo[39m
@@ -128,6 +130,35 @@
   [31m2 uncaught exceptions[39m
 
   [31mtest [90m[2m›[22m[39m[31m known failure[39m
+
+  [1mnested-objects [90m[2m›[22m[1m[39m format with max depth 4[22m
+
+  [90mnested-objects.js:28[39m
+
+   [90m27:[39m   };                    
+  [41m 28:   t.deepEqual(exp, act);[49m
+   [90m29:[39m });                     
+
+  Difference:
+
+    [90m{[39m
+      a: [90m{[39m
+        b: [90m{[39m
+          foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+        [90m}[39m[90m,[39m
+      [90m}[39m[90m,[39m
+  [32m+[39m   c: [90m{[39m
+  [32m+[39m     d: [90m{[39m
+  [32m+[39m       e: [90m{[39m
+  [32m+[39m         foo: [34m'[39m[34mbar[39m[34m'[39m[90m,[39m
+  [32m+[39m       [90m}[39m[90m,[39m
+  [32m+[39m     [90m}[39m[90m,[39m
+  [32m+[39m   [90m}[39m[90m,[39m
+    [90m}[39m
+
+  [90m› test-tap/fixture/report/regular/nested-objects.js:28:4[39m
+
+
 
   [1moutput-in-hook [90m[2m›[22m[1m[39m failing test[22m
 


### PR DESCRIPTION
The depth-limit for `t.deepEqual` was always set to 1. Fixed it.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1850: Object diffs are not always useful](https://issuehunt.io/repos/26820798/issues/1850)
---
</details>
<!-- /Issuehunt content-->