### PR TITLE
Fix reporter logs for Node.js 14

### DIFF
--- a/test-tap/reporters/mini.regular.v14.log
+++ b/test-tap/reporters/mini.regular.v14.log
@@ -504,8 +504,8 @@
   Error: Can’t catch me
 
   [90m› Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)[39m
-  [90m[2m› listOnTimeout (internal/timers.js:549:17)[22m[39m
-  [90m[2m› processTimers (internal/timers.js:492:7)[22m[39m
+  [90m[2m› listOnTimeout (internal/timers.js:551:17)[22m[39m
+  [90m[2m› processTimers (internal/timers.js:494:7)[22m[39m
 
 
 

--- a/test-tap/reporters/tap.regular.v14.log
+++ b/test-tap/reporters/tap.regular.v14.log
@@ -298,8 +298,8 @@ not ok 25 - Error: Can’t catch me
     message: Can’t catch me
     at: |-
       Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)
-      listOnTimeout (internal/timers.js:549:17)
-      processTimers (internal/timers.js:492:7)
+      listOnTimeout (internal/timers.js:551:17)
+      processTimers (internal/timers.js:494:7)
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception.js exited with a non-zero exit code: 1

--- a/test-tap/reporters/verbose.regular.v14.log
+++ b/test-tap/reporters/verbose.regular.v14.log
@@ -94,8 +94,8 @@
   Error: Can’t catch me
 
   [90m› Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)[39m
-  [90m[2m› listOnTimeout (internal/timers.js:549:17)[22m[39m
-  [90m[2m› processTimers (internal/timers.js:492:7)[22m[39m
+  [90m[2m› listOnTimeout (internal/timers.js:551:17)[22m[39m
+  [90m[2m› processTimers (internal/timers.js:494:7)[22m[39m
 
 ---tty-stream-chunk-separator
   [31m✖ uncaught-exception.js exited with a non-zero exit code: 1[39m


### PR DESCRIPTION
Clearly this isn't ideal but it gets tests passing for now.
