### PR TITLE
Add StackBlitz examples for TypeScript

### DIFF
--- a/.xo-config.json
+++ b/.xo-config.json
@@ -3,7 +3,8 @@
 		"media/**",
 		"test/config/fixtures/config-errors/test.js",
 		"test-tap/fixture/snapshots/test-sourcemaps/build/**",
-		"test-tap/fixture/report/edgecases/ast-syntax-error.cjs"
+		"test-tap/fixture/report/edgecases/ast-syntax-error.cjs",
+		"examples/typescript-*/**/*.ts"
 	],
 	"rules": {
 		"import/no-anonymous-default-export": "off",

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -95,6 +95,8 @@ It's worth noting that with this configuration, tests will fail if there are Typ
 
 ## Writing tests
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/typescript-basic?file=source%2Ftest.ts&terminal=test&view=editor)
+
 Create a `test.ts` file.
 
 ```ts
@@ -185,6 +187,8 @@ test('providedTitle', macro, '3 * 3', 9);
 ```
 
 ## Typing [`t.context`](../01-writing-tests.md#test-context)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/typescript-context?file=source%2Ftest.ts&terminal=test&view=editor)
 
 By default, the type of `t.context` will be the empty object (`{}`). AVA exposes an interface `TestInterface<Context>` (in AVA 4 this is `TestFn<Context>`) which you can use to apply your own type to `t.context`. This can help you catch errors at compile-time:
 

--- a/examples/typescript-basic/package.json
+++ b/examples/typescript-basic/package.json
@@ -2,17 +2,17 @@
 	"name": "ava-typescript-basic",
 	"description": "Basic example for AVA with TypeScript",
 	"scripts": {
-		"compile": "tsc -p .",
-		"test": "npm run compile && ava"
+		"test": "ava"
 	},
 	"devDependencies": {
-		"@ava/typescript": "^1.1.1",
+		"@ava/typescript": "^2.0.0",
 		"@sindresorhus/tsconfig": "^1.0.2",
 		"ava": "^3.15.0",
 		"typescript": "^4.3.4"
 	},
 	"ava": {
 		"typescript": {
+			"compile": "tsc",
 			"rewritePaths": {
 				"source/": "build/"
 			}

--- a/examples/typescript-basic/package.json
+++ b/examples/typescript-basic/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "ava-typescript-basic",
+	"description": "Basic example for AVA with TypeScript",
+	"scripts": {
+		"test": "ava"
+	},
+	"devDependencies": {
+		"@sindresorhus/tsconfig": "^1.0.2",
+		"ava": "^3.15.0",
+		"ts-node": "^10.0.0",
+		"typescript": "^4.3.4"
+	},
+	"ava": {
+		"extensions": [
+			"ts"
+		],
+		"require": [
+			"ts-node/register"
+		]
+	}
+}

--- a/examples/typescript-basic/package.json
+++ b/examples/typescript-basic/package.json
@@ -2,20 +2,20 @@
 	"name": "ava-typescript-basic",
 	"description": "Basic example for AVA with TypeScript",
 	"scripts": {
-		"test": "ava"
+		"compile": "tsc -p .",
+		"test": "npm run compile && ava"
 	},
 	"devDependencies": {
+		"@ava/typescript": "^1.1.1",
 		"@sindresorhus/tsconfig": "^1.0.2",
 		"ava": "^3.15.0",
-		"ts-node": "^10.0.0",
 		"typescript": "^4.3.4"
 	},
 	"ava": {
-		"extensions": [
-			"ts"
-		],
-		"require": [
-			"ts-node/register"
-		]
+		"typescript": {
+			"rewritePaths": {
+				"source/": "build/"
+			}
+		}
 	}
 }

--- a/examples/typescript-basic/readme.md
+++ b/examples/typescript-basic/readme.md
@@ -1,0 +1,5 @@
+# TypeScript basic example
+
+> Basic example for [AVA with TypeScript](https://github.com/avajs/ava/blob/main/docs/recipes/typescript.md)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/typescript-basic?file=source%2Ftest.ts&terminal=test&view=editor)

--- a/examples/typescript-basic/source/index.ts
+++ b/examples/typescript-basic/source/index.ts
@@ -1,0 +1,3 @@
+export const sum = (a: number, b: number) => a + b;
+
+export const subtract = (a: number, b: number) => a - b;

--- a/examples/typescript-basic/source/test.ts
+++ b/examples/typescript-basic/source/test.ts
@@ -1,0 +1,13 @@
+import test from 'ava';
+
+import {sum, subtract} from '.';
+
+test('sum', t => {
+	t.is(sum(0, 0), 0);
+	t.is(sum(2, 2), 4);
+});
+
+test('subtract', t => {
+	t.is(subtract(0, 0), 0);
+	t.is(subtract(4, 2), 2);
+});

--- a/examples/typescript-basic/tsconfig.json
+++ b/examples/typescript-basic/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "@sindresorhus/tsconfig",
+	"compilerOptions": {
+		"module": "commonjs"
+	}
+}

--- a/examples/typescript-basic/tsconfig.json
+++ b/examples/typescript-basic/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
-		"module": "commonjs"
+		"module": "commonjs",
+		"outDir": "build",
 	}
 }

--- a/examples/typescript-context/package.json
+++ b/examples/typescript-context/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "ava-typescript-context",
+	"description": "TypeScript example for typing t.context",
+	"scripts": {
+		"test": "ava"
+	},
+	"devDependencies": {
+		"@sindresorhus/tsconfig": "^1.0.2",
+		"ava": "^3.15.0",
+		"ts-node": "^10.0.0",
+		"typescript": "^4.3.4"
+	},
+	"ava": {
+		"extensions": [
+			"ts"
+		],
+		"require": [
+			"ts-node/register"
+		]
+	}
+}

--- a/examples/typescript-context/package.json
+++ b/examples/typescript-context/package.json
@@ -2,20 +2,20 @@
 	"name": "ava-typescript-context",
 	"description": "TypeScript example for typing t.context",
 	"scripts": {
-		"test": "ava"
+		"compile": "tsc -p .",
+		"test": "npm run compile && ava"
 	},
 	"devDependencies": {
+		"@ava/typescript": "^1.1.1",
 		"@sindresorhus/tsconfig": "^1.0.2",
 		"ava": "^3.15.0",
-		"ts-node": "^10.0.0",
 		"typescript": "^4.3.4"
 	},
 	"ava": {
-		"extensions": [
-			"ts"
-		],
-		"require": [
-			"ts-node/register"
-		]
+		"typescript": {
+			"rewritePaths": {
+				"source/": "build/"
+			}
+		}
 	}
 }

--- a/examples/typescript-context/package.json
+++ b/examples/typescript-context/package.json
@@ -2,17 +2,17 @@
 	"name": "ava-typescript-context",
 	"description": "TypeScript example for typing t.context",
 	"scripts": {
-		"compile": "tsc -p .",
-		"test": "npm run compile && ava"
+		"test": "ava"
 	},
 	"devDependencies": {
-		"@ava/typescript": "^1.1.1",
+		"@ava/typescript": "^2.0.0",
 		"@sindresorhus/tsconfig": "^1.0.2",
 		"ava": "^3.15.0",
 		"typescript": "^4.3.4"
 	},
 	"ava": {
 		"typescript": {
+			"compile": "tsc",
 			"rewritePaths": {
 				"source/": "build/"
 			}

--- a/examples/typescript-context/readme.md
+++ b/examples/typescript-context/readme.md
@@ -1,0 +1,5 @@
+# TypeScript context example
+
+> TypeScript example for [typing `t.context`](https://github.com/avajs/ava/blob/main/docs/recipes/typescript.md#typing-tcontext)
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/avajs/ava/tree/main/examples/typescript-context?file=source%2Ftest.ts&terminal=test&view=editor)

--- a/examples/typescript-context/source/index.ts
+++ b/examples/typescript-context/source/index.ts
@@ -1,0 +1,1 @@
+export const concat = (input: string[]) => input.join(' ');

--- a/examples/typescript-context/source/test.ts
+++ b/examples/typescript-context/source/test.ts
@@ -1,0 +1,15 @@
+import anyTest, {TestInterface} from 'ava';
+
+import {concat} from '.';
+
+const test = anyTest as TestInterface<{sort: (a: string, b: string) => number}>;
+
+test.beforeEach(t => {
+	t.context = {
+		sort: (a: string, b: string) => a.localeCompare(b)
+	};
+});
+
+test('concat', t => {
+	t.is(concat(['b', 'c', 'a'].sort(t.context.sort)), 'a b c');
+});

--- a/examples/typescript-context/tsconfig.json
+++ b/examples/typescript-context/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "@sindresorhus/tsconfig",
+	"compilerOptions": {
+		"module": "commonjs"
+	}
+}

--- a/examples/typescript-context/tsconfig.json
+++ b/examples/typescript-context/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
-		"module": "commonjs"
+		"module": "commonjs",
+		"outDir": "build",
 	}
 }


### PR DESCRIPTION
I improved the TypeScript support on StackBlitz and added two TypeScript examples.

- [Basic example for AVA with TypeScript](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/typescript/examples/typescript-basic?file=source%2Ftest.ts&terminal=test&view=editor)
- [TypeScript example for typing `t.context`](https://stackblitz.com/github/SamVerschueren/ava/tree/stackblitz/examples/typescript/examples/typescript-context?file=source%2Ftest.ts&terminal=test&view=editor)