### PR TITLE
Add StackBlitz examples for command line documentation

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -76,6 +76,12 @@
 			"rules": {
 				"ava/no-identical-title": "off"
 			}
+		},
+		{
+			"files": "examples/**",
+			"rules": {
+				"ava/no-only-test": "off"
+			}
 		}
 	]
 }

--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -80,6 +80,8 @@ When using `npm test`, you can pass positional arguments directly `npm test test
 
 ## Running tests with matching titles
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/matching-titles?file=test.js&terminal=test&view=editor)
+
 The `--match` flag allows you to run just the tests that have a matching title. This is achieved with simple wildcard patterns. Patterns are case insensitive. See [`matcher`](https://github.com/sindresorhus/matcher) for more details.
 
 Match titles ending with `foo`:
@@ -153,6 +155,8 @@ test(function foo(t) {
 ```
 
 ## Running tests at specific line numbers
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/specific-line-numbers?file=test.js&terminal=test&view=editor)
 
 AVA lets you run tests exclusively by referring to their line numbers. Target a single line, a range of lines or both. You can select any line number of a test.
 
@@ -235,6 +239,8 @@ AVA 3 defaults to a less verbose reporter:
 Use the `--verbose` flag to enable the verbose reporter. This is always used in CI environments unless the [TAP reporter](#tap-reporter) is enabled.
 
 ### TAP reporter
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/tap-reporter?file=test.js&terminal=test&view=editor)
 
 AVA supports the TAP format and thus is compatible with [any TAP reporter](https://github.com/sindresorhus/awesome-tap#reporters). Use the `--tap` flag to enable TAP output.
 

--- a/examples/matching-titles/package.json
+++ b/examples/matching-titles/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "ava-matching-titles",
+	"description": "Example for running tests with matching titles",
+	"scripts": {
+		"test": "ava --match='*oo*'"
+	},
+	"devDependencies": {
+		"ava": "^3.15.0"
+	}
+}

--- a/examples/matching-titles/readme.md
+++ b/examples/matching-titles/readme.md
@@ -1,0 +1,5 @@
+# Running tests with matching titles
+
+> Example for [running tests with matching titles](https://github.com/avajs/ava/blob/main/docs/05-command-line.md#running-tests-with-matching-titles)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/matching-titles?file=test.js&terminal=test&view=editor)

--- a/examples/matching-titles/test.js
+++ b/examples/matching-titles/test.js
@@ -1,0 +1,14 @@
+'use strict';
+const test = require('ava');
+
+test('foo will run', t => {
+	t.pass();
+});
+
+test('moo will also run', t => {
+	t.pass();
+});
+
+test.only('boo will run but not exclusively', t => {
+	t.pass();
+});

--- a/examples/specific-line-numbers/package.json
+++ b/examples/specific-line-numbers/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "ava-specific-line-numbers",
+	"description": "Example for running tests at specific line numbers",
+	"scripts": {
+		"test": "ava test.js:5"
+	},
+	"devDependencies": {
+		"ava": "^3.15.0"
+	}
+}

--- a/examples/specific-line-numbers/readme.md
+++ b/examples/specific-line-numbers/readme.md
@@ -1,0 +1,5 @@
+# Running tests at specific line numbers
+
+> Example for [running tests at specific line numbers](https://github.com/avajs/ava/blob/main/docs/05-command-line.md#running-tests-at-specific-line-numbers)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/specific-line-numbers?file=test.js&terminal=test&view=editor)

--- a/examples/specific-line-numbers/test.js
+++ b/examples/specific-line-numbers/test.js
@@ -1,0 +1,10 @@
+'use strict';
+const test = require('ava');
+
+test('unicorn', t => {
+	t.pass();
+});
+
+test('rainbow', t => {
+	t.fail();
+});

--- a/examples/tap-reporter/package.json
+++ b/examples/tap-reporter/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "ava-tap-reporter",
+	"description": "Example for a custom TAP reporter",
+	"scripts": {
+		"test": "ava --tap | tap-nyan"
+	},
+	"devDependencies": {
+		"ava": "^3.15.0",
+		"tap-nyan": "^1.1.0"
+	}
+}

--- a/examples/tap-reporter/readme.md
+++ b/examples/tap-reporter/readme.md
@@ -1,0 +1,5 @@
+# Running tests at specific line numbers
+
+> Example for a [custom TAP reporter](https://github.com/avajs/ava/blob/main/docs/05-command-line.md#running-tests-at-specific-line-numbers)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/tap-reporter?file=test.js&terminal=test&view=editor)

--- a/examples/tap-reporter/test.js
+++ b/examples/tap-reporter/test.js
@@ -1,0 +1,22 @@
+'use strict';
+const test = require('ava');
+
+test('unicorn', t => {
+	t.pass();
+});
+
+test('rainbow', t => {
+	t.fail();
+});
+
+test('foo', t => {
+	t.pass();
+});
+
+test('bar', t => {
+	t.pass();
+});
+
+test('baz', t => {
+	t.pass();
+});


### PR DESCRIPTION
I've added 3 examples for the [Command line](https://github.com/avajs/ava/blob/main/docs/05-command-line.md) documentation.

- [Running tests with matching titles](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/command-line/examples/matching-titles?file=test.js&terminal=test&view=editor)
- [Running tests at specific line numbers](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/command-line/examples/specific-line-numbers?file=test.js&terminal=test&view=editor)
- [TAP reporter](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/command-line/examples/tap-reporter?file=test.js&terminal=test&view=editor)

Let me know if you want to move buttons to different places or rename directories or what not. Example of the docs page https://github.com/SamVerschueren/ava/blob/stackblitz/examples/command-line/docs/05-command-line.md.