### PR TITLE
Add StackBlitz example for snapshot testing

### DIFF
--- a/docs/04-snapshot-testing.md
+++ b/docs/04-snapshot-testing.md
@@ -6,6 +6,8 @@ AVA supports snapshot testing, [as introduced by Jest](https://facebook.github.i
 
 ```js
 // Your component
+import React from 'react';
+
 const HelloWorld = () => <h1>Hello World...!</h1>;
 
 export default HelloWorld;
@@ -13,17 +15,18 @@ export default HelloWorld;
 
 ```js
 // Your test
-const test = require('ava');
-const render = require('react-test-renderer');
-const HelloWorld = require('.');
+import test from 'ava';
+import React from 'react';
+import render from 'react-test-renderer';
+import HelloWorld from '.';
 
 test('HelloWorld component', t => {
-	const tree = render.create(<HelloWorld/>).toJSON();
+	const tree = render.create(<HelloWorld />).toJSON();
 	t.snapshot(tree);
 });
 ```
 
-[Try it out in this example project.](https://github.com/avajs/ava-snapshot-example)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/snapshot-testing?file=index.js&terminal=test&view=editor)
 
 Snapshots are stored alongside your test files. If your tests are in a `test` or `tests` folder the snapshots will be stored in a `snapshots` folder. If your tests are in a `__tests__` folder then they they'll be stored in a `__snapshots__` folder.
 

--- a/examples/snapshot-testing/index.js
+++ b/examples/snapshot-testing/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const HelloWorld = () => <h1>Hello World...!</h1>;
+
+export default HelloWorld;

--- a/examples/snapshot-testing/index.js
+++ b/examples/snapshot-testing/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
 
 const HelloWorld = () => <h1>Hello World...!</h1>;

--- a/examples/snapshot-testing/package.json
+++ b/examples/snapshot-testing/package.json
@@ -1,0 +1,28 @@
+{
+	"scripts": {
+		"test": "ava"
+	},
+	"dependencies": {
+		"react": "^17.0.2"
+	},
+	"devDependencies": {
+		"@ava/babel": "^1.0.1",
+		"@babel/preset-react": "^7.14.5",
+		"@babel/register": "^7.14.5",
+		"ava": "^3.15.0",
+		"react-test-renderer": "^17.0.2"
+	},
+	"ava": {
+		"babel": true,
+		"snapshotDir": ".snapshots",
+		"require": [
+			"@babel/register"
+		]
+	},
+	"babel": {
+		"presets": [
+			"@babel/preset-react",
+			"@ava/babel/stage-4"
+		]
+	}
+}

--- a/examples/snapshot-testing/readme.md
+++ b/examples/snapshot-testing/readme.md
@@ -1,0 +1,14 @@
+# Macros
+
+> Example for [snapshot testing](https://github.com/avajs/ava/blob/main/docs/04-snapshot-testing.md)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/snapshot-testing?file=index.js&terminal=test&view=editor)
+
+
+## Usage
+
+```
+$ npm test
+```
+
+Then change `Hello World...!` in `index.js` to something else and run `npm test` again.

--- a/examples/snapshot-testing/test.js
+++ b/examples/snapshot-testing/test.js
@@ -1,0 +1,9 @@
+import test from 'ava';
+import React from 'react';
+import render from 'react-test-renderer';
+import HelloWorld from '.';
+
+test('HelloWorld component', t => {
+	const tree = render.create(<HelloWorld />).toJSON();
+	t.snapshot(tree);
+});

--- a/examples/snapshot-testing/test.js
+++ b/examples/snapshot-testing/test.js
@@ -1,7 +1,9 @@
+/* eslint-disable no-unused-vars */
 import test from 'ava';
 import React from 'react';
 import render from 'react-test-renderer';
-import HelloWorld from '.';
+
+import HelloWorld from './index.js';
 
 test('HelloWorld component', t => {
 	const tree = render.create(<HelloWorld />).toJSON();


### PR DESCRIPTION
This PR adds an example for snapshot testing of a React component.

I could've made the snapshot example without React, but because the docs use that React component, I figured it would be best to just follow that example instead.

You can test it out with the following button which points to my fork.

[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/snapshot-react/examples/snapshot-testing?file=index.js&terminal=test&view=editor)

![image](https://user-images.githubusercontent.com/1913805/124393725-1a893100-dcfc-11eb-8dc5-05329e49ebc6.png)

One downside in this example is that I had to go with a `snapshotDirectory` starting with a `.`. The reason is that we don't sync this directory with our backend. Because the snapshots are binary files, I receive the PostgreSQL error `\u0000 cannot be converted to text.` which is a null-byte.