### PR TITLE
Add Babel and TypeScript provider packages as optional peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,13 @@
 				"node": ">=12.20 <13 || >=14.15 <15 || >=15"
 			},
 			"peerDependencies": {
+				"@ava/babel": "*",
 				"@ava/typescript": "*"
 			},
 			"peerDependenciesMeta": {
+				"@ava/babel": {
+					"optional": true
+				},
 				"@ava/typescript": {
 					"optional": true
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,14 @@
 			},
 			"engines": {
 				"node": ">=12.20 <13 || >=14.15 <15 || >=15"
+			},
+			"peerDependencies": {
+				"@ava/typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"@ava/typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@ava/babel": {

--- a/package.json
+++ b/package.json
@@ -141,9 +141,13 @@
 		"zen-observable": "^0.8.15"
 	},
 	"peerDependencies": {
+		"@ava/babel": "*",
 		"@ava/typescript": "*"
 	},
 	"peerDependenciesMeta": {
+		"@ava/babel": {
+			"optional": true
+		},
 		"@ava/typescript": {
 			"optional": true
 		}

--- a/package.json
+++ b/package.json
@@ -139,5 +139,13 @@
 		"typescript": "^4.1.3",
 		"xo": "^0.37.1",
 		"zen-observable": "^0.8.15"
+	},
+	"peerDependencies": {
+		"@ava/typescript": "*"
+	},
+	"peerDependenciesMeta": {
+		"@ava/typescript": {
+			"optional": true
+		}
 	}
 }


### PR DESCRIPTION
`@ava/typescript` is an optional peer dependency - this should be indicated in `package.json`, otherwise stricter package manages (such as Yarn PnP) throw errors:

> ✖ ava tried to access @ava/typescript, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.