### PR TITLE
Include test invocation in trace

### DIFF
--- a/lib/reporters/beautify-stack.js
+++ b/lib/reporters/beautify-stack.js
@@ -23,6 +23,8 @@ const stackUtils = new StackUtils({
 	]
 });
 
+exports.stackUtils = stackUtils;
+
 /*
  * Given a string value of the format generated for the `stack` property of a
  * V8 error object, return a string that contains only stack frame information
@@ -59,7 +61,7 @@ const stackUtils = new StackUtils({
  * Module.runMain (module.js:604:10)
  * ```
  */
-module.exports = stack => {
+exports.beautifyStack = stack => {
 	if (!stack) {
 		return [];
 	}

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -13,7 +13,7 @@ const trimOffNewlines = require('trim-off-newlines');
 
 const chalk = require('../chalk').get();
 const codeExcerpt = require('../code-excerpt');
-const beautifyStack = require('./beautify-stack');
+const {beautifyStack} = require('./beautify-stack');
 const colors = require('./colors');
 const formatSerializedError = require('./format-serialized-error');
 const improperUsageMessages = require('./improper-usage-messages');

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -7,7 +7,7 @@ const stripAnsi = require('strip-ansi');
 const supertap = require('supertap');
 const indentString = require('indent-string');
 
-const beautifyStack = require('./beautify-stack');
+const {beautifyStack} = require('./beautify-stack');
 const prefixTitle = require('./prefix-title');
 
 function dumpError(error) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,6 +4,7 @@ const matcher = require('matcher');
 const ContextRef = require('./context-ref');
 const createChain = require('./create-chain');
 const parseTestArgs = require('./parse-test-args');
+const {stackUtils} = require('./reporters/beautify-stack');
 const snapshotManager = require('./snapshot-manager');
 const serializeError = require('./serialize-error');
 const Runnable = require('./test');
@@ -88,6 +89,8 @@ class Runner extends Emittery {
 			}
 
 			metadata.taskIndex = this.nextTaskIndex++;
+			const testInvocation = stackUtils.parseLine(stackUtils.captureString().split('\n')[0]);
+			metadata.testLine = `    at test (${testInvocation.file}:${testInvocation.line}:${testInvocation.column})`;
 
 			const {args, buildTitle, implementations, rawTitle} = parseTestArgs(testArgs);
 
@@ -366,7 +369,7 @@ class Runner extends Emittery {
 				this.emit('stateChange', {
 					type: 'test-failed',
 					title: result.title,
-					err: serializeError('Test failure', true, result.error, this.file),
+					err: serializeError('Test failure', true, result.error, this.file, task.metadata.testLine),
 					duration: result.duration,
 					knownFailing: result.metadata.failing,
 					logs: result.logs

--- a/lib/serialize-error.js
+++ b/lib/serialize-error.js
@@ -67,7 +67,7 @@ function buildSource(source) {
 	};
 }
 
-function trySerializeError(error, shouldBeautifyStack, testFile) {
+function trySerializeError(error, shouldBeautifyStack, testFile, testLine) {
 	const stack = error.savedError ? error.savedError.stack : error.stack;
 
 	const retval = {
@@ -81,6 +81,8 @@ function trySerializeError(error, shouldBeautifyStack, testFile) {
 	if (error.actualStack) {
 		retval.stack = error.actualStack;
 	}
+
+	retval.stack += `\n${testLine}`;
 
 	if (retval.avaAssertionError) {
 		retval.improperUsage = error.improperUsage;
@@ -143,7 +145,7 @@ function trySerializeError(error, shouldBeautifyStack, testFile) {
 	return retval;
 }
 
-function serializeError(origin, shouldBeautifyStack, error, testFile) {
+function serializeError(origin, shouldBeautifyStack, error, testFile, testLine) {
 	if (!isError(error)) {
 		return {
 			avaAssertionError: false,
@@ -153,7 +155,7 @@ function serializeError(origin, shouldBeautifyStack, error, testFile) {
 	}
 
 	try {
-		return trySerializeError(error, shouldBeautifyStack, testFile);
+		return trySerializeError(error, shouldBeautifyStack, testFile, testLine);
 	} catch {
 		const replacement = new Error(`${origin}: Could not serialize error`);
 		return {


### PR DESCRIPTION
Closes #2722.

@novemberborn, before I look into testing this, are you satisfied with this code? There are a few ways this can be accomplished with this one changing the least.

**The change**  

```js
const test = require('ava');

const {macro} = require('../helper/macro');

test('Number must be 5', macro, 4);
```

now results in the follow output

```diff
  Number must be 5

  Difference:

  - 4
  + 5

  › exports.macro (javascript/helper/macro.js:2:7)
+ › test (javascript/spec/something.spec.js:5:1)
```