### PR TITLE
Remove --preserve-symlink and npm link detection

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -1,13 +1,8 @@
 'use strict';
 const {Worker} = require('worker_threads');
 const childProcess = require('child_process');
-const fs = require('fs');
 const Emittery = require('emittery');
 const {controlFlow} = require('./ipc-flow-control');
-
-if (fs.realpathSync(__filename) !== __filename) {
-	console.warn('WARNING: `npm link ava` and the `--preserve-symlink` flag are incompatible. We have detected that AVA is linked via `npm link`, and that you are using either an early version of Node 6, or the `--preserve-symlink` flag. This breaks AVA. You should upgrade to Node 6.2.0+, avoid the `--preserve-symlink` flag, or avoid using `npm link ava`.');
-}
 
 const WORKER_PATH = require.resolve('./worker/base.js');
 


### PR DESCRIPTION
This is old and untested. I don't know if it's still relevant. We could always bring it back.
