### PR TITLE
Update enzyme recipe to work with latest enzyme

### DIFF
--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -26,22 +26,58 @@ You can find more information in [`@ava/babel`](https://github.com/avajs/babel).
 
 ## Using [Enzyme](https://github.com/airbnb/enzyme)
 
-Let's first see how to use AVA with one of the most popular React testing libraries: [Enzyme](https://github.com/airbnb/enzyme).
+Let's first see how to use AVA with one of the most popular React testing libraries: [Enzyme](https://github.com/enzymejs/enzyme).
 
 If you intend to only use [shallow component rendering](https://facebook.github.io/react/docs/test-utils.html#shallow-rendering), you don't need any extra setup.
 
-First install [Enzyme required packages](https://github.com/airbnb/enzyme/#installation):
+### Install enzyme
+
+First install [Enzyme required packages](https://github.com/enzymejs/enzyme#installation):
 
 ```console
-$ npm install --save-dev enzyme react-addons-test-utils react-dom
+$ npm install --save-dev enzyme enzyme-adapter-react-16
 ```
 
+### Setup enzyme
+
+Create a helper file, prefixed with an underscore. This ensures AVA does not treat it as a test.
+
+`test/_setup-enzyme-adapter.js`:
+
+```js
+const Enzyme = require('enzyme');
+const Adapter = require('enzyme-adapter-react-16');
+
+Enzyme.configure({ adapter: new Adapter() });
+```
+
+### Configure tests to use enzyme
+
+Configure AVA to `require` the helper before every test file.
+
+**`package.json`:**
+
+```json
+{
+	"ava": {
+		"require": [
+			"./test/_setup-enzyme-adapter.js"
+		]
+	}
+}
+```
+
+### Enjoy
+
 Then you can use Enzyme straight away:
+
+`test.js`:
 
 ```js
 const test = require('ava');
 const React = require('react');
-const {shallow} = require('enzyme');
+const PropTypes = require('prop-types');
+const { shallow } = require('enzyme');
 
 const Foo = ({children}) =>
 	<div className="Foo">
@@ -51,7 +87,7 @@ const Foo = ({children}) =>
 	</div>;
 
 Foo.propTypes = {
-	children: React.PropTypes.any
+	children: PropTypes.any
 };
 
 test('has a .Foo class name', t => {
@@ -93,6 +129,7 @@ Usage example:
 ```js
 const test = require('ava');
 const React = require('react');
+const PropTypes = require('prop-types');
 const {renderJSX, JSX} = require('jsx-test-helpers');
 
 const Foo = ({children}) =>
@@ -103,7 +140,7 @@ const Foo = ({children}) =>
 	</div>;
 
 Foo.propTypes = {
-	children: React.PropTypes.any
+	children: PropTypes.any
 };
 
 test('renders correct markup', t => {

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -30,15 +30,15 @@ Let's first see how to use AVA with one of the most popular React testing librar
 
 If you intend to only use [shallow component rendering](https://facebook.github.io/react/docs/test-utils.html#shallow-rendering), you don't need any extra setup.
 
-### Install enzyme
+### Install Enzyme
 
-First install [Enzyme required packages](https://github.com/enzymejs/enzyme#installation):
+First install [Enzyme and its required adapter](https://github.com/enzymejs/enzyme#installation):
 
 ```console
 $ npm install --save-dev enzyme enzyme-adapter-react-16
 ```
 
-### Setup enzyme
+### Set up Enzyme
 
 Create a helper file, prefixed with an underscore. This ensures AVA does not treat it as a test.
 
@@ -48,10 +48,12 @@ Create a helper file, prefixed with an underscore. This ensures AVA does not tre
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
-Enzyme.configure({ adapter: new Adapter() });
+Enzyme.configure({
+	adapter: new Adapter()
+});
 ```
 
-### Configure tests to use enzyme
+### Configure tests to use Enzyme
 
 Configure AVA to `require` the helper before every test file.
 
@@ -77,7 +79,7 @@ Then you can use Enzyme straight away:
 const test = require('ava');
 const React = require('react');
 const PropTypes = require('prop-types');
-const { shallow } = require('enzyme');
+const {shallow} = require('enzyme');
 
 const Foo = ({children}) =>
 	<div className="Foo">


### PR DESCRIPTION
React's enzyme recipe was updated to work with latest react (v16) and enzyme (v2) versions. I made the following assumptions:

- React is already configured in the project, therefore no instructions to add `react`, `react-dom` and `prop-types` packages were added
- Used the [browser testing recipe](https://github.com/avajs/ava/blob/master/docs/recipes/browser-testing.md) structure to guide the user through the configuration process.

Let me know if additional changes are required.

Solves #2522