### PR TITLE
Include failed test files and titles in default reporter

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -915,6 +915,35 @@ class Reporter {
 		if (this.watching) {
 			this.lineWriter.writeLine();
 		}
+
+		const failedFiles = [...this.stats.byFile.keys()].filter(failedFile => this.failures.some(failure => failure.testFile === failedFile));
+
+		const failedTestInFile = failedFile => this.failures.filter(failure => failure.testFile === failedFile).map(failure => failure.title);
+
+		if (failedFiles.length > 0) {
+			this.lineWriter.writeLine();
+		}
+
+		for (const failedFile of failedFiles) {
+			this.lineWriter.writeLine(colors.errorSource(this.relativeFile(failedFile)));
+			for (const failedTestTitle of failedTestInFile(failedFile)) {
+				this.lineWriter.writeLine(colors.error(`${figures.cross} ${failedTestTitle}`));
+			}
+		}
+
+		const uncaughtExceptionsTestFiles = this.uncaughtExceptions.map(failedFile => failedFile.testFile);
+
+		if (failedFiles.length > 0 || uncaughtExceptionsTestFiles.length > 0) {
+			this.lineWriter.writeLine();
+		}
+
+		for (const failedFile of uncaughtExceptionsTestFiles) {
+			this.lineWriter.writeLine(colors.title(`Uncaught exception in ${this.relativeFile(failedFile)}`));
+		}
+
+		if (uncaughtExceptionsTestFiles.length > 0) {
+			this.lineWriter.writeLine();
+		}
 	}
 }
 module.exports = Reporter;


### PR DESCRIPTION
Related to https://github.com/avajs/ava/issues/2500#issuecomment-758878957

@novemberborn I want to hear your opinions before fixing the tests.

### Difference when running Ava on one of my personal projects:

##### Before:

![image](https://user-images.githubusercontent.com/12954665/104729057-896bd100-5740-11eb-8e4b-a1c20bd49df6.png)

##### After:

![image](https://user-images.githubusercontent.com/12954665/104728789-1c583b80-5740-11eb-8228-bedcd487c02c.png)

----

The only way to search the failed tests before this PR is to search the "✖" symbol and search for "Uncaught exception".

----

#### TODO:

@novemberborn When all of the tests of a worker passed but the worker exit with code 1, I can't find a way to get the failed-tests in the default reporter:

```
test('test1', async () => {
  process.exitCode = 1
})
```

In this situation, I would also expect that `--serial --fail-fast` won't run tests after `test1` but that's not the case. Maybe Ava needs to evaluate the process.exitCode before moving on to the next test.

wdyt?