### PR TITLE
Add StackBlitz example for test timeouts

### DIFF
--- a/docs/07-test-timeouts.md
+++ b/docs/07-test-timeouts.md
@@ -2,6 +2,8 @@
 
 Translations: [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/07-test-timeouts.md)
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/timeouts?file=test.js&terminal=test&view=editor)
+
 Timeouts in AVA behave differently than in other test frameworks. AVA resets a timer after each test, forcing tests to quit if no new test results were received within the specified timeout. This can be used to handle stalled tests.
 
 The default timeout is 10 seconds.

--- a/examples/timeouts/index.js
+++ b/examples/timeouts/index.js
@@ -1,7 +1,42 @@
 'use strict';
 
-exports.delay = ms => {
+const delay = ms => {
 	return new Promise(resolve => {
 		setTimeout(resolve, ms);
 	});
+};
+
+exports.fetchUsers = async () => {
+	await delay(50);
+
+	return [
+		{
+			id: 1,
+			firstName: 'Ava',
+			name: 'Rocks',
+			email: 'ava@rocks.com'
+		}
+	];
+};
+
+exports.fetchPosts = async userId => {
+	await delay(200);
+
+	return [
+		{
+			id: 1,
+			userId,
+			message: 'AVA Rocks 🚀'
+		}
+	];
+};
+
+exports.createPost = async message => {
+	await delay(3000);
+
+	return {
+		id: 2,
+		userId: 1,
+		message
+	};
 };

--- a/examples/timeouts/index.js
+++ b/examples/timeouts/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+exports.delay = ms => {
+	return new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
+};

--- a/examples/timeouts/package.json
+++ b/examples/timeouts/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "ava-timeouts",
+	"description": "Example for test timeouts",
+	"scripts": {
+		"test": "ava --timeout=2s --verbose"
+	},
+	"devDependencies": {
+		"ava": "^3.15.0"
+	}
+}

--- a/examples/timeouts/readme.md
+++ b/examples/timeouts/readme.md
@@ -1,0 +1,5 @@
+# Test timeouts
+
+> Example for [test timeouts](https://github.com/avajs/ava/blob/main/docs/07-test-timeouts.md)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/timeouts?file=test.js&terminal=test&view=editor)

--- a/examples/timeouts/test.js
+++ b/examples/timeouts/test.js
@@ -1,0 +1,26 @@
+'use strict';
+const test = require('ava');
+
+const {delay} = require('.');
+
+test('start server', async t => {
+	t.timeout(100);
+
+	await delay(50);
+
+	t.pass();
+});
+
+test('connect with database', async t => {
+	t.timeout(100, 'make sure database has started');
+
+	await delay(200);
+
+	t.pass();
+});
+
+test('very long and slow operation', async t => {
+	await delay(3000);
+
+	t.pass();
+});

--- a/examples/timeouts/test.js
+++ b/examples/timeouts/test.js
@@ -1,26 +1,43 @@
 'use strict';
 const test = require('ava');
 
-const {delay} = require('.');
+const {fetchUsers, fetchPosts, createPost} = require('.');
 
-test('start server', async t => {
+test('retrieve users', async t => {
 	t.timeout(100);
 
-	await delay(50);
+	const users = await fetchUsers();
 
-	t.pass();
+	t.deepEqual(users, [
+		{
+			id: 1,
+			firstName: 'Ava',
+			name: 'Rocks',
+			email: 'ava@rocks.com'
+		}
+	]);
 });
 
-test('connect with database', async t => {
-	t.timeout(100, 'make sure database has started');
+test('retrieve posts', async t => {
+	t.timeout(100, 'retrieving posts is too slow');
 
-	await delay(200);
+	const posts = await fetchPosts(1);
 
-	t.pass();
+	t.deepEqual(posts, [
+		{
+			id: 1,
+			userId: 1,
+			message: 'AVA Rocks 🚀'
+		}
+	]);
 });
 
-test('very long and slow operation', async t => {
-	await delay(3000);
+test('create post', async t => {
+	const post = await createPost('I love 🦄 and 🌈');
 
-	t.pass();
+	t.deepEqual(post, {
+		id: 2,
+		userId: 1,
+		message: 'I love 🦄 and 🌈'
+	});
 });


### PR DESCRIPTION
You can test the example on my fork by clicking the button

[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/timeout/examples/timeouts?file=test.js&terminal=test&view=editor)

Example is pretty straight forward I think. Let me know if you want something differently.