### PR TITLE
Update endpoint testing with Mongoose recipe

### DIFF
--- a/docs/recipes/endpoint-testing-with-mongoose.md
+++ b/docs/recipes/endpoint-testing-with-mongoose.md
@@ -56,7 +56,7 @@ const mongod = new MongoMemoryServer()
 
 // Create connection to Mongoose before tests are run
 test.before(async () => {
-	const uri = await mongod.getConnectionString();
+	const uri = await mongod.getUri();
 	await mongoose.connect(uri, {useMongoClient: true});
 });
 ```


### PR DESCRIPTION
`getConnectionString` is deprecated in newer versions, use `getUri` instead