### PR TITLE
resolveCwd doesn't work when use ava from an npm linked project

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -9,7 +9,6 @@ import commonPathPrefix from 'common-path-prefix';
 import Emittery from 'emittery';
 import ms from 'ms';
 import pMap from 'p-map';
-import resolveCwd from 'resolve-cwd';
 import tempDir from 'temp-dir';
 
 import fork from './fork.js';
@@ -23,7 +22,7 @@ import serializeError from './serialize-error.js';
 
 function resolveModules(modules) {
 	return arrify(modules).map(name => {
-		const modulePath = resolveCwd.silent(name);
+		const modulePath = require.resolve(name);
 
 		if (modulePath === undefined) {
 			throw new Error(`Could not resolve required module ’${name}’`);


### PR DESCRIPTION
A common senario:
Project A depends on ava. Project B depends on project A. In Project A, call `npm link`. In project B, call `npm link ProjectA`. Now in project B tests are broken because resolveCwd cannot find ts-node/register:
```
Error: Could not resolve required module ’ts-node/register’
```

However, nodejs's `require` can find it, and also `require.resolve`. And use `require.resolve` doesn't break in original setup of ava so i use `require.resolve`.

Also with `console.log` I noticed that this `resolveModules` only tries to resolve one module: `ts-node/register`. What is the purpose of this method?