### PR TITLE
Make assertions return Booleans

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,40 +39,68 @@ export type SnapshotOptions = {
 };
 
 export interface Assertions {
-	/** Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy). Comes with power-assert. */
+	/**
+	 * Assert that `actual` is
+	 * [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy),
+	 * returning Boolean indicating whether the assertion passes. Comes with
+	 * power-assert.
+	 */
 	assert: AssertAssertion;
 
-	/** Assert that `actual` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
+	/**
+	 * Assert that `actual` is [deeply
+	 * equal](https://github.com/concordancejs/concordance#comparison-details) to
+	 * `expected`, returning Boolean indicating whether the assertion passes.
+	 */
 	deepEqual: DeepEqualAssertion;
 
-	/** Assert that `actual` is like `expected`. */
+	/**
+	 * Assert that `value` is like `selector`, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
 	like: LikeAssertion;
 
-	/** Fail the test. */
+	/** Fail the test, always returning `false`. */
 	fail: FailAssertion;
 
-	/** Assert that `actual` is strictly false. */
+	/**
+	 * Assert that `actual` is strictly false, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
 	false: FalseAssertion;
 
-	/** Assert that `actual` is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy). */
+	/**
+	 * Assert that `actual` is
+	 * [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy), returning
+	 * Boolean whether the assertion passes.
+	 */
 	falsy: FalsyAssertion;
 
 	/**
 	 * Assert that `actual` is [the same
-	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is)
+	 * as `expected`, returning Boolean indicating whether the assertion passes.
 	 */
 	is: IsAssertion;
 
 	/**
 	 * Assert that `actual` is not [the same
-	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is)
+	 * as `expected`, returning Boolean indicating whether the assertion passes.
 	 */
 	not: NotAssertion;
 
-	/** Assert that `actual` is not [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
+	/**
+	 * Assert that `actual` is not [deeply
+	 * equal](https://github.com/concordancejs/concordance#comparison-details) to
+	 * `expected`, returning Boolean indicating whether the assertion passes.
+	 */
 	notDeepEqual: NotDeepEqualAssertion;
 
-	/** Assert that `string` does not match the regular expression. */
+	/**
+	 * Assert that `string` does not match the regular expression, returning
+	 * Boolean indicating whether the assertion passes.
+	 */
 	notRegex: NotRegexAssertion;
 
 	/** Assert that the function does not throw. */
@@ -81,10 +109,13 @@ export interface Assertions {
 	/** Assert that the async function does not throw, or that the promise does not reject. Must be awaited. */
 	notThrowsAsync: NotThrowsAsyncAssertion;
 
-	/** Count a passing assertion. */
+	/** Count a passing assertion, always returning `true`. */
 	pass: PassAssertion;
 
-	/** Assert that `string` matches the regular expression. */
+	/**
+	 * Assert that `string` matches the regular expression, returning Boolean
+	 * indicating whether the assertion passes.
+	 */
 	regex: RegexAssertion;
 
 	/**
@@ -105,56 +136,82 @@ export interface Assertions {
 	 */
 	throwsAsync: ThrowsAsyncAssertion;
 
-	/** Assert that `actual` is strictly true. */
+	/**
+	 * Assert that `actual` is strictly true, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
 	true: TrueAssertion;
 
-	/** Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy). */
+	/**
+	 * Assert that `actual` is
+	 * [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy),
+	 * returning Boolean indicating whether the assertion passes.
+	 */
 	truthy: TruthyAssertion;
 }
 
 export interface AssertAssertion {
-	/** Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy). Comes with power-assert. */
-	(actual: any, message?: string): void;
+	/**
+	 * Assert that `actual` is
+	 * [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy),
+	 * returning Boolean indicating whether the assertion passes. Comes with
+	 * power-assert.
+	 */
+	(actual: any, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
 }
 
 export interface DeepEqualAssertion {
-	/** Assert that `actual` is [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	/**
+	 * Assert that `actual` is [deeply
+	 * equal](https://github.com/concordancejs/concordance#comparison-details) to
+	 * `expected`, returning Boolean indicating whether the assertion passes.
+	 */
+	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;
 }
 
 export interface LikeAssertion {
-	/** Assert that `value` is like `selector`. */
-	(value: any, selector: Record<string, any>, message?: string): void;
+	/**
+	 * Assert that `value` is like `selector`, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
+	(value: any, selector: Record<string, any>, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(value: any, selector: any, message?: string): void;
 }
 
 export interface FailAssertion {
-	/** Fail the test. */
-	(message?: string): void;
+	/** Fail the test, always returning `false`. */
+	(message?: string): false;
 
 	/** Skip this assertion. */
 	skip(message?: string): void;
 }
 
 export interface FalseAssertion {
-	/** Assert that `actual` is strictly false. */
-	(actual: any, message?: string): void;
+	/**
+	 * Assert that `actual` is strictly false, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
+	(actual: any, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
 }
 
 export interface FalsyAssertion {
-	/** Assert that `actual` is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy). */
-	(actual: any, message?: string): void;
+	/**
+	 * Assert that `actual` is
+	 * [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy), returning
+	 * Boolean whether the assertion passes.
+	 */
+	(actual: any, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
@@ -163,9 +220,10 @@ export interface FalsyAssertion {
 export interface IsAssertion {
 	/**
 	 * Assert that `actual` is [the same
-	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is)
+	 * as `expected`, returning Boolean indicating whether the assertion passes.
 	 */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;
@@ -174,25 +232,33 @@ export interface IsAssertion {
 export interface NotAssertion {
 	/**
 	 * Assert that `actual` is not [the same
-	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) as `expected`.
+	 * value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is)
+	 * as `expected`, returning Boolean indicating whether the assertion passes.
 	 */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;
 }
 
 export interface NotDeepEqualAssertion {
-	/** Assert that `actual` is not [deeply equal](https://github.com/concordancejs/concordance#comparison-details) to `expected`. */
-	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): void;
+	/**
+	 * Assert that `actual` is not [deeply
+	 * equal](https://github.com/concordancejs/concordance#comparison-details) to
+	 * `expected`, returning Boolean indicating whether the assertion passes.
+	 */
+	<ValueType = any>(actual: ValueType, expected: ValueType, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, expected: any, message?: string): void;
 }
 
 export interface NotRegexAssertion {
-	/** Assert that `string` does not match the regular expression. */
-	(string: string, regex: RegExp, message?: string): void;
+	/**
+	 * Assert that `string` does not match the regular expression, returning
+	 * Boolean indicating whether the assertion passes.
+	 */
+	(string: string, regex: RegExp, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(string: string, regex: RegExp, message?: string): void;
@@ -218,16 +284,19 @@ export interface NotThrowsAsyncAssertion {
 }
 
 export interface PassAssertion {
-	/** Count a passing assertion. */
-	(message?: string): void;
+	/** Count a passing assertion, always returning `true`. */
+	(message?: string): true;
 
 	/** Skip this assertion. */
 	skip(message?: string): void;
 }
 
 export interface RegexAssertion {
-	/** Assert that `string` matches the regular expression. */
-	(string: string, regex: RegExp, message?: string): void;
+	/**
+	 * Assert that `string` matches the regular expression, returning Boolean
+	 * indicating whether the assertion passes.
+	 */
+	(string: string, regex: RegExp, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(string: string, regex: RegExp, message?: string): void;
@@ -296,16 +365,23 @@ export interface ThrowsAsyncAssertion {
 }
 
 export interface TrueAssertion {
-	/** Assert that `actual` is strictly true. */
-	(actual: any, message?: string): void;
+	/**
+	 * Assert that `actual` is strictly true, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
+	(actual: any, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
 }
 
 export interface TruthyAssertion {
-	/** Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy). */
-	(actual: any, message?: string): void;
+	/**
+	 * Assert that `actual` is
+	 * [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy),
+	 * returning Boolean indicating whether the assertion passes.
+	 */
+	(actual: any, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
@@ -433,7 +509,7 @@ export interface CbExecutionContext<Context = unknown> extends ExecutionContext<
 	end(error?: any): void;
 }
 
-export type ImplementationResult = PromiseLike<void> | Subscribable | void;
+export type ImplementationResult = PromiseLike<void> | Subscribable | boolean | void;
 export type Implementation<Context = unknown> = (t: ExecutionContext<Context>) => ImplementationResult;
 export type CbImplementation<Context = unknown> = (t: CbExecutionContext<Context>) => ImplementationResult;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,10 +103,17 @@ export interface Assertions {
 	 */
 	notRegex: NotRegexAssertion;
 
-	/** Assert that the function does not throw. */
+	/**
+	 * Assert that the function does not throw, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
 	notThrows: NotThrowsAssertion;
 
-	/** Assert that the async function does not throw, or that the promise does not reject. Must be awaited. */
+	/**
+	 * Assert that the async function does not throw, or that the promise does
+	 * not reject, returning Boolean indicating whether the assertion passes. Must
+	 * be awaited.
+	 */
 	notThrowsAsync: NotThrowsAsyncAssertion;
 
 	/** Count a passing assertion, always returning `true`. */
@@ -265,19 +272,28 @@ export interface NotRegexAssertion {
 }
 
 export interface NotThrowsAssertion {
-	/** Assert that the function does not throw. */
-	(fn: () => any, message?: string): void;
+	/**
+	 * Assert that the function does not throw, returning Boolean indicating
+	 * whether the assertion passes.
+	 */
+	(fn: () => any, message?: string): boolean;
 
 	/** Skip this assertion. */
 	skip(fn: () => any, message?: string): void;
 }
 
 export interface NotThrowsAsyncAssertion {
-	/** Assert that the async function does not throw. You must await the result. */
-	(fn: () => PromiseLike<any>, message?: string): Promise<void>;
+	/**
+	 * Assert that the async function does not throw, returning Boolean
+	 * indicating whether the assertion passes. You must await the result.
+	 */
+	(fn: () => PromiseLike<any>, message?: string): Promise<boolean>;
 
-	/** Assert that the promise does not reject. You must await the result. */
-	(promise: PromiseLike<any>, message?: string): Promise<void>;
+	/**
+	 * Assert that the promise does not reject, returning Boolean indicating
+	 * whether the assertion passes. You must await the result.
+	 */
+	(promise: PromiseLike<any>, message?: string): Promise<boolean>;
 
 	/** Skip this assertion. */
 	skip(nonThrower: any, message?: string): void;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -269,6 +269,25 @@ class Assertions {
 		experiments = {},
 		disableSnapshots = false
 	} = {}) {
+		// We wrap the original `pass` and `fail` functions in variants that return
+		// their corresponding Boolean values so we can use them like `return
+		// fail(...)` in all our internal assertion definitions.
+		//
+		// We "override" the original values in this way to ensure that we don't
+		// accidentally end up calling the original non-Boolean-returning variants
+		// later in this method, erroneously expecting them to return Booleans.
+		const originalPass = pass;
+		pass = (...args) => {
+			originalPass(...args);
+			return true;
+		};
+
+		const originalFail = fail;
+		fail = (...args) => {
+			originalFail(...args);
+			return false;
+		};
+
 		const withSkip = assertionFn => {
 			assertionFn.skip = skip;
 			return assertionFn;
@@ -306,15 +325,15 @@ class Assertions {
 		};
 
 		this.pass = withSkip(() => {
-			pass();
+			return pass();
 		});
 
 		this.fail = withSkip(message => {
 			if (!checkMessage('fail', message)) {
-				return;
+				return false;
 			}
 
-			fail(new AssertionError({
+			return fail(new AssertionError({
 				assertion: 'fail',
 				message: message || 'Test failed via `t.fail()`'
 			}));
@@ -322,103 +341,102 @@ class Assertions {
 
 		this.is = withSkip((actual, expected, message) => {
 			if (!checkMessage('is', message)) {
-				return;
+				return false;
 			}
 
 			if (Object.is(actual, expected)) {
-				pass();
-			} else {
-				const result = concordance.compare(actual, expected, concordanceOptions);
-				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
-				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
-
-				if (result.pass) {
-					fail(new AssertionError({
-						assertion: 'is',
-						message,
-						raw: {actual, expected},
-						values: [formatDescriptorWithLabel('Values are deeply equal to each other, but they are not the same:', actualDescriptor)]
-					}));
-				} else {
-					fail(new AssertionError({
-						assertion: 'is',
-						message,
-						raw: {actual, expected},
-						values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-					}));
-				}
+				return pass();
 			}
+
+			const result = concordance.compare(actual, expected, concordanceOptions);
+			const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
+			const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
+
+			if (result.pass) {
+				return fail(new AssertionError({
+					assertion: 'is',
+					message,
+					raw: {actual, expected},
+					values: [formatDescriptorWithLabel('Values are deeply equal to each other, but they are not the same:', actualDescriptor)]
+				}));
+			}
+
+			return fail(new AssertionError({
+				assertion: 'is',
+				message,
+				raw: {actual, expected},
+				values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
+			}));
 		});
 
 		this.not = withSkip((actual, expected, message) => {
 			if (!checkMessage('not', message)) {
-				return;
+				return false;
 			}
 
 			if (Object.is(actual, expected)) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'not',
 					message,
 					raw: {actual, expected},
 					values: [formatWithLabel('Value is the same as:', actual)]
 				}));
-			} else {
-				pass();
 			}
+
+			return pass();
 		});
 
 		this.deepEqual = withSkip((actual, expected, message) => {
 			if (!checkMessage('deepEqual', message)) {
-				return;
+				return false;
 			}
 
 			const result = concordance.compare(actual, expected, concordanceOptions);
 			if (result.pass) {
-				pass();
-			} else {
-				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
-				const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
-				fail(new AssertionError({
-					assertion: 'deepEqual',
-					message,
-					raw: {actual, expected},
-					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-				}));
+				return pass();
 			}
+
+			const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
+			const expectedDescriptor = result.expected || concordance.describe(expected, concordanceOptions);
+			return fail(new AssertionError({
+				assertion: 'deepEqual',
+				message,
+				raw: {actual, expected},
+				values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
+			}));
 		});
 
 		this.notDeepEqual = withSkip((actual, expected, message) => {
 			if (!checkMessage('notDeepEqual', message)) {
-				return;
+				return false;
 			}
 
 			const result = concordance.compare(actual, expected, concordanceOptions);
 			if (result.pass) {
 				const actualDescriptor = result.actual || concordance.describe(actual, concordanceOptions);
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'notDeepEqual',
 					message,
 					raw: {actual, expected},
 					values: [formatDescriptorWithLabel('Value is deeply equal:', actualDescriptor)]
 				}));
-			} else {
-				pass();
 			}
+
+			return pass();
 		});
 
 		this.like = withSkip((actual, selector, message) => {
 			if (!checkMessage('like', message)) {
-				return;
+				return false;
 			}
 
 			if (!isLikeSelector(selector)) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'like',
 					improperUsage: true,
 					message: '`t.like()` selector must be a non-empty object',
 					values: [formatWithLabel('Called with:', selector)]
 				}));
-				return;
 			}
 
 			let comparable;
@@ -426,13 +444,12 @@ class Assertions {
 				comparable = selectComparable(actual, selector);
 			} catch (error) {
 				if (error === CIRCULAR_SELECTOR) {
-					fail(new AssertionError({
+					return fail(new AssertionError({
 						assertion: 'like',
 						improperUsage: true,
 						message: '`t.like()` selector must not contain circular references',
 						values: [formatWithLabel('Called with:', selector)]
 					}));
-					return;
 				}
 
 				throw error;
@@ -440,16 +457,16 @@ class Assertions {
 
 			const result = concordance.compare(comparable, selector, concordanceOptions);
 			if (result.pass) {
-				pass();
-			} else {
-				const actualDescriptor = result.actual || concordance.describe(comparable, concordanceOptions);
-				const expectedDescriptor = result.expected || concordance.describe(selector, concordanceOptions);
-				fail(new AssertionError({
-					assertion: 'like',
-					message,
-					values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
-				}));
+				return pass();
 			}
+
+			const actualDescriptor = result.actual || concordance.describe(comparable, concordanceOptions);
+			const expectedDescriptor = result.expected || concordance.describe(selector, concordanceOptions);
+			return fail(new AssertionError({
+				assertion: 'like',
+				message,
+				values: [formatDescriptorDiff(actualDescriptor, expectedDescriptor)]
+			}));
 		});
 
 		this.throws = withSkip((...args) => {
@@ -770,97 +787,95 @@ class Assertions {
 
 		this.truthy = withSkip((actual, message) => {
 			if (!checkMessage('truthy', message)) {
-				return;
+				return false;
 			}
 
 			if (actual) {
-				pass();
-			} else {
-				fail(new AssertionError({
-					assertion: 'truthy',
-					message,
-					operator: '!!',
-					values: [formatWithLabel('Value is not truthy:', actual)]
-				}));
+				return pass();
 			}
+
+			return fail(new AssertionError({
+				assertion: 'truthy',
+				message,
+				operator: '!!',
+				values: [formatWithLabel('Value is not truthy:', actual)]
+			}));
 		});
 
 		this.falsy = withSkip((actual, message) => {
 			if (!checkMessage('falsy', message)) {
-				return;
+				return false;
 			}
 
 			if (actual) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'falsy',
 					message,
 					operator: '!',
 					values: [formatWithLabel('Value is not falsy:', actual)]
 				}));
-			} else {
-				pass();
 			}
+
+			return pass();
 		});
 
 		this.true = withSkip((actual, message) => {
 			if (!checkMessage('true', message)) {
-				return;
+				return false;
 			}
 
 			if (actual === true) {
-				pass();
-			} else {
-				fail(new AssertionError({
-					assertion: 'true',
-					message,
-					values: [formatWithLabel('Value is not `true`:', actual)]
-				}));
+				return pass();
 			}
+
+			return fail(new AssertionError({
+				assertion: 'true',
+				message,
+				values: [formatWithLabel('Value is not `true`:', actual)]
+			}));
 		});
 
 		this.false = withSkip((actual, message) => {
 			if (!checkMessage('false', message)) {
-				return;
+				return false;
 			}
 
 			if (actual === false) {
-				pass();
-			} else {
-				fail(new AssertionError({
-					assertion: 'false',
-					message,
-					values: [formatWithLabel('Value is not `false`:', actual)]
-				}));
+				return pass();
 			}
+
+			return fail(new AssertionError({
+				assertion: 'false',
+				message,
+				values: [formatWithLabel('Value is not `false`:', actual)]
+			}));
 		});
 
 		this.regex = withSkip((string, regex, message) => {
 			if (!checkMessage('regex', message)) {
-				return;
+				return false;
 			}
 
 			if (typeof string !== 'string') {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'regex',
 					improperUsage: true,
 					message: '`t.regex()` must be called with a string',
 					values: [formatWithLabel('Called with:', string)]
 				}));
-				return;
 			}
 
 			if (!(regex instanceof RegExp)) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'regex',
 					improperUsage: true,
 					message: '`t.regex()` must be called with a regular expression',
 					values: [formatWithLabel('Called with:', regex)]
 				}));
-				return;
 			}
 
 			if (!regex.test(string)) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'regex',
 					message,
 					values: [
@@ -868,39 +883,36 @@ class Assertions {
 						formatWithLabel('Regular expression:', regex)
 					]
 				}));
-				return;
 			}
 
-			pass();
+			return pass();
 		});
 
 		this.notRegex = withSkip((string, regex, message) => {
 			if (!checkMessage('notRegex', message)) {
-				return;
+				return false;
 			}
 
 			if (typeof string !== 'string') {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'notRegex',
 					improperUsage: true,
 					message: '`t.notRegex()` must be called with a string',
 					values: [formatWithLabel('Called with:', string)]
 				}));
-				return;
 			}
 
 			if (!(regex instanceof RegExp)) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'notRegex',
 					improperUsage: true,
 					message: '`t.notRegex()` must be called with a regular expression',
 					values: [formatWithLabel('Called with:', regex)]
 				}));
-				return;
 			}
 
 			if (regex.test(string)) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'notRegex',
 					message,
 					values: [
@@ -908,29 +920,27 @@ class Assertions {
 						formatWithLabel('Regular expression:', regex)
 					]
 				}));
-				return;
 			}
 
-			pass();
+			return pass();
 		});
 
 		if (powerAssert === undefined) {
 			this.assert = withSkip((actual, message) => {
 				if (!checkMessage('assert', message)) {
-					return;
+					return false;
 				}
 
 				if (!actual) {
-					fail(new AssertionError({
+					return fail(new AssertionError({
 						assertion: 'assert',
 						message,
 						operator: '!!',
 						values: [formatWithLabel('Value is not truthy:', actual)]
 					}));
-					return;
 				}
 
-				pass();
+				return pass();
 			});
 		} else {
 			this.assert = withSkip(withPowerAssert(

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -626,47 +626,44 @@ class Assertions {
 
 		this.notThrows = withSkip((fn, message) => {
 			if (!checkMessage('notThrows', message)) {
-				return;
+				return false;
 			}
 
 			if (typeof fn !== 'function') {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'notThrows',
 					improperUsage: true,
 					message: '`t.notThrows()` must be called with a function',
 					values: [formatWithLabel('Called with:', fn)]
 				}));
-				return;
 			}
 
 			try {
 				fn();
 			} catch (error) {
-				fail(new AssertionError({
+				return fail(new AssertionError({
 					assertion: 'notThrows',
 					message,
 					actualStack: error.stack,
 					values: [formatWithLabel('Function threw:', error)]
 				}));
-				return;
 			}
 
-			pass();
+			return pass();
 		});
 
 		this.notThrowsAsync = withSkip((nonThrower, message) => {
 			if (!checkMessage('notThrowsAsync', message)) {
-				return Promise.resolve();
+				return Promise.resolve(false);
 			}
 
 			if (typeof nonThrower !== 'function' && !isPromise(nonThrower)) {
-				fail(new AssertionError({
+				return Promise.resolve(fail(new AssertionError({
 					assertion: 'notThrowsAsync',
 					improperUsage: true,
 					message: '`t.notThrowsAsync()` must be called with a function or promise',
 					values: [formatWithLabel('Called with:', nonThrower)]
-				}));
-				return Promise.resolve();
+				})));
 			}
 
 			const handlePromise = (promise, wasReturned) => {
@@ -683,7 +680,8 @@ class Assertions {
 				});
 				pending(intermediate);
 				// Don't reject the returned promise, even if the assertion fails.
-				return intermediate.catch(noop);
+				// eslint-disable-next-line promise/prefer-await-to-then
+				return intermediate.then(() => true).catch(noop);
 			};
 
 			if (isPromise(nonThrower)) {
@@ -694,22 +692,20 @@ class Assertions {
 			try {
 				retval = nonThrower();
 			} catch (error) {
-				fail(new AssertionError({
+				return Promise.resolve(fail(new AssertionError({
 					assertion: 'notThrowsAsync',
 					message,
 					actualStack: error.stack,
 					values: [formatWithLabel('Function threw:', error)]
-				}));
-				return Promise.resolve();
+				})));
 			}
 
 			if (!isPromise(retval)) {
-				fail(new AssertionError({
+				return Promise.resolve(fail(new AssertionError({
 					assertion: 'notThrowsAsync',
 					message,
 					values: [formatWithLabel('Function did not return a promise. Use `t.notThrows()` instead:', retval)]
-				}));
-				return Promise.resolve();
+				})));
 			}
 
 			return handlePromise(retval, true);


### PR DESCRIPTION
This makes most of the built-in assertion functions return Boolean
values, `true` when the assertion succeeds and `false` when the
assertion fails.

This is intended to allow a user to emulate the assertion function
throwing an exception by allowing control flow to only proceed if the
assertion passes, something like:

```
if (t.is(foo, 42)) {
  // Do some other things that only make sense when `foo` is `42`.
}
```

`snapshot` is left alone since it doesn't seem to make much sense to
make it return a Boolean in this way, given its existing contract.

`pass` and `fail` are somewhat special since they act more as "flags"
that tell the test runner to pass or fail the test and don't actually do
any asserting. In their cases, their returned flag values are chosen for
use as analogues of `if (true) { ... }` and `if (false) { ... }`, i.e.
`if (pass()) { ... }` and `if (fail()) { ... }`.

Fixes issue #2455, and refines the work done in #2586.