### PR TITLE
Add catch parameter to prevent error

### DIFF
--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -10,7 +10,7 @@ const supportsESM = async () => {
 	try {
 		await import('data:text/javascript,'); // eslint-disable-line node/no-unsupported-features/es-syntax
 		return true;
-	} catch {}
+	} catch (_) {}
 
 	return false;
 };


### PR DESCRIPTION
Hi!

I'm getting this error:

```javascript
/node_modules/ava/lib/worker/subprocess.js:13
	} catch {}
         ^

SyntaxError: Unexpected token
```
This error happens after running `nyc ava` with this config:

```json
...
  "ava": {
    "babel": true,
    "files": [
      "test/**/*.{spec,test}.js",
      "!**/node_modules/**",
      "!**/coverage/**",
      "!**/vendor/**"
    ],
    "ignoredByWatcher": [
      "**/*.{js,jsx}",
      "!dist/**/*",
      "!**/node_modules/**",
      "!**/coverage/**",
      "!**/vendor/**"
    ],
    "concurrency": 5,
    "failFast": true,
    "failWithoutAssertions": false,
    "tap": true,
    "verbose": true
  },
...
```

This is due to the missing catch parameter.
I fixed it by adding a simple `(_)`.

**node**: v13.5.0
**npm**: 6.13.6
