### PR TITLE
Experimentally disable null expectations for throws assertions

### DIFF
--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -244,7 +244,7 @@ Assert that an error is thrown. `fn` must be a function which should throw. The 
 * `name`: the expected `.name` value of the thrown error
 * `code`: the expected `.code` value of the thrown error
 
-`expectation` does not need to be specified. If you don't need it but do want to set an assertion message you have to specify `null`.
+`expectation` does not need to be specified. If you don't need it but do want to set an assertion message you have to specify `undefined`. (AVA 3 also allows you to specify `null`. This will be removed in AVA 4. You can opt into this change early by enabling the `disableNullExpectations` experiment.)
 
 Example:
 
@@ -276,7 +276,7 @@ The thrown value *must* be an error. It is returned so you can run more assertio
 * `name`: the expected `.name` value of the thrown error
 * `code`: the expected `.code` value of the thrown error
 
-`expectation` does not need to be specified. If you don't need it but do want to set an assertion message you have to specify `null`.
+`expectation` does not need to be specified. If you don't need it but do want to set an assertion message you have to specify `undefined`. (AVA 3 also allows you to specify `null`. This will be removed in AVA 4. You can opt into this change early by enabling the `disableNullExpectations` experiment.)
 
 Example:
 

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -26,21 +26,59 @@ You can find more information in [`@ava/babel`](https://github.com/avajs/babel).
 
 ## Using [Enzyme](https://github.com/airbnb/enzyme)
 
-Let's first see how to use AVA with one of the most popular React testing libraries: [Enzyme](https://github.com/airbnb/enzyme).
+Let's first see how to use AVA with one of the most popular React testing libraries: [Enzyme](https://github.com/enzymejs/enzyme).
 
 If you intend to only use [shallow component rendering](https://facebook.github.io/react/docs/test-utils.html#shallow-rendering), you don't need any extra setup.
 
-First install [Enzyme required packages](https://github.com/airbnb/enzyme/#installation):
+### Install Enzyme
+
+First install [Enzyme and its required adapter](https://github.com/enzymejs/enzyme#installation):
 
 ```console
-$ npm install --save-dev enzyme react-addons-test-utils react-dom
+$ npm install --save-dev enzyme enzyme-adapter-react-16
 ```
 
+### Set up Enzyme
+
+Create a helper file, prefixed with an underscore. This ensures AVA does not treat it as a test.
+
+`test/_setup-enzyme-adapter.js`:
+
+```js
+const Enzyme = require('enzyme');
+const Adapter = require('enzyme-adapter-react-16');
+
+Enzyme.configure({
+	adapter: new Adapter()
+});
+```
+
+### Configure tests to use Enzyme
+
+Configure AVA to `require` the helper before every test file.
+
+**`package.json`:**
+
+```json
+{
+	"ava": {
+		"require": [
+			"./test/_setup-enzyme-adapter.js"
+		]
+	}
+}
+```
+
+### Enjoy
+
 Then you can use Enzyme straight away:
+
+`test.js`:
 
 ```js
 const test = require('ava');
 const React = require('react');
+const PropTypes = require('prop-types');
 const {shallow} = require('enzyme');
 
 const Foo = ({children}) =>
@@ -51,7 +89,7 @@ const Foo = ({children}) =>
 	</div>;
 
 Foo.propTypes = {
-	children: React.PropTypes.any
+	children: PropTypes.any
 };
 
 test('has a .Foo class name', t => {
@@ -93,6 +131,7 @@ Usage example:
 ```js
 const test = require('ava');
 const React = require('react');
+const PropTypes = require('prop-types');
 const {renderJSX, JSX} = require('jsx-test-helpers');
 
 const Foo = ({children}) =>
@@ -103,7 +142,7 @@ const Foo = ({children}) =>
 	</div>;
 
 Foo.propTypes = {
-	children: React.PropTypes.any
+	children: PropTypes.any
 };
 
 test('renders correct markup', t => {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -88,16 +88,16 @@ function getErrorWithLongStackTrace() {
 }
 
 function validateExpectations(assertion, expectations, numberArgs, experiments) { // eslint-disable-line complexity
-	// Expectations must not be null when disableNullExpectations is defined
-	const didntPassExpectation = numberArgs === 1;
-	const expectationIsNullOrUndefined = experiments.disableNullExpectations ?
-		expectations === undefined :
-		(expectations === undefined || expectations === null);
-
-	if (didntPassExpectation || expectationIsNullOrUndefined) {
+	if (numberArgs === 1 || expectations === null || expectations === undefined) {
+		if (experiments.disableNullExpectations && expectations === null) {
+			throw new AssertionError({
+				assertion,
+				message: `The second argument to \`t.${assertion}()\` must be an expectation object or \`undefined\``,
+				values: [formatWithLabel('Called with:', expectations)]
+			})
+		}
 		expectations = {};
 	} else if (
-		(experiments.disableNullExpectations && expectations === null) ||
 		typeof expectations === 'function' ||
 		typeof expectations === 'string' ||
 		expectations instanceof RegExp ||
@@ -105,11 +105,9 @@ function validateExpectations(assertion, expectations, numberArgs, experiments) 
 		Array.isArray(expectations) ||
 		Object.keys(expectations).length === 0
 	) {
-		const shouldIncludeNull = experiments.disableNullExpectations ? '' : ', `null`';
-
 		throw new AssertionError({
 			assertion,
-			message: `The second argument to \`t.${assertion}()\` must be an expectation object${shouldIncludeNull} or \`undefined\``,
+			message: `The second argument to \`t.${assertion}()\` must be an expectation object, \`null\` or \`undefined\``,
 			values: [formatWithLabel('Called with:', expectations)]
 		});
 	} else {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -94,8 +94,9 @@ function validateExpectations(assertion, expectations, numberArgs, experiments) 
 				assertion,
 				message: `The second argument to \`t.${assertion}()\` must be an expectation object or \`undefined\``,
 				values: [formatWithLabel('Called with:', expectations)]
-			})
+			});
 		}
+
 		expectations = {};
 	} else if (
 		typeof expectations === 'function' ||

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -87,10 +87,17 @@ function getErrorWithLongStackTrace() {
 	return err;
 }
 
-function validateExpectations(assertion, expectations, numberArgs) { // eslint-disable-line complexity
-	if (numberArgs === 1 || expectations === null || expectations === undefined) {
+function validateExpectations(assertion, expectations, numberArgs, experiments) { // eslint-disable-line complexity
+	// Expectations must not be null when disableNullExpectations is defined
+	const didntPassExpectation = numberArgs === 1;
+	const expectationIsNullOrUndefined = experiments.disableNullExpectations ?
+		expectations === undefined :
+		(expectations === undefined || expectations === null);
+
+	if (didntPassExpectation || expectationIsNullOrUndefined) {
 		expectations = {};
 	} else if (
+		(experiments.disableNullExpectations && expectations === null) ||
 		typeof expectations === 'function' ||
 		typeof expectations === 'string' ||
 		expectations instanceof RegExp ||
@@ -98,9 +105,11 @@ function validateExpectations(assertion, expectations, numberArgs) { // eslint-d
 		Array.isArray(expectations) ||
 		Object.keys(expectations).length === 0
 	) {
+		const shouldIncludeNull = experiments.disableNullExpectations ? '' : ', `null`';
+
 		throw new AssertionError({
 			assertion,
-			message: `The second argument to \`t.${assertion}()\` must be an expectation object, \`null\` or \`undefined\``,
+			message: `The second argument to \`t.${assertion}()\` must be an expectation object${shouldIncludeNull} or \`undefined\``,
 			values: [formatWithLabel('Called with:', expectations)]
 		});
 	} else {
@@ -465,7 +474,7 @@ class Assertions {
 			}
 
 			try {
-				expectations = validateExpectations('throws', expectations, args.length);
+				expectations = validateExpectations('throws', expectations, args.length, experiments);
 			} catch (error) {
 				fail(error);
 				return;
@@ -531,7 +540,7 @@ class Assertions {
 			}
 
 			try {
-				expectations = validateExpectations('throwsAsync', expectations, args.length);
+				expectations = validateExpectations('throwsAsync', expectations, args.length, experiments);
 			} catch (error) {
 				fail(error);
 				return Promise.resolve();

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -7,7 +7,7 @@ const pkgConf = require('pkg-conf');
 
 const NO_SUCH_FILE = Symbol('no ava.config.js file');
 const MISSING_DEFAULT_EXPORT = Symbol('missing default export');
-const EXPERIMENTS = new Set(['configurableModuleFormat', 'disableSnapshotsInHooks', 'reverseTeardowns']);
+const EXPERIMENTS = new Set(['configurableModuleFormat', 'disableSnapshotsInHooks', 'reverseTeardowns', 'disableNullExpectations']);
 
 // *Very* rudimentary support for loading ava.config.js files containing an `export default` statement.
 const evaluateJsConfig = configFile => {

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -14,7 +14,7 @@ const HelloMessage = require('./fixture/hello-message');
 let lastFailure = null;
 let lastPassed = false;
 
-const assertions = new class extends assert.Assertions {
+const AssertionsBase = class extends assert.Assertions {
 	constructor(overwrites = {}) {
 		super({
 			pass: () => {
@@ -35,7 +35,9 @@ const assertions = new class extends assert.Assertions {
 			...overwrites
 		});
 	}
-}();
+};
+
+const assertions = new AssertionsBase();
 
 function assertFailure(t, subset) {
 	if (!lastFailure) {
@@ -1469,6 +1471,34 @@ test('.throwsAsync() fails if passed a bad expectation', t => {
 		assertion: 'throwsAsync',
 		message: 'The second argument to `t.throwsAsync()` contains unexpected properties',
 		values: [{label: 'Called with:', formatted: /foo: null/}]
+	});
+
+	t.end();
+});
+
+test('.throws() fails if passed null expectation with disableNullExpectations', t => {
+	const asserter = new AssertionsBase({experiments: {disableNullExpectations: true}});
+
+	failsWith(t, () => {
+		asserter.throws(() => {}, null);
+	}, {
+		assertion: 'throws',
+		message: 'The second argument to `t.throws()` must be an expectation object or `undefined`',
+		values: [{label: 'Called with:', formatted: /null/}]
+	});
+
+	t.end();
+});
+
+test('.throwsAsync() fails if passed null expectation with disableNullExpectations', t => {
+	const asserter = new AssertionsBase({experiments: {disableNullExpectations: true}});
+
+	failsWith(t, () => {
+		asserter.throwsAsync(() => {}, null);
+	}, {
+		assertion: 'throwsAsync',
+		message: 'The second argument to `t.throwsAsync()` must be an expectation object or `undefined`',
+		values: [{label: 'Called with:', formatted: /null/}]
 	});
 
 	t.end();


### PR DESCRIPTION
Aims to fix https://github.com/avajs/ava/issues/2410