### PR TITLE
Remove dependency on `equal-length`

### DIFF
--- a/lib/code-excerpt.js
+++ b/lib/code-excerpt.js
@@ -33,7 +33,7 @@ export default function exceptCode(source, options = {}) {
 		value: truncate(item.value, maxWidth - String(line).length - 5),
 	}));
 
-	const extendedWidth = Math.max.apply(null, lines.map(item => item.value.length));
+	const extendedWidth = Math.max(...lines.map(item => item.value.length));
 
 	return lines
 		.map(item => {
@@ -41,8 +41,7 @@ export default function exceptCode(source, options = {}) {
 
 			const lineNumber = formatLineNumber(item.line, line) + ':';
 			const coloredLineNumber = isErrorSource ? lineNumber : chalk.grey(lineNumber);
-			const paddedLineValue = item.value.padEnd(extendedWidth);
-			const result = ` ${coloredLineNumber} ${paddedLineValue}`;
+			const result = ` ${coloredLineNumber} ${item.value.padEnd(extendedWidth)}`;
 
 			return isErrorSource ? chalk.bgRed(result) : result;
 		})

--- a/lib/code-excerpt.js
+++ b/lib/code-excerpt.js
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 
 import truncate from 'cli-truncate';
 import codeExcerpt from 'code-excerpt';
-import equalLength from 'equal-length';
 
 import {chalk} from './chalk.js';
 
@@ -34,20 +33,16 @@ export default function exceptCode(source, options = {}) {
 		value: truncate(item.value, maxWidth - String(line).length - 5),
 	}));
 
-	const joinedLines = lines.map(line => line.value).join('\n');
-	const extendedLines = equalLength(joinedLines).split('\n');
+	const extendedWidth = Math.max.apply(null, lines.map(item => item.value.length));
 
 	return lines
-		.map((item, index) => ({
-			line: item.line,
-			value: extendedLines[index],
-		}))
 		.map(item => {
 			const isErrorSource = item.line === line;
 
 			const lineNumber = formatLineNumber(item.line, line) + ':';
 			const coloredLineNumber = isErrorSource ? lineNumber : chalk.grey(lineNumber);
-			const result = ` ${coloredLineNumber} ${item.value}`;
+			const paddedLineValue = item.value.padEnd(extendedWidth);
+			const result = ` ${coloredLineNumber} ${paddedLineValue}`;
 
 			return isErrorSource ? chalk.bgRed(result) : result;
 		})

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
 				"debug": "^4.3.2",
 				"del": "^6.0.0",
 				"emittery": "^0.10.0",
-				"equal-length": "^1.0.1",
 				"figures": "^4.0.0",
 				"globby": "^12.0.2",
 				"ignore-by-default": "^2.0.0",
@@ -3532,6 +3531,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
 			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
 		"debug": "^4.3.2",
 		"del": "^6.0.0",
 		"emittery": "^0.10.0",
-		"equal-length": "^1.0.1",
 		"figures": "^4.0.0",
 		"globby": "^12.0.2",
 		"ignore-by-default": "^2.0.0",


### PR DESCRIPTION
It's tiny, but still superfluous for a single point of use.
