### PR TITLE
Document that concurrency can be configured in the config files

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -46,6 +46,7 @@ Arguments passed to the CLI will always take precedence over the CLI options con
 - `ignoredByWatcher`: an array of glob patterns to match files that, even if changed, are ignored by the watcher. See the [watch mode recipe for details](https://github.com/avajs/ava/blob/main/docs/recipes/watch-mode.md)
 - `match`: not typically useful in the `package.json` configuration, but equivalent to [specifying `--match` on the CLI](./05-command-line.md#running-tests-with-matching-titles)
 - `cache`: cache compiled files under `node_modules/.cache/ava`. If `false`, files are cached in a temporary directory instead
+- `concurrency`: max number of test files running at the same time (default: CPU cores)
 - `failFast`: stop running further tests once a test fails
 - `failWithoutAssertions`: if `false`, does not fail a test if it doesn't run [assertions](./03-assertions.md)
 - `environmentVariables`: specifies environment variables to be made available to the tests. The environment variables defined here override the ones from `process.env`


### PR DESCRIPTION
Closes #2674 

I found the information in the CLI documentation:

https://github.com/avajs/ava/blame/main/docs/05-command-line.md#L28-L29