### PR TITLE
Add StackBlitz example for macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules/
 /test-tap/**/node_modules/
 /test/**/fixtures/**/node_modules/*/
+/examples/**/node_modules/

--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -290,6 +290,8 @@ console.log('Test file currently being run:', test.meta.file);
 
 ## Reusing test logic through macros
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/macros?file=test.js&terminal=test&view=editor)
+
 Additional arguments passed to the test declaration will be passed to the test implementation. This is useful for creating reusable test macros.
 
 ```js

--- a/examples/macros/index.js
+++ b/examples/macros/index.js
@@ -1,0 +1,1 @@
+exports.sum = (a, b) => a + b;

--- a/examples/macros/package.json
+++ b/examples/macros/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"test": "ava"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"ava": "^3.15.0"
 	}
 }

--- a/examples/macros/package.json
+++ b/examples/macros/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "ava-macros",
+	"description": "Example for reusing test logic through macros",
+	"scripts": {
+		"test": "ava"
+	},
+	"dependencies": {
+		"ava": "^3.15.0"
+	}
+}

--- a/examples/macros/readme.md
+++ b/examples/macros/readme.md
@@ -1,0 +1,5 @@
+# Macros
+
+> Example for [reusing test logic through macros](https://github.com/avajs/ava/blob/main/docs/01-writing-tests.md#reusing-test-logic-through-macros)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/macros?file=test.js&terminal=test&view=editor)

--- a/examples/macros/test.js
+++ b/examples/macros/test.js
@@ -1,12 +1,13 @@
 'use strict';
 const test = require('ava');
-const { sum } = require('.');
+
+const {sum} = require('.');
 
 function macro(t, a, b, expected) {
 	t.is(sum(a, b), expected);
 }
 
-macro.title = (providedTitle = '', a, b, expected) => `${providedTitle} ${a}+${b} = ${expected}`.trim();
+macro.title = (providedTitle, a, b, expected) => `${providedTitle || ''} ${a}+${b} = ${expected}`.trim();
 
 test(macro, 2, 2, 4);
 test(macro, 3, 3, 6);

--- a/examples/macros/test.js
+++ b/examples/macros/test.js
@@ -1,0 +1,13 @@
+'use strict';
+const test = require('ava');
+const { sum } = require('.');
+
+function macro(t, a, b, expected) {
+	t.is(sum(a, b), expected);
+}
+
+macro.title = (providedTitle = '', a, b, expected) => `${providedTitle} ${a}+${b} = ${expected}`.trim();
+
+test(macro, 2, 2, 4);
+test(macro, 3, 3, 6);
+test('providedTitle', macro, 4, 4, 8);


### PR DESCRIPTION
This PR adds an `examples` directory with currently one example, being `macros`.

I've copied one macro case from the documentation as you will see. We can add a different one, or add multiple test files even. But maybe, the smaller the example, the easier it is to understand for new people. Open to suggestions here.

If you want to test it out how it will look like if you click the button, use this button which does the same but points to my fork.

[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/macros/examples/macros?file=test.js&terminal=test&view=editor)

These are the properties I added to the URL
- Open `test.js` by default if you click the button
- Run the `test` command by default if someone opens the example
- Hide the preview pane on the right

One small sidenote, I did notice that the `view=editor` query parameter is not working and the preview pane is still open, but I will look into that to fix it asap.

Some small questions
- Do you guys want to use the `Open in StackBlitz` button? Or do you rather prefer textual links?
- Is it ok to embed the buttons in the `docs` documentation? I assume that the easier it is to play with a feature, the better. Then people don't have to skim through the examples.
- Do we want to put more information in the `readme.md` of the example? This is what it looks like now https://github.com/SamVerschueren/ava/tree/stackblitz/examples/macros/examples/macros. I didn't want to copy parts of the documentation because it can only become outdated.