### PR TITLE
Provide feedback when cli globs match no tests

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -120,11 +120,24 @@ class Api extends Emittery {
 				if (filter.length === 0) {
 					selectedFiles = testFiles;
 				} else {
+					const globPatterns = filter.map(({pattern}) => pattern);
 					selectedFiles = globs.applyTestFileFilter({
 						cwd: this.options.projectDir,
-						filter: filter.map(({pattern}) => pattern),
+						filter: globPatterns,
 						testFiles
 					});
+
+					if (selectedFiles.length === 0 && testFiles.length > 0) {
+						console.error(`${testFiles.length} files found based on configuration, but none matched glob pattern(s): ${globPatterns.join(', ')}`);
+						const matchingTypeScriptFiles = await globs.findTests({
+							cwd: this.options.projectDir,
+							extensions: ['ts'],
+							filePatterns: globPatterns
+						});
+						if (matchingTypeScriptFiles.length > 0) {
+							console.error(`\nGlob pattern matches ${matchingTypeScriptFiles.length} TypeScript file(s). To configure AVA to load TypeScript files, see https://github.com/avajs/ava/blob/master/docs/recipes/typescript.md`);
+						}
+					}
 				}
 			}
 		} catch (error) {


### PR DESCRIPTION
Addresses #2373 
This is the minimalist approach which outputs like this:
![image](https://user-images.githubusercontent.com/1486613/95638802-ee3dce00-0a63-11eb-91bf-8d3bdab59f01.png)

However if you'd prefer to keep api.js from outputting any messages directly, another option could be to emit a new event that is either handled in `cli.js` and printed using [`exit()`](https://github.com/avajs/ava/blob/master/lib/cli.js#L12), or that flows all the way through to the reporter and is printed somewhere around [here](https://github.com/avajs/ava/blob/master/lib/reporters/default.js#L667)