### PR TITLE
Fix typo for Next generation configuration

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -197,7 +197,7 @@ export default {
 	nonSemVerExperiments: {
 		nextGenConfig: true
 	},
-	files: ['unit-tests/**/*]
+	files: ['unit-tests/**/*']
 };
 ```
 


### PR DESCRIPTION
Fixes missing `'` for the files path config example