### PR TITLE
Mention experimental specifier resolution in TypeScript recipe

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -39,7 +39,8 @@ If your `package.json` has `"type": "module"`, then this is the AVA configuratio
 			"configurableModuleFormat": true
 		},
 		"nodeArguments": [
-			"--loader=ts-node/esm"
+			"--loader=ts-node/esm",
+			"--experimental-specifier-resolution=node"
 		]
 	}
 }
@@ -56,7 +57,6 @@ You also need to have this in your `tsconfig.json`:
 }
 ```
 
-And finally, even though you directly import code from your TypeScript files, you **must** import it from your `.ts` files with the `.js` extension instead!
 
 For example if your source file is `index.ts` looks like this:
 
@@ -70,7 +70,10 @@ Then in your AVA test files you must import it **as if it has the `.js` extensio
 import {myFunction} from './index.js';
 ```
 
-The reason that you need to write `.js` to import `.ts` files in your AVA test files, is explained by the `ts-node` author [in this post](https://github.com/nodejs/modules/issues/351#issuecomment-621257543).
+**NOTE** about the nodeArgument `--experimental-specifier-resolution=node`:    
+This instructs node to attempt to resolve file extensions by "guessing" the most likely extension, whereas the default requires that one is explicit.
+You can omit this setting if your code explicitly includes the `.js` extension when importing (although this is unlikely in a typescript project)   
+See [this ts-node issue](https://github.com/TypeStrong/ts-node/issues/1007) for details.
 
 #### For packages without type "module"
 

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -57,19 +57,6 @@ You also need to have this in your `tsconfig.json`:
 }
 ```
 
-
-For example if your source file is `index.ts` looks like this:
-
-```ts
-export function myFunction() {}
-```
-
-Then in your AVA test files you must import it **as if it has the `.js` extension** it like so:
-
-```ts
-import {myFunction} from './index.js';
-```
-
 **NOTE** about the nodeArgument `--experimental-specifier-resolution=node`:    
 This instructs node to attempt to resolve file extensions by "guessing" the most likely extension, whereas the default requires that one is explicit.
 You can omit this setting if your code explicitly includes the `.js` extension when importing (although this is unlikely in a typescript project)   

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -39,8 +39,7 @@ If your `package.json` has `"type": "module"`, then this is the AVA configuratio
 			"configurableModuleFormat": true
 		},
 		"nodeArguments": [
-			"--loader=ts-node/esm",
-			"--experimental-specifier-resolution=node"
+			"--loader=ts-node/esm"
 		]
 	}
 }
@@ -57,10 +56,9 @@ You also need to have this in your `tsconfig.json`:
 }
 ```
 
-**NOTE** about the nodeArgument `--experimental-specifier-resolution=node`:    
-This instructs node to attempt to resolve file extensions by "guessing" the most likely extension, whereas the default requires that one is explicit.
-You can omit this setting if your code explicitly includes the `.js` extension when importing (although this is unlikely in a typescript project)   
-See [this ts-node issue](https://github.com/TypeStrong/ts-node/issues/1007) for details.
+Remember that, by default, ES modules require you to specify the file extension and TypeScript outputs `.js` files, so you have to write your imports to load from `.js` files not `.ts`.
+
+If this is not to your liking there is an _experimental_ option in Node.js that you might want to use. You can add it to the `nodeArguments` array in the AVA configuration so it applies to your test runs: [`--experimental-specifier-resolution=node`](https://nodejs.org/api/esm.html#customizing-esm-specifier-resolution-algorithm).
 
 #### For packages without type "module"
 


### PR DESCRIPTION
Using the nodeArgument `--experimental-specifier-resolution=node` makes it so one you don't have to add the `.js` extension to files when importing for your tests. (Such things are not feasible for people with large typescript workspaces)

This PR just updates the typescript recipe to suggest such a change. 