### PR TITLE
Fix link to Discussions in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Questions? Ideas? Something to share?
+  - name: Discussions
     url: https://github.com/avajs/ava/discussions
+    about: Questions? Ideas? Something to share?
   - name: Babel
     url: https://github.com/avajs/babel/issues
     about: Report a bug with AVA's Babel integration


### PR DESCRIPTION
As far as I can tell the link to https://github.com/avajs/ava/discussions was never showing up because of the missing `about` key.