### PR TITLE
Remove trim-off-newlines

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -8,7 +8,6 @@ import indentString from 'indent-string';
 import plur from 'plur';
 import prettyMs from 'pretty-ms';
 import StackUtils from 'stack-utils';
-import trimOffNewlines from 'trim-off-newlines';
 
 import {chalk} from '../chalk.js';
 import codeExcerpt from '../code-excerpt.js';
@@ -409,7 +408,7 @@ export default class Reporter {
 
 	writeErr(event) {
 		if (event.err.name === 'TSError' && event.err.object && event.err.object.diagnosticText) {
-			this.lineWriter.writeLine(colors.errorStack(trimOffNewlines(event.err.object.diagnosticText)));
+			this.lineWriter.writeLine(colors.errorStack(event.err.object.diagnosticText));
 			this.lineWriter.writeLine();
 			return;
 		}
@@ -442,7 +441,7 @@ export default class Reporter {
 				this.lineWriter.writeLine();
 			}
 		} else if (event.err.nonErrorObject) {
-			this.lineWriter.writeLine(trimOffNewlines(event.err.formatted));
+			this.lineWriter.writeLine(event.err.formatted);
 			this.lineWriter.writeLine();
 		} else {
 			this.lineWriter.writeLine(event.err.summary);

--- a/lib/reporters/format-serialized-error.js
+++ b/lib/reporters/format-serialized-error.js
@@ -1,5 +1,3 @@
-import trimOffNewlines from 'trim-off-newlines';
-
 import {chalk} from '../chalk.js';
 
 export default function formatSerializedError(error) {
@@ -13,13 +11,12 @@ export default function formatSerializedError(error) {
 
 	let formatted = '';
 	for (const value of error.values) {
-		formatted += `${value.label}\n\n${trimOffNewlines(value.formatted)}\n\n`;
+		formatted += `${value.label}\n\n${value.formatted}\n\n`;
 	}
 
 	for (const statement of error.statements) {
-		formatted += `${statement[0]}\n${chalk.grey('=>')} ${trimOffNewlines(statement[1])}\n\n`;
+		formatted += `${statement[0]}\n${chalk.grey('=>')} ${statement[1]}\n\n`;
 	}
 
-	formatted = trimOffNewlines(formatted);
-	return {formatted, printMessage};
+	return {formatted: formatted.trim(), printMessage};
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "ava",
 			"version": "4.0.0-alpha.2",
 			"license": "MIT",
 			"dependencies": {
@@ -57,7 +58,6 @@
 				"strip-ansi": "^6.0.0",
 				"supertap": "^2.0.0",
 				"temp-dir": "^2.0.0",
-				"trim-off-newlines": "^1.0.1",
 				"write-file-atomic": "^3.0.3",
 				"yargs": "^16.2.0"
 			},
@@ -12922,6 +12922,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
 			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -24181,7 +24182,8 @@
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+			"dev": true
 		},
 		"trivial-deferred": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
 		"strip-ansi": "^6.0.0",
 		"supertap": "^2.0.0",
 		"temp-dir": "^2.0.0",
-		"trim-off-newlines": "^1.0.1",
 		"write-file-atomic": "^3.0.3",
 		"yargs": "^16.2.0"
 	},


### PR DESCRIPTION
Concordance-formatted text shouldn't have newlines at the start or end. I'm not sure about power-assert output, but let's assume the same.

An extra newline around TypeScript diagnostic text is fine — this is only a convenience for in-process TypeScript compilation which requires a lot of custom configuration to be a thing.

For the remaining use case, trim() should suffice.
