### PR TITLE
Sanitize timers.js positions in reporter logs

### DIFF
--- a/test-tap/helper/report.js
+++ b/test-tap/helper/report.js
@@ -61,6 +61,7 @@ exports.sanitizers = {
 	experimentalWarning: string => string.replace(/^\(node:\d+\) ExperimentalWarning.+\n/g, ''),
 	lineEndings: string => replaceString(string, '\r\n', '\n'),
 	posix: string => replaceString(string, '\\', '/'),
+	timers: string => string.replace(/timers\.js:\d+:\d+/g, 'timers.js'),
 	version: string => replaceString(string, `v${pkg.version}`, 'v1.0.0-beta.5.1')
 };
 

--- a/test-tap/reporters/mini.js
+++ b/test-tap/reporters/mini.js
@@ -19,7 +19,7 @@ const run = (type, sanitizers = []) => t => {
 
 	const tty = new TTYStream({
 		columns: 200,
-		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix, report.sanitizers.version]
+		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix, report.sanitizers.timers, report.sanitizers.version]
 	});
 	const reporter = new Reporter({
 		projectDir: report.projectDir(type),

--- a/test-tap/reporters/mini.regular.v12.log
+++ b/test-tap/reporters/mini.regular.v12.log
@@ -504,8 +504,8 @@
   Error: Can’t catch me
 
   [90m› Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)[39m
-  [90m[2m› listOnTimeout (internal/timers.js:549:17)[22m[39m
-  [90m[2m› processTimers (internal/timers.js:492:7)[22m[39m
+  [90m[2m› listOnTimeout (internal/timers.js)[22m[39m
+  [90m[2m› processTimers (internal/timers.js)[22m[39m
 
 
 

--- a/test-tap/reporters/mini.regular.v14.log
+++ b/test-tap/reporters/mini.regular.v14.log
@@ -504,8 +504,8 @@
   Error: Can’t catch me
 
   [90m› Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)[39m
-  [90m[2m› listOnTimeout (internal/timers.js:551:17)[22m[39m
-  [90m[2m› processTimers (internal/timers.js:494:7)[22m[39m
+  [90m[2m› listOnTimeout (internal/timers.js)[22m[39m
+  [90m[2m› processTimers (internal/timers.js)[22m[39m
 
 
 

--- a/test-tap/reporters/tap.js
+++ b/test-tap/reporters/tap.js
@@ -14,7 +14,7 @@ const run = (type, sanitizers = []) => t => {
 
 	const tty = new TTYStream({
 		columns: 200,
-		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix]
+		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix, report.sanitizers.timers]
 	});
 	const reporter = new TapReporter({
 		projectDir: report.projectDir(type),

--- a/test-tap/reporters/tap.regular.v12.log
+++ b/test-tap/reporters/tap.regular.v12.log
@@ -298,8 +298,8 @@ not ok 25 - Error: Can’t catch me
     message: Can’t catch me
     at: |-
       Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)
-      listOnTimeout (internal/timers.js:549:17)
-      processTimers (internal/timers.js:492:7)
+      listOnTimeout (internal/timers.js)
+      processTimers (internal/timers.js)
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception.js exited with a non-zero exit code: 1

--- a/test-tap/reporters/tap.regular.v14.log
+++ b/test-tap/reporters/tap.regular.v14.log
@@ -298,8 +298,8 @@ not ok 25 - Error: Can’t catch me
     message: Can’t catch me
     at: |-
       Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)
-      listOnTimeout (internal/timers.js:551:17)
-      processTimers (internal/timers.js:494:7)
+      listOnTimeout (internal/timers.js)
+      processTimers (internal/timers.js)
   ...
 ---tty-stream-chunk-separator
 # uncaught-exception.js exited with a non-zero exit code: 1

--- a/test-tap/reporters/verbose.js
+++ b/test-tap/reporters/verbose.js
@@ -13,7 +13,7 @@ const run = (type, sanitizers = []) => t => {
 
 	const tty = new TTYStream({
 		columns: 200,
-		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix, report.sanitizers.version]
+		sanitizers: [...sanitizers, report.sanitizers.cwd, report.sanitizers.experimentalWarning, report.sanitizers.posix, report.sanitizers.timers, report.sanitizers.version]
 	});
 	const reporter = new Reporter({
 		projectDir: report.projectDir(type),

--- a/test-tap/reporters/verbose.regular.v12.log
+++ b/test-tap/reporters/verbose.regular.v12.log
@@ -94,8 +94,8 @@
   Error: Can’t catch me
 
   [90m› Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)[39m
-  [90m[2m› listOnTimeout (internal/timers.js:549:17)[22m[39m
-  [90m[2m› processTimers (internal/timers.js:492:7)[22m[39m
+  [90m[2m› listOnTimeout (internal/timers.js)[22m[39m
+  [90m[2m› processTimers (internal/timers.js)[22m[39m
 
 ---tty-stream-chunk-separator
   [31m✖ uncaught-exception.js exited with a non-zero exit code: 1[39m

--- a/test-tap/reporters/verbose.regular.v14.log
+++ b/test-tap/reporters/verbose.regular.v14.log
@@ -94,8 +94,8 @@
   Error: Can’t catch me
 
   [90m› Timeout._onTimeout (test-tap/fixture/report/regular/uncaught-exception.js:5:9)[39m
-  [90m[2m› listOnTimeout (internal/timers.js:551:17)[22m[39m
-  [90m[2m› processTimers (internal/timers.js:494:7)[22m[39m
+  [90m[2m› listOnTimeout (internal/timers.js)[22m[39m
+  [90m[2m› processTimers (internal/timers.js)[22m[39m
 
 ---tty-stream-chunk-separator
   [31m✖ uncaught-exception.js exited with a non-zero exit code: 1[39m


### PR DESCRIPTION
Fix test failures with Node.js 14.9.
