### PR TITLE
Detect active inspectors; update VSCode debugging recipe

### DIFF
--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -34,12 +34,12 @@ Open the file(s) you want to debug. You can set breakpoints or use the `debugger
 
 Now, *with a test file open*, from the *Debug* menu run the *Debug AVA test file* configuration.
 
-## Debugging with the Debug Terminal
+## Debugging with the debug terminal
 
-You can use VS Code's "JavaScript Debug Terminal" to automatically debug Ava run on the command line.
+You can use VS Code's “JavaScript Debug Terminal” to automatically debug AVA run on the command-line.
 
-1. From the Command Pallete (F1, or Cmd/Ctrl+Shift+P), run `Debug: Create JavaScript Debug Terminal`
-1. Run `ava` in the terminal, or `npm run test`
+1. From the Command Palette (F1 or Cmd/Ctrl+Shift+P), run `Debug: Create JavaScript Debug Terminal`
+2. Run `ava` in the terminal or `npm run test`
 
 ## Debugging precompiled tests
 

--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -19,11 +19,8 @@ You can debug your tests using [Visual Studio Code](https://code.visualstudio.co
     "name": "Debug AVA test file",
     "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/ava",
     "runtimeArgs": [
-      "debug",
-      "--break",
       "${file}"
     ],
-    "port": 9229,
     "outputCapture": "std",
     "skipFiles": [
       "<node_internals>/**/*.js"
@@ -36,6 +33,13 @@ You can debug your tests using [Visual Studio Code](https://code.visualstudio.co
 Open the file(s) you want to debug. You can set breakpoints or use the `debugger` keyword.
 
 Now, *with a test file open*, from the *Debug* menu run the *Debug AVA test file* configuration.
+
+## Debugging with the Debug Terminal
+
+You can use VS Code's "JavaScript Debug Terminal" to automatically debug Ava run on the command line.
+
+1. From the Command Pallete (F1, or Cmd/Ctrl+Shift+P), run `Debug: Create JavaScript Debug Terminal`
+1. Run `ava` in the terminal, or `npm run test`
 
 ## Debugging precompiled tests
 
@@ -51,11 +55,8 @@ Assuming the names of your test files are unique you could try the following con
   "name": "Debug AVA test file",
   "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/ava",
   "runtimeArgs": [
-    "debug",
-    "--break",
     "build/**/${fileBasenameNoExtension}.*"
   ],
-  "port": 9229,
   "outputCapture": "std",
   "skipFiles": [
     "<node_internals>/**/*.js"
@@ -74,12 +75,9 @@ By default AVA runs tests concurrently. This may complicate debugging. Add a con
   "name": "Debug AVA test file",
   "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/ava",
   "runtimeArgs": [
-    "debug",
-    "--break",
     "--serial",
     "${file}"
   ],
-  "port": 9229,
   "outputCapture": "std",
   "skipFiles": [
     "<node_internals>/**/*.js"

--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -4,7 +4,16 @@ Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/do
 
 You can debug your tests using [Visual Studio Code](https://code.visualstudio.com/).
 
+## Debugging with the debug terminal
+
+You can use VS Code's “JavaScript Debug Terminal” to automatically debug AVA run on the command-line.
+
+1. From the Command Palette (<kbd>F1</kbd> or <kbd>command + shift + p</kbd> / <kbd>control + shift + p</kbd>), run `Debug: Create JavaScript Debug Terminal`
+2. Run `npx ava` in the terminal
+
 ## Creating a launch configuration
+
+Alternatively you can create a lanch configuration, which makes it easier to debug individual test files.
 
 1. Open a workspace for your project.
 1. In the sidebar click the *Debug* handle.
@@ -28,20 +37,13 @@ You can debug your tests using [Visual Studio Code](https://code.visualstudio.co
   }
   ```
 
-## Using the debugger
+### Using the debugger
 
 Open the file(s) you want to debug. You can set breakpoints or use the `debugger` keyword.
 
 Now, *with a test file open*, from the *Debug* menu run the *Debug AVA test file* configuration.
 
-## Debugging with the debug terminal
-
-You can use VS Code's “JavaScript Debug Terminal” to automatically debug AVA run on the command-line.
-
-1. From the Command Palette (F1 or Cmd/Ctrl+Shift+P), run `Debug: Create JavaScript Debug Terminal`
-2. Run `ava` in the terminal or `npm run test`
-
-## Debugging precompiled tests
+### Debugging precompiled tests
 
 If you compile your test files into a different directory, and run the tests *from* that directory, the above configuration won't work.
 
@@ -66,7 +68,13 @@ Assuming the names of your test files are unique you could try the following con
 
 ## Serial debugging
 
-By default AVA runs tests concurrently. This may complicate debugging. Add a configuration with the `--serial` argument so AVA runs only one test at a time:
+By default AVA runs tests concurrently. This may complicate debugging. Instead make sure AVA runs only one test at a time.
+
+*Note that, if your tests aren't properly isolated, certain test failures may not appear when running the tests serially.*
+
+If you use the debug terminal make sure to invoke AVA with `npx ava --serial`.
+
+Or, if you're using a launch configuration, add the `--serial` argument:
 
 ```json
 {
@@ -84,5 +92,3 @@ By default AVA runs tests concurrently. This may complicate debugging. Add a con
   ]
 }
 ```
-
-*Note that, if your tests aren't properly isolated, certain test failures may not appear when running the tests serially.*

--- a/lib/api.js
+++ b/lib/api.js
@@ -147,7 +147,7 @@ class Api extends Emittery {
 				runStatus = new RunStatus(selectedFiles.length, null);
 			}
 
-			const debugWithoutSpecificFile = Boolean(this.options.debug) && !this.options.debug.vscode && selectedFiles.length !== 1;
+			const debugWithoutSpecificFile = Boolean(this.options.debug) && !this.options.debug.active && selectedFiles.length !== 1;
 
 			await this.emit('run', {
 				bailWithoutReporting: debugWithoutSpecificFile,

--- a/lib/api.js
+++ b/lib/api.js
@@ -147,7 +147,7 @@ class Api extends Emittery {
 				runStatus = new RunStatus(selectedFiles.length, null);
 			}
 
-			const debugWithoutSpecificFile = Boolean(this.options.debug) && selectedFiles.length !== 1;
+			const debugWithoutSpecificFile = Boolean(this.options.debug) && !this.options.debug.vscode && selectedFiles.length !== 1;
 
 			await this.emit('run', {
 				bailWithoutReporting: debugWithoutSpecificFile,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -151,7 +151,8 @@ exports.run = async () => { // eslint-disable-line complexity
 					break: argv.break === true,
 					files: argv.pattern,
 					host: argv.host,
-					port: argv.port
+					port: argv.port,
+					vscode: Boolean(process.env.VSCODE_INSPECTOR_OPTIONS)
 				};
 			})
 		.command(
@@ -195,6 +196,16 @@ exports.run = async () => { // eslint-disable-line complexity
 	}
 
 	updateNotifier({pkg: require('../package.json')}).notify();
+
+	if (debug === null && Boolean(process.env.VSCODE_INSPECTOR_OPTIONS)) {
+		debug = {
+			break: false,
+			files: argv.pattern || [],
+			host: undefined,
+			port: undefined,
+			vscode: true
+		};
+	}
 
 	const {nonSemVerExperiments: experiments, projectDir} = conf;
 	if (resetCache) {
@@ -444,14 +455,14 @@ exports.run = async () => { // eslint-disable-line complexity
 	} else {
 		let debugWithoutSpecificFile = false;
 		api.on('run', plan => {
-			if (plan.debug && plan.files.length !== 1) {
+			if (debug !== null && plan.files.length !== 1) {
 				debugWithoutSpecificFile = true;
 			}
 		});
 
 		const runStatus = await api.run({filter});
 
-		if (debugWithoutSpecificFile) {
+		if (debugWithoutSpecificFile && !debug.vscode) {
 			exit('Provide the path to the test file you wish to debug');
 			return;
 		}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -88,7 +88,19 @@ exports.run = async () => { // eslint-disable-line complexity
 		confError = error;
 	}
 
-	let debug = null;
+	// Enter debug mode if the main process is being inspected. This assumes the
+	// worker processes are automatically inspected, too. It is not necessary to
+	// run AVA with the debug command, though it's allowed.
+	const activeInspector = require('inspector').url() !== undefined; // eslint-disable-line node/no-unsupported-features/node-builtins
+	let debug = activeInspector ?
+		{
+			active: true,
+			break: false,
+			files: [],
+			host: undefined,
+			port: undefined
+		} : null;
+
 	let resetCache = false;
 	const {argv} = yargs
 		.parserConfiguration({
@@ -122,7 +134,11 @@ exports.run = async () => { // eslint-disable-line complexity
 			array: true,
 			describe: 'Glob patterns to select what test files to run. Leave empty if you want AVA to run all test files instead. Add a colon and specify line numbers of specific tests to run',
 			type: 'string'
-		}))
+		}), argv => {
+			if (activeInspector) {
+				debug.files = argv.pattern || [];
+			}
+		})
 		.command(
 			'debug [<pattern>...]',
 			'Activate Node.js inspector and run a single test file',
@@ -148,11 +164,11 @@ exports.run = async () => { // eslint-disable-line complexity
 			}),
 			argv => {
 				debug = {
+					active: activeInspector,
 					break: argv.break === true,
 					files: argv.pattern,
 					host: argv.host,
-					port: argv.port,
-					vscode: Boolean(process.env.VSCODE_INSPECTOR_OPTIONS)
+					port: argv.port
 				};
 			})
 		.command(
@@ -196,16 +212,6 @@ exports.run = async () => { // eslint-disable-line complexity
 	}
 
 	updateNotifier({pkg: require('../package.json')}).notify();
-
-	if (debug === null && Boolean(process.env.VSCODE_INSPECTOR_OPTIONS)) {
-		debug = {
-			break: false,
-			files: argv.pattern || [],
-			host: undefined,
-			port: undefined,
-			vscode: true
-		};
-	}
 
 	const {nonSemVerExperiments: experiments, projectDir} = conf;
 	if (resetCache) {
@@ -462,7 +468,7 @@ exports.run = async () => { // eslint-disable-line complexity
 
 		const runStatus = await api.run({filter});
 
-		if (debugWithoutSpecificFile && !debug.vscode) {
+		if (debugWithoutSpecificFile && !debug.active) {
 			exit('Provide the path to the test file you wish to debug');
 			return;
 		}

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -205,7 +205,7 @@ ipc.options.then(async options => {
 		// to make sure we also track dependencies with custom require hooks
 		dependencyTracking.install(testPath);
 
-		if (options.debug) {
+		if (options.debug && options.debug.port !== undefined && options.debug.host !== undefined) {
 			require('inspector').open(options.debug.port, options.debug.host, true); // eslint-disable-line node/no-unsupported-features/node-builtins
 			if (options.debug.break) {
 				debugger; // eslint-disable-line no-debugger

--- a/lib/worker/subprocess.js
+++ b/lib/worker/subprocess.js
@@ -206,7 +206,13 @@ ipc.options.then(async options => {
 		dependencyTracking.install(testPath);
 
 		if (options.debug && options.debug.port !== undefined && options.debug.host !== undefined) {
-			require('inspector').open(options.debug.port, options.debug.host, true); // eslint-disable-line node/no-unsupported-features/node-builtins
+			// If an inspector was active when the main process started, and is
+			// already active for the worker process, do not open a new one.
+			const inspector = require('inspector'); // eslint-disable-line node/no-unsupported-features/node-builtins
+			if (!options.debug.active || inspector.url() === undefined) {
+				inspector.open(options.debug.port, options.debug.host, true);
+			}
+
 			if (options.debug.break) {
 				debugger; // eslint-disable-line no-debugger
 			}


### PR DESCRIPTION
VS Code has a new debugger which works differently than the old debugger. Some arguments in the launch config were no longer needed or caused issues, and I also added a method using the debug terminal for users more comfortable with that.

Fixes #2542