### PR TITLE
Use ESM syntax for ESM example

### DIFF
--- a/docs/recipes/es-modules.md
+++ b/docs/recipes/es-modules.md
@@ -65,8 +65,8 @@ export default function sum(a, b) {
 
 ```js
 // test.js
-const test = require('ava');
-const sum = require('./sum');
+import test from 'ava';
+import sum from './sum';
 
 test('2 + 2 = 4', t => {
 	t.is(sum(2, 2), 4);


### PR DESCRIPTION
The ES modules example uses the "require()" syntax for the `test.js` file. This changes to use ES Module "import from ..." syntax in `test.js` example.