### PR TITLE
Remove reference to enhanced assertion messages

### DIFF
--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -18,8 +18,6 @@ AVA will set `process.env.NODE_ENV` to `test`, unless the `NODE_ENV` environment
 
 To declare a test you call the `test` function you imported from AVA. Provide the required title and implementation function. Titles must be unique within each test file. The function will be called when your test is run. It's passed an [execution object](./02-execution-context.md) as its first argument.
 
-**Note:** In order for the [enhanced assertion messages](./03-assertions.md#enhanced-assertion-messages) to behave correctly, the first argument **must** be named `t`.
-
 ```js
 const test = require('ava');
 


### PR DESCRIPTION
This has been removed in AVA 4.
