### PR TITLE
Fix prefix normalization

### DIFF
--- a/lib/reporters/prefix-title.js
+++ b/lib/reporters/prefix-title.js
@@ -7,16 +7,17 @@ import {chalk} from '../chalk.js';
 const SEPARATOR = ' ' + chalk.gray.dim(figures.pointerSmall) + ' ';
 
 export default function prefixTitle(extensions, base, file, title) {
-	const prefix = file
+	const parts = file
 		// Only replace base if it is found at the start of the path
 		.replace(base, (match, offset) => offset === 0 ? '' : match)
-		.replace(/\.spec/, '')
-		.replace(/\.test/, '')
-		.replace(/test-/g, '')
-		.replace(new RegExp(`.(${extensions.join('|')})$`), '')
 		.split(path.sep)
-		.filter(p => p !== '__tests__')
-		.join(SEPARATOR);
+		.filter(p => p !== '__tests__');
 
-	return prefix + SEPARATOR + title;
+	const filename = parts.pop()
+		.replace(/\.spec\./, '.')
+		.replace(/\.test\./, '.')
+		.replace(/test-/, '')
+		.replace(new RegExp(`.(${extensions.join('|')})$`), '');
+
+	return [...parts, filename, title].join(SEPARATOR);
 }

--- a/test-tap/reporters/prefix-title.js
+++ b/test-tap/reporters/prefix-title.js
@@ -33,17 +33,33 @@ test('removes __tests__ from path', t => {
 	t.end();
 });
 
-test('removes .spec from path', t => {
+test('removes .spec from file', t => {
 	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend/run-status.spec.cjs'), 'title'), `backend${sep}run-status${sep}title`);
 	t.end();
 });
 
-test('removes .test from path', t => {
-	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend/run-status.test.cjs'), 'title'), `backend${sep}run-status${sep}title`);
+test('retains .spec elsewhere in path', t => {
+	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend.spec/run-status.cjs'), 'title'), `backend.spec${sep}run-status${sep}title`);
 	t.end();
 });
 
-test('removes test- from path', t => {
+test('removes .test from file', t => {
+	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend/run-status.test.cjs'), 'title'), `backend${sep}run-status${sep}title`);
+	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend/run-status.tests.cjs'), 'title'), `backend${sep}run-status.tests${sep}title`);
+	t.end();
+});
+
+test('retains .test elsewhere in path', t => {
+	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend.test/run-status.cjs'), 'title'), `backend.test${sep}run-status${sep}title`);
+	t.end();
+});
+
+test('removes test- from file', t => {
 	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend/test-run-status.cjs'), 'title'), `backend${sep}run-status${sep}title`);
+	t.end();
+});
+
+test('retains test- elsewhere in path', t => {
+	t.equal(prefixTitle(['cjs'], path.sep, path.normalize('backend-test/run-status.cjs'), 'title'), `backend-test${sep}run-status${sep}title`);
 	t.end();
 });


### PR DESCRIPTION
Remove .test, .spec and test- from filenames, in line with the default glob patterns. Retain elsewhere in the path.

Fixes #2793.
