### PR TITLE
Improve typings for `t.is` and `t.deepEqual`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -165,7 +165,7 @@ export interface IsAssertion {
 	 * Assert that `actual` is [the same
 	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
 	 */
-	<ValueType = any, ValueType_ extends ValueType>(actual: ValueType, expected: ValueType_, message?: string): void; // See #2575
+	<ValueType = any, ValueType_ extends ValueType = ValueType>(actual: ValueType, expected: ValueType_, message?: string): void; // See #2575
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -165,7 +165,7 @@ export interface IsAssertion {
 	 * Assert that `actual` is [the same
 	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
 	 */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	<ValueType = any, ValueType_ extends ValueType>(actual: ValueType, expected: ValueType_, message?: string): void; // See #2575
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ export interface AssertAssertion {
 
 export interface DeepEqualAssertion {
 	/** Assert that `actual` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	<ValueType = any, ValueType_ extends ValueType = ValueType>(actual: ValueType, expected: ValueType_, message?: string): void; // See #2575
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;
@@ -176,7 +176,7 @@ export interface NotAssertion {
 	 * Assert that `actual` is not [the same
 	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
 	 */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	<ValueType = any, ValueType_ extends ValueType = ValueType>(actual: ValueType, expected: ValueType_, message?: string): void; // See #2575
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;
@@ -184,7 +184,7 @@ export interface NotAssertion {
 
 export interface NotDeepEqualAssertion {
 	/** Assert that `actual` is not [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	<ValueType = any, ValueType_ extends ValueType = ValueType>(actual: ValueType, expected: ValueType_, message?: string): void; // See #2575
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;

--- a/test-d/is.ts
+++ b/test-d/is.ts
@@ -1,9 +1,0 @@
-import {expectError} from 'tsd';
-import {IsAssertion} from '..';
-
-declare const is: IsAssertion;
-
-declare function getLiteralStringUnion(): 'hello' | 'world';
-
-// See #2575 and https://github.com/microsoft/TypeScript/issues/40377
-expectError(is(getLiteralStringUnion(), 'another-string'));

--- a/test-d/is.ts
+++ b/test-d/is.ts
@@ -1,0 +1,9 @@
+import {expectError} from 'tsd';
+import {IsAssertion} from '..';
+
+declare const is: IsAssertion;
+
+declare function getLiteralStringUnion(): 'hello' | 'world';
+
+// See #2575 and https://github.com/microsoft/TypeScript/issues/40377
+expectError(is(getLiteralStringUnion(), 'another-string'));

--- a/test-d/regression-2575.ts
+++ b/test-d/regression-2575.ts
@@ -1,0 +1,16 @@
+import {expectError} from 'tsd';
+import {IsAssertion, NotAssertion, DeepEqualAssertion, NotDeepEqualAssertion} from '..';
+
+declare const is: IsAssertion;
+declare const not: NotAssertion;
+declare const deepEqual: DeepEqualAssertion;
+declare const notDeepEqual: NotDeepEqualAssertion;
+
+declare const literalStringUnionValue: 'hello' | 'world';
+declare const objectWithLiteralStringUnionValue: { foo: 'hello' | 'world' };
+
+// See #2575 and https://github.com/microsoft/TypeScript/issues/40377
+expectError(is(literalStringUnionValue, 'another-string'));
+expectError(not(literalStringUnionValue, 'another-string'));
+expectError(deepEqual(objectWithLiteralStringUnionValue, { foo: 'another-string' }));
+expectError(notDeepEqual(objectWithLiteralStringUnionValue, { foo: 'another-string' }));

--- a/test-d/regression-2575.ts
+++ b/test-d/regression-2575.ts
@@ -7,10 +7,10 @@ declare const deepEqual: DeepEqualAssertion;
 declare const notDeepEqual: NotDeepEqualAssertion;
 
 declare const literalStringUnionValue: 'hello' | 'world';
-declare const objectWithLiteralStringUnionValue: { foo: 'hello' | 'world' };
+declare const objectWithLiteralStringUnionValue: {foo: 'hello' | 'world'};
 
 // See #2575 and https://github.com/microsoft/TypeScript/issues/40377
 expectError(is(literalStringUnionValue, 'another-string'));
 expectError(not(literalStringUnionValue, 'another-string'));
-expectError(deepEqual(objectWithLiteralStringUnionValue, { foo: 'another-string' }));
-expectError(notDeepEqual(objectWithLiteralStringUnionValue, { foo: 'another-string' }));
+expectError(deepEqual(objectWithLiteralStringUnionValue, {foo: 'another-string'}));
+expectError(notDeepEqual(objectWithLiteralStringUnionValue, {foo: 'another-string'}));


### PR DESCRIPTION
This PR improves typings for `t.is`. I created a test to show the difference. In short, the code below will compile fine, while the typings should give an error.

```ts
declare function getLiteralStringUnion(): 'hello' | 'world';

test('foo', t => {
  t.is(getLiteralStringUnion(), 'another-string');
});
```

This is a "workaround" for https://github.com/microsoft/TypeScript/issues/40377 (although it is not settled whether it's really a bug or intended behavior).