### PR TITLE
Final ESM tweaks

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -251,7 +251,7 @@ export default {
 };
 ```
 
-### Configuring module formats
+## Configuring module formats
 
 Node.js can only load non-standard extension as ES Modules when using [experimental loaders](https://nodejs.org/docs/latest/api/esm.html#esm_experimental_loaders). To use this you'll also have to configure AVA to `import()` your test file.
 
@@ -264,9 +264,6 @@ As with the array form, you need to explicitly list `js`, `cjs`, and `mjs` exten
 `ava.config.js`:
 ```js
 export default {
-	nonSemVerExperiments: {
-		configurableModuleFormat: true
-	},
 	extensions: {
 		js: true,
 		ts: 'module'

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -133,18 +133,19 @@ const run = async options => {
 
 	const require = createRequire(import.meta.url);
 	const load = async ref => {
-		for (const extension of extensionsToLoadAsModules) {
-			if (ref.endsWith(`.${extension}`)) {
-				return import(pathToFileURL(ref)); // eslint-disable-line node/no-unsupported-features/es-syntax
-			}
-		}
-
 		for (const provider of providers) {
 			if (provider.canLoad(ref)) {
 				return provider.load(ref, {requireFn: require});
 			}
 		}
 
+		for (const extension of extensionsToLoadAsModules) {
+			if (ref.endsWith(`.${extension}`)) {
+				return import(pathToFileURL(ref)); // eslint-disable-line node/no-unsupported-features/es-syntax
+			}
+		}
+
+		// We still support require() since it's more easily monkey-patched.
 		return require(ref);
 	};
 


### PR DESCRIPTION
* Allow providers to load files even if they're ESM.
* Clarify why we still require().
* Update documentation since module format configuration is no longer experimental.
