### PR TITLE
feat(watch): add on-change cli option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -75,6 +75,10 @@ const FLAGS = {
 		coerce: coerceLastValue,
 		description: 'Re-run tests when files change',
 		type: 'boolean'
+	},
+	'on-change': {
+		description: 'Extra command to run when files change',
+		type: 'string'
 	}
 };
 
@@ -457,7 +461,8 @@ exports.run = async () => { // eslint-disable-line complexity
 			globs,
 			projectDir,
 			providers,
-			reporter
+			reporter,
+			onChange: combined['on-change']
 		});
 		watcher.observeStdin(process.stdin);
 	} else {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -78,7 +78,7 @@ class TestDependency {
 }
 
 class Watcher {
-	constructor({api, filter = [], globs, projectDir, providers, reporter}) {
+	constructor({api, filter = [], globs, projectDir, providers, reporter, onChange}) {
 		this.debouncer = new Debouncer(this);
 
 		this.clearLogOnNextRun = true;
@@ -147,6 +147,20 @@ class Watcher {
 				.catch(rethrowAsync);
 		};
 
+		this.onChange = onChange && (event => {
+			try {
+				const output = require('child_process').execSync(onChange, {
+					env: {AVA_WATCH_EVENT: event, ...process.env}
+				});
+				if (output) {
+					reporter.lineWriter.writeLine(output.toString());
+				}
+			} catch {
+				reporter.endRun();
+				process.exit(1); // eslint-disable-line unicorn/no-process-exit
+			}
+		});
+
 		this.testDependencies = [];
 		this.trackTestDependencies(api);
 
@@ -172,6 +186,10 @@ class Watcher {
 		}).on('all', (event, path) => {
 			if (event === 'add' || event === 'change' || event === 'unlink') {
 				debug('Detected %s of %s', event, path);
+				if (this.onChange) {
+					this.onChange(event);
+				}
+
 				this.dirtyStates[nodePath.join(this.globs.cwd, path)] = event;
 				this.debouncer.debounce();
 			}


### PR DESCRIPTION
#1602 and #1366 described the use case for executing a piece of code before all tests. I have a similar use case where I need to wipe my test database each time the tests are run. This is more of a problem when AVA is in watch mode because I need to run my logic every time it detects a change. So I propose a CLI option to run a custom shell command every time the test are re-run.