### PR TITLE
Only create the cache directory when needed

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -111,10 +111,8 @@ class Api extends Emittery {
 			}
 		};
 
-		let cacheDir;
 		let testFiles;
 		try {
-			cacheDir = this._createCacheDir();
 			testFiles = await globs.findTests({cwd: this.options.projectDir, ...apiOptions.globs});
 			if (selectedFiles.length === 0) {
 				selectedFiles = filter.length === 0 ? testFiles : globs.applyTestFileFilter({
@@ -189,7 +187,7 @@ class Api extends Emittery {
 
 			const {providers = []} = this.options;
 			const providerStates = (await Promise.all(providers.map(async ({type, main}) => {
-				const state = await main.compile({cacheDir, files: testFiles});
+				const state = await main.compile({cacheDir: this._createCacheDir(), files: testFiles});
 				return state === null ? null : {type, state};
 			}))).filter(state => state !== null);
 


### PR DESCRIPTION
Avoid potential permission issues if we don't use the cache dir anyway, see <https://github.com/avajs/ava/issues/1128#issuecomment-716745299>.
