### PR TITLE
Revert "Use advanced serialization (when available) for test worker communication"

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -14,12 +14,6 @@ const AVA_PATH = path.resolve(__dirname, '..');
 
 const workerPath = require.resolve('./worker/subprocess');
 
-const useAdvanced = process.versions.node >= '12.16.0';
-// FIXME: Fix this in api.js or cli.js.
-const serializeOptions = useAdvanced ?
-	options => JSON.parse(JSON.stringify(options)) : // Use JSON serialization to remove non-clonable values.
-	options => options;
-
 module.exports = (file, options, execArgv = process.execArgv) => {
 	let finished = false;
 
@@ -40,8 +34,7 @@ module.exports = (file, options, execArgv = process.execArgv) => {
 		cwd: options.projectDir,
 		silent: true,
 		env: {NODE_ENV: 'test', ...process.env, ...options.environmentVariables, AVA_PATH},
-		execArgv,
-		serialization: useAdvanced ? 'advanced' : 'json'
+		execArgv
 	});
 
 	subprocess.stdout.on('data', chunk => {
@@ -73,7 +66,7 @@ module.exports = (file, options, execArgv = process.execArgv) => {
 			}
 
 			if (message.ava.type === 'ready-for-options') {
-				send({type: 'options', options: serializeOptions(options)});
+				send({type: 'options', options});
 				return;
 			}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -743,12 +743,12 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.5.0.tgz",
-			"integrity": "sha512-m4erZ8AkSjoIUOf8s4k2V1xdL2c1Vy0D3dN6/jC9d7+nEqjY3gxXCkgi3gW/GAxPaA4hV8biaCoTVdQmfAeTCQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.0.tgz",
+			"integrity": "sha512-ubHlHVt1lsPQB/CZdEov9XuOFhNG9YRC//kuiS1cMQI6Bs1SsqKrEmZnpgRwthGR09/kEDtr9MywlqXyyYd8GA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "3.5.0",
+				"@typescript-eslint/experimental-utils": "3.6.0",
 				"debug": "^4.1.1",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.0.0",
@@ -757,45 +757,45 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.5.0.tgz",
-			"integrity": "sha512-zGNOrVi5Wz0jcjUnFZ6QUD0MCox5hBuVwemGCew2qJzUX5xPoyR+0EzS5qD5qQXL/vnQ8Eu+nv03tpeFRwLrDg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.6.0.tgz",
+			"integrity": "sha512-4Vdf2hvYMUnTdkCNZu+yYlFtL2v+N2R7JOynIOkFbPjf9o9wQvRwRkzUdWlFd2YiiUwJLbuuLnl5civNg5ykOQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/types": "3.5.0",
-				"@typescript-eslint/typescript-estree": "3.5.0",
+				"@typescript-eslint/types": "3.6.0",
+				"@typescript-eslint/typescript-estree": "3.6.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.5.0.tgz",
-			"integrity": "sha512-sU07VbYB70WZHtgOjH/qfAp1+OwaWgrvD1Km1VXqRpcVxt971PMTU7gJtlrCje0M+Sdz7xKAbtiyIu+Y6QdnVA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.6.0.tgz",
+			"integrity": "sha512-taghDxuLhbDAD1U5Fk8vF+MnR0yiFE9Z3v2/bYScFb0N1I9SK8eKHkdJl1DAD48OGFDMFTeOTX0z7g0W6SYUXw==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "3.5.0",
-				"@typescript-eslint/types": "3.5.0",
-				"@typescript-eslint/typescript-estree": "3.5.0",
+				"@typescript-eslint/experimental-utils": "3.6.0",
+				"@typescript-eslint/types": "3.6.0",
+				"@typescript-eslint/typescript-estree": "3.6.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.5.0.tgz",
-			"integrity": "sha512-Dreqb5idi66VVs1QkbAwVeDmdJG+sDtofJtKwKCZXIaBsINuCN7Jv5eDIHrS0hFMMiOvPH9UuOs4splW0iZe4Q==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.6.0.tgz",
+			"integrity": "sha512-JwVj74ohUSt0ZPG+LZ7hb95fW8DFOqBuR6gE7qzq55KDI3BepqsCtHfBIoa0+Xi1AI7fq5nCu2VQL8z4eYftqg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.5.0.tgz",
-			"integrity": "sha512-Na71ezI6QP5WVR4EHxwcBJgYiD+Sre9BZO5iJK2QhrmRPo/42+b0no/HZIrdD1sjghzlYv7t+7Jis05M1uMxQg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.6.0.tgz",
+			"integrity": "sha512-G57NDSABHjvob7zVV09ehWyD1K6/YUKjz5+AufObFyjNO4DVmKejj47MHjVHHlZZKgmpJD2yyH9lfCXHrPITFg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "3.5.0",
-				"@typescript-eslint/visitor-keys": "3.5.0",
+				"@typescript-eslint/types": "3.6.0",
+				"@typescript-eslint/visitor-keys": "3.6.0",
 				"debug": "^4.1.1",
 				"glob": "^7.1.6",
 				"is-glob": "^4.0.1",
@@ -805,9 +805,9 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.5.0.tgz",
-			"integrity": "sha512-7cTp9rcX2sz9Z+zua9MCOX4cqp5rYyFD5o8LlbSpXrMTXoRdngTtotRZEkm8+FNMHPWYFhitFK+qt/brK8BVJQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.6.0.tgz",
+			"integrity": "sha512-p1izllL2Ubwunite0ITjubuMQRBGgjdVYwyG7lXPX8GbrA6qF0uwSRz9MnXZaHMxID4948gX0Ez8v9tUDi/KfQ==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
@@ -2905,9 +2905,9 @@
 			}
 		},
 		"eslint-plugin-ava": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-10.3.1.tgz",
-			"integrity": "sha512-7akA13Nxaub7QGKaXvywVXlbr5fTdbziRhbVYCoQlsVHh10bDcqv4JRaScKaX1cCJF8w7U1Q6S2gQUSfV9Jneg==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-10.4.0.tgz",
+			"integrity": "sha512-pTjf5qbMETsx0NScFMjKH3Sfku+E9TQHTu9WzVpdfLrV9cYo2sIohGThQdJryL7WXJMoARhXJb2t+a7vtx3d+g==",
 			"dev": true,
 			"requires": {
 				"deep-strict-equal": "^0.2.0",

--- a/test/test-timeouts/fixtures/custom-message.js
+++ b/test/test-timeouts/fixtures/custom-message.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 
 test('timeout with custom message', async t => {
-	t.timeout(10, 'time budget exceeded'); // eslint-disable-line ava/assertion-arguments
+	t.timeout(10, 'time budget exceeded');
 	await new Promise(() => {});
 });

--- a/test/test-timeouts/fixtures/invalid-message.js
+++ b/test/test-timeouts/fixtures/invalid-message.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 
 test('timeout with invalid message', t => {
-	t.timeout(10, 20); // eslint-disable-line ava/assertion-arguments
+	t.timeout(10, 20);
 });
 


### PR DESCRIPTION
This reverts commit 51fafed989a1b0b9e384dc4c589f3453082dcde1.

We're seeing intermittent failures, see https://github.com/avajs/ava/issues/2535.
