### PR TITLE
Remove outdated AVA 3 config from TypeScript recipe

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -35,9 +35,6 @@ If your `package.json` has `"type": "module"`, then this is the AVA configuratio
 		"extensions": {
 			"ts": "module"
 		},
-		"nonSemVerExperiments": {
-			"configurableModuleFormat": true
-		},
 		"nodeArguments": [
 			"--loader=ts-node/esm"
 		]


### PR DESCRIPTION
https://github.com/avajs/ava/issues/2945
Fix according to this [comment](https://github.com/avajs/ava/issues/2945#issuecomment-1013024157)
> Nice find, that documentation is outdated. The feature is no longer experimental in AVA 4 so this needs to be removed:
> 
> ```
>     "nonSemVerExperiments": {
>       "configurableModuleFormat": true
>     },
> ```

