### PR TITLE
shared-workers: Don't warn when too many message listeners are added

### DIFF
--- a/lib/plugin-support/shared-workers.js
+++ b/lib/plugin-support/shared-workers.js
@@ -34,6 +34,8 @@ function launchWorker({filename, initialData}) {
 			initialData
 		}
 	});
+	worker.setMaxListeners(0);
+
 	const launched = {
 		statePromises: {
 			available: waitForAvailable(worker),


### PR DESCRIPTION
Each test process using the shared worker will add a listener. There could be more than 10 processes using the worker concurrently. Disable the standard listener limit since the warning it prints is irrelevant.
