### PR TITLE
Add StackBlitz example endpoint testing

### DIFF
--- a/docs/recipes/endpoint-testing.md
+++ b/docs/recipes/endpoint-testing.md
@@ -2,6 +2,8 @@
 
 Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/docs/recipes/endpoint-testing.md), [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/docs/recipes/endpoint-testing.md), [Italiano](https://github.com/avajs/ava-docs/blob/master/it_IT/docs/recipes/endpoint-testing.md), [日本語](https://github.com/avajs/ava-docs/blob/master/ja_JP/docs/recipes/endpoint-testing.md), [Português](https://github.com/avajs/ava-docs/blob/master/pt_BR/docs/recipes/endpoint-testing.md), [Русский](https://github.com/avajs/ava-docs/blob/master/ru_RU/docs/recipes/endpoint-testing.md), [简体中文](https://github.com/avajs/ava-docs/blob/master/zh_CN/docs/recipes/endpoint-testing.md)
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/endpoint-testing?file=test.js&terminal=test&view=editor)
+
 AVA doesn't have a built-in method for testing endpoints, but you can use any HTTP client of your choosing, for example [`got`](https://github.com/sindresorhus/got). You'll also need to start an HTTP server, preferably on a unique port so that you can run tests in parallel. For that we recommend [`test-listen`](https://github.com/zeit/test-listen).
 
 Since tests run concurrently, it's best to create a fresh server instance at least for each test file, but perhaps even for each test. This can be accomplished with `test.before()` and `test.beforeEach()` hooks and `t.context`. If you start your server using a `test.before()` hook you should make sure to execute your tests serially.
@@ -30,7 +32,7 @@ test.serial('get /user', async t => {
 });
 ```
 
-Other libraries you may find useful: 
+Other libraries you may find useful:
 
 - [`supertest`](https://github.com/visionmedia/supertest)
 - [`get-port`](https://github.com/sindresorhus/get-port)

--- a/examples/endpoint-testing/app.js
+++ b/examples/endpoint-testing/app.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (request, response) => {
+	if (request.url === '/user') {
+		response.setHeader('Content-Type', 'application/json');
+		response.end(JSON.stringify({email: 'ava@rocks.com'}));
+	} else {
+		response.writeHead('404');
+		response.end();
+	}
+};

--- a/examples/endpoint-testing/package.json
+++ b/examples/endpoint-testing/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "ava-endpoint-testing",
+	"description": "Example for endpoint testing",
+	"scripts": {
+		"test": "ava"
+	},
+	"devDependencies": {
+		"ava": "^3.15.0",
+		"got": "^11.8.2",
+		"test-listen": "^1.1.0"
+	}
+}

--- a/examples/endpoint-testing/readme.md
+++ b/examples/endpoint-testing/readme.md
@@ -1,0 +1,5 @@
+# Endpoint testing
+
+> Example for [endpoint testing](https://github.com/avajs/ava/blob/main/docs/recipes/endpoint-testing.md)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/endpoint-testing?file=test.js&terminal=test&view=editor)

--- a/examples/endpoint-testing/test.js
+++ b/examples/endpoint-testing/test.js
@@ -1,0 +1,23 @@
+'use strict';
+const http = require('http');
+
+const test = require('ava');
+const got = require('got');
+const listen = require('test-listen');
+
+const app = require('./app');
+
+test.before(async t => {
+	t.context.server = http.createServer(app);
+	t.context.prefixUrl = await listen(t.context.server);
+});
+
+test.after.always(t => {
+	t.context.server.close();
+});
+
+test.serial('get /user', async t => {
+	const {email} = await got('user', {prefixUrl: t.context.prefixUrl}).json();
+
+	t.is(email, 'ava@rocks.com');
+});


### PR DESCRIPTION
Added an example for the [Endpoint testing](https://github.com/avajs/ava/blob/main/docs/recipes/endpoint-testing.md) recipe.

[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/endpoint-testing/examples/endpoint-testing?file=test.js&terminal=test&view=editor)