### PR TITLE
Clarify caching

### DIFF
--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -224,7 +224,7 @@ AVA itself does not cache files unless used with our [`@ava/babel`](https://gith
 npx ava reset-cache
 ```
 
-This notifies you if cache files within the `node_modules/.cache/ava` directory are deleted or if there are no cache files to be deleted.
+This deletes all files in the `node_modules/.cache/ava` directory.
 
 ## Reporters
 

--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -218,7 +218,7 @@ When running a file with and without line numbers, line numbers take precedence.
 
 ## Resetting AVA's cache
 
-AVA itself does not cache files unless used with our [`@ava/babel`](https://github.com/avajs/babel) provider. However, if it seems like your latest changes aren't being picked up by AVA you can try resetting the cache by running:
+AVA itself does not cache files unless used with our [`@ava/babel`](https://github.com/avajs/babel) provider. If it seems like your latest changes aren't being picked up by AVA you can try resetting the cache by running:
 
 ```console
 npx ava reset-cache

--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -218,13 +218,13 @@ When running a file with and without line numbers, line numbers take precedence.
 
 ## Resetting AVA's cache
 
-AVA may cache certain files, especially when you use our [`@ava/babel`](https://github.com/avajs/babel) provider. If it seems like your latest changes aren't being picked up by AVA you can reset the cache by running:
+AVA itself does not cache files unless used with our [`@ava/babel`](https://github.com/avajs/babel) provider. However, if it seems like your latest changes aren't being picked up by AVA you can try resetting the cache by running:
 
 ```console
 npx ava reset-cache
 ```
 
-This deletes all files in the `node_modules/.cache/ava` directory.
+This notifies you if cache files within the `node_modules/.cache/ava` directory are deleted or if there are no cache files to be deleted.
 
 ## Reporters
 

--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -45,7 +45,7 @@ Arguments passed to the CLI will always take precedence over the CLI options con
 - `files`: an array of glob patterns to select test files. Files with an underscore prefix are ignored. By default only selects files with `cjs`, `mjs` & `js` extensions, even if the pattern matches other files. Specify `extensions` to allow other file extensions
 - `ignoredByWatcher`: an array of glob patterns to match files that, even if changed, are ignored by the watcher. See the [watch mode recipe for details](https://github.com/avajs/ava/blob/main/docs/recipes/watch-mode.md)
 - `match`: not typically useful in the `package.json` configuration, but equivalent to [specifying `--match` on the CLI](./05-command-line.md#running-tests-with-matching-titles)
-- `cache`: cache compiled files under `node_modules/.cache/ava`. If `false`, files are cached in a temporary directory instead
+- `cache`: a boolean value on whether to cache compiled files under `node_modules/.cache/ava`. If `false`, files are cached in a temporary directory instead
 - `concurrency`: max number of test files running at the same time (default: CPU cores)
 - `workerThreads`: use worker threads to run tests (requires AVA 4, enabled by default). If `false`, tests will run in child processes (how AVA 3 behaves)
 - `failFast`: stop running further tests once a test fails

--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -45,7 +45,7 @@ Arguments passed to the CLI will always take precedence over the CLI options con
 - `files`: an array of glob patterns to select test files. Files with an underscore prefix are ignored. By default only selects files with `cjs`, `mjs` & `js` extensions, even if the pattern matches other files. Specify `extensions` to allow other file extensions
 - `ignoredByWatcher`: an array of glob patterns to match files that, even if changed, are ignored by the watcher. See the [watch mode recipe for details](https://github.com/avajs/ava/blob/main/docs/recipes/watch-mode.md)
 - `match`: not typically useful in the `package.json` configuration, but equivalent to [specifying `--match` on the CLI](./05-command-line.md#running-tests-with-matching-titles)
-- `cache`: a boolean value on whether to cache compiled files under `node_modules/.cache/ava`. If `false`, files are cached in a temporary directory instead
+- `cache`: defaults to `true` to cache compiled files under `node_modules/.cache/ava`. If `false`, files are cached in a temporary directory instead
 - `concurrency`: max number of test files running at the same time (default: CPU cores)
 - `workerThreads`: use worker threads to run tests (requires AVA 4, enabled by default). If `false`, tests will run in child processes (how AVA 3 behaves)
 - `failFast`: stop running further tests once a test fails

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,3 +1,4 @@
+import fsPromises from 'fs/promises';
 import {createRequire} from 'module';
 import path from 'path';
 
@@ -244,18 +245,21 @@ export default async () => { // eslint-disable-line complexity
 	const {nonSemVerExperiments: experiments, projectDir} = conf;
 	if (resetCache) {
 		const cacheDir = path.join(projectDir, 'node_modules', '.cache', 'ava');
+
 		try {
-			await del('*', {
-				cwd: cacheDir,
-				nodir: true
-			});
-			console.error(`\n${chalk.green(figures.tick)} Removed AVA cache files in ${cacheDir}`);
+			await fsPromises.access(cacheDir);
+		} catch {
+			console.log(`\n${chalk.green(figures.tick)} No cache files to remove`);
+			process.exit(0); // eslint-disable-line unicorn/no-process-exit
+		}
+
+		try {
+			await del('*', {cwd: cacheDir});
+			console.log(`\n${chalk.green(figures.tick)} Removed AVA cache files in ${cacheDir}`);
 			process.exit(0); // eslint-disable-line unicorn/no-process-exit
 		} catch (error) {
 			exit(`Error removing AVA cache files in ${cacheDir}\n\n${chalk.gray((error && error.stack) || error)}`);
 		}
-
-		return;
 	}
 
 	if (argv.watch) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,3 @@
-import fsPromises from 'fs/promises';
 import {createRequire} from 'module';
 import path from 'path';
 
@@ -247,15 +246,14 @@ export default async () => { // eslint-disable-line complexity
 		const cacheDir = path.join(projectDir, 'node_modules', '.cache', 'ava');
 
 		try {
-			await fsPromises.access(cacheDir);
-		} catch {
-			console.log(`\n${chalk.green(figures.tick)} No cache files to remove`);
-			process.exit(0); // eslint-disable-line unicorn/no-process-exit
-		}
+			const deletedFilePaths = await del('*', {cwd: cacheDir});
 
-		try {
-			await del('*', {cwd: cacheDir});
-			console.log(`\n${chalk.green(figures.tick)} Removed AVA cache files in ${cacheDir}`);
+			if (deletedFilePaths.length === 0) {
+				console.log(`\n${chalk.green(figures.tick)} No cache files to remove`);
+			} else {
+				console.log(`\n${chalk.green(figures.tick)} Removed AVA cache files in ${cacheDir}`);
+			}
+
 			process.exit(0); // eslint-disable-line unicorn/no-process-exit
 		} catch (error) {
 			exit(`Error removing AVA cache files in ${cacheDir}\n\n${chalk.gray((error && error.stack) || error)}`);


### PR DESCRIPTION
Hi! I'm new to AVA and while I was using it I noticed that subsequent runs didn't seem to finish faster even though I wasn't changing some of my test files. This prompted me to try setting up caching, so I set `"cache": true` in my `package.json` like the docs suggested. However, it didn't seem to make a difference and I couldn't find the specified `node_modules/.cache/ava` directory where the cache is supposed to be. Turns out, [AVA itself doesn't cache files unless used with `@ava/babel`](https://github.com/avajs/ava/issues/2481#issuecomment-622302992). This pull request aims to clarify this, both in the docs and when running `npx ava reset-cache`.

Some notes on the changes I made to the docs:

- I specified that the `cache` option is boolean because some (like I did) might think that it can be set to a directory where the cache will then be set.

Some notes on the changes I made to the `reset-cache` command:

- I removed the return statement at the end of the if check for `resetCache` because it is redundant as either `process.exit()` or `exit()` already terminates the script.
- I changed `console.error()` to `console.log()` because the message logged isn't an error.
- I removed the `nodir: true` option from `del` as it is not a valid option in `fast-glob`, [`fast-glob` instead uses `onlyFiles`](https://github.com/mrmlnc/fast-glob#compatible-with-node-glob) which is then set to `true` by default.