### PR TITLE
Make `t.passed` usable in tests and teardown functions

### DIFF
--- a/docs/02-execution-context.md
+++ b/docs/02-execution-context.md
@@ -24,7 +24,7 @@ Contains shared state from hooks.
 
 ## `t.passed`
 
-Whether a test has passed. This value is only accurate in the `test.afterEach()` and `test.afterEach.always()` hooks.
+When used in `test.afterEach()` or `test.afterEach.always()` hooks this tells you whether the test has passed. When used in a test itself (including teardown functions) this remains `true` until an assertion fails, the test has ended with an error, or a teardown function caused an error. This value has no meaning in other hooks.
 
 ## `t.end()`
 
@@ -36,7 +36,7 @@ Log values contextually alongside the test result instead of immediately printin
 
 ## `t.plan(count)`
 
-Plan how many assertion there are in the test. The test will fail if the actual assertion count doesn't match the number of planned assertions. See [assertion planning](./03-assertions.md#assertion-planning).
+Plan how many assertions there are in the test. The test will fail if the actual assertion count doesn't match the number of planned assertions. See [assertion planning](./03-assertions.md#assertion-planning).
 
 ## `t.teardown(fn)`
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -187,7 +187,8 @@ class ExecutionContext extends assert.Assertions {
 	}
 
 	get passed() {
-		return testMap.get(this).testPassed;
+		const test = testMap.get(this);
+		return test.isHook ? test.testPassed : !test.assertError;
 	}
 
 	_throwsArgStart(assertion, file, line) {

--- a/test-tap/test.js
+++ b/test-tap/test.js
@@ -956,3 +956,33 @@ test('.teardown() is bound', t => {
 		t.ok(teardownCallback.calledOnce);
 	});
 });
+
+test('t.passed value is true when teardown callback is executed for passing test', t => {
+	new Test({
+		fn(a) {
+			a.teardown(() => {
+				t.is(a.passed, true);
+				t.end();
+			});
+			a.pass();
+		},
+		metadata: {type: 'test'},
+		onResult() {},
+		title: 'foo'
+	}).run();
+});
+
+test('t.passed value is false when teardown callback is executed for failing test', t => {
+	new Test({
+		fn(a) {
+			a.teardown(() => {
+				t.is(a.passed, false);
+				t.end();
+			});
+			a.fail();
+		},
+		metadata: {type: 'test'},
+		onResult() {},
+		title: 'foo'
+	}).run();
+});


### PR DESCRIPTION
Set the `t.passed` value before teardowns callbacks are executed to enabled logic based on test result.
Fixes #2572 