### PR TITLE
Match name of debug task to current VSCode

### DIFF
--- a/docs/recipes/debugging-with-vscode.md
+++ b/docs/recipes/debugging-with-vscode.md
@@ -8,7 +8,7 @@ You can debug your tests using [Visual Studio Code](https://code.visualstudio.co
 
 You can use VS Code's “JavaScript Debug Terminal” to automatically debug AVA run on the command-line.
 
-1. From the Command Palette (<kbd>F1</kbd> or <kbd>command + shift + p</kbd> / <kbd>control + shift + p</kbd>), run `Debug: Create JavaScript Debug Terminal`
+1. From the Command Palette (<kbd>F1</kbd> or <kbd>command + shift + p</kbd> / <kbd>control + shift + p</kbd>), run `Debug: JavaScript Debug Terminal`
 2. Run `npx ava` in the terminal
 
 ## Creating a launch configuration


### PR DESCRIPTION
The newer version of VSCode changed the command pallet text. This PR is just updating the README to reflect it. It took me a few seconds to find the command.

Awesome project by the way. I've been able to debug a test that easily before. 🎉 