### PR TITLE
Support message testing function in `throws` & `throwsAsync` assertions

### DIFF
--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -172,7 +172,10 @@ Assert that an error is thrown. `fn` must be a function which should throw. The 
 
 * `instanceOf`: a constructor, the thrown error must be an instance of
 * `is`: the thrown error must be strictly equal to `expectation.is`
-* `message`: either a *string*, which is compared against the thrown error's message, a *regular expression*, which is matched against this message or a *function* which is passed the thrown error message and must return a boolean. true makes the assertion pass
+* `message`: the following types are valid: 
+  * *string* - it is compared against the thrown error's message
+  * *regular expression* - it is matched against this message
+  * *function* - it is passed the thrown error message and must return a boolean for whether the assertion passed
 * `name`: the expected `.name` value of the thrown error
 * `code`: the expected `.code` value of the thrown error
 
@@ -204,7 +207,10 @@ The thrown value *must* be an error. It is returned so you can run more assertio
 
 * `instanceOf`: a constructor, the thrown error must be an instance of
 * `is`: the thrown error must be strictly equal to `expectation.is`
-* `message`: either a *string*, which is compared against the thrown error's message, a *regular expression*, which is matched against this message or a *function* which is passed the thrown error message and must return a boolean. true makes the assertion pass
+* `message`: the following types are valid: 
+  * *string* - it is compared against the thrown error's message
+  * *regular expression* - it is matched against this message
+  * *function* - it is passed the thrown error message and must return a boolean for whether the assertion passed
 * `name`: the expected `.name` value of the thrown error
 * `code`: the expected `.code` value of the thrown error
 

--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -172,7 +172,7 @@ Assert that an error is thrown. `fn` must be a function which should throw. The 
 
 * `instanceOf`: a constructor, the thrown error must be an instance of
 * `is`: the thrown error must be strictly equal to `expectation.is`
-* `message`: either a string, which is compared against the thrown error's message, or a regular expression, which is matched against this message
+* `message`: either a *string*, which is compared against the thrown error's message, a *regular expression*, which is matched against this message or a *function* which is passed the thrown error message and must return a boolean. true makes the assertion pass
 * `name`: the expected `.name` value of the thrown error
 * `code`: the expected `.code` value of the thrown error
 
@@ -204,7 +204,7 @@ The thrown value *must* be an error. It is returned so you can run more assertio
 
 * `instanceOf`: a constructor, the thrown error must be an instance of
 * `is`: the thrown error must be strictly equal to `expectation.is`
-* `message`: either a string, which is compared against the thrown error's message, or a regular expression, which is matched against this message
+* `message`: either a *string*, which is compared against the thrown error's message, a *regular expression*, which is matched against this message or a *function* which is passed the thrown error message and must return a boolean. true makes the assertion pass
 * `name`: the expected `.name` value of the thrown error
 * `code`: the expected `.code` value of the thrown error
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -106,11 +106,16 @@ function validateExpectations(assertion, expectations, numberArgs) { // eslint-d
 			});
 		}
 
-		if (hasOwnProperty(expectations, 'message') && typeof expectations.message !== 'string' && !(expectations.message instanceof RegExp)) {
+		if (
+			hasOwnProperty(expectations, "message") &&
+			typeof expectations.message !== "string" &&
+			!(expectations.message instanceof RegExp) &&
+			!(expectations.message instanceof Function)
+		) {
 			throw new AssertionError({
 				assertion,
 				message: `The \`message\` property of the second argument to \`t.${assertion}()\` must be a string or regular expression`,
-				values: [formatWithLabel('Called with:', expectations)],
+				values: [formatWithLabel("Called with:", expectations)],
 			});
 		}
 
@@ -226,6 +231,19 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 			values: [
 				formatWithLabel(`${prefix} unexpected exception:`, actual),
 				formatWithLabel('Expected message to match:', expectations.message),
+			],
+		});
+	}
+
+	if (expectations.message instanceof Function && expectations.message(actual.message) === false) {
+		throw new AssertionError({
+			assertion,
+			message,
+			savedError,
+			actualStack,
+			values: [
+				formatWithLabel(`${prefix} unexpected exception:`, actual),
+				formatWithLabel('Expected message to return true:', expectations.message),
 			],
 		});
 	}

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -107,15 +107,15 @@ function validateExpectations(assertion, expectations, numberArgs) { // eslint-d
 		}
 
 		if (
-			hasOwnProperty(expectations, "message") &&
-			typeof expectations.message !== "string" &&
-			!(expectations.message instanceof RegExp) &&
-			!(expectations.message instanceof Function)
+			hasOwnProperty(expectations, 'message')
+			&& typeof expectations.message !== 'string'
+			&& !(expectations.message instanceof RegExp)
+			&& !(expectations.message instanceof Function)
 		) {
 			throw new AssertionError({
 				assertion,
 				message: `The \`message\` property of the second argument to \`t.${assertion}()\` must be a string or regular expression`,
-				values: [formatWithLabel("Called with:", expectations)],
+				values: [formatWithLabel('Called with:', expectations)],
 			});
 		}
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -110,7 +110,7 @@ function validateExpectations(assertion, expectations, numberArgs) { // eslint-d
 			hasOwnProperty(expectations, 'message')
 			&& typeof expectations.message !== 'string'
 			&& !(expectations.message instanceof RegExp)
-			&& !(expectations.message instanceof Function)
+			&& !(typeof expectations.message === 'function')
 		) {
 			throw new AssertionError({
 				assertion,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -114,7 +114,7 @@ function validateExpectations(assertion, expectations, numberArgs) { // eslint-d
 		) {
 			throw new AssertionError({
 				assertion,
-				message: `The \`message\` property of the second argument to \`t.${assertion}()\` must be a string or regular expression`,
+				message: `The \`message\` property of the second argument to \`t.${assertion}()\` must be a string, regular expression or a function`,
 				values: [formatWithLabel('Called with:', expectations)],
 			});
 		}
@@ -235,7 +235,7 @@ function assertExpectations({assertion, actual, expectations, message, prefix, s
 		});
 	}
 
-	if (expectations.message instanceof Function && expectations.message(actual.message) === false) {
+	if (typeof expectations.message === 'function' && expectations.message(actual.message) === false) {
 		throw new AssertionError({
 			assertion,
 			message,

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -899,6 +899,54 @@ test('.throws()', gather(t => {
 			formatted: /null/,
 		}],
 	});
+
+	// Fails because the string in the message is incorrect
+	failsWith(
+		t,
+		() => assertions.throws(() => { throw new Error('error') }, { message: 'my error' }),
+		{
+			assertion: 'throws',
+			message: "",
+			values: [
+				{ label: 'Function threw unexpected exception:', formatted: /error/ },
+				{ label: 'Expected message to equal:', formatted: /my error/ }
+			],
+		}
+	);
+
+	passes(t, () => assertions.throws(() => { throw new Error('error') }, { message: 'error' }));
+
+	// Fails because the regular expression in the message is incorrect
+	failsWith(
+		t,
+		() => assertions.throws(() => { throw new Error('error') }, { message: /my error/ }),
+		{
+			assertion: 'throws',
+			message: "",
+			values: [
+				{ label: 'Function threw unexpected exception:', formatted: /error/ },
+				{ label: 'Expected message to match:', formatted: /my error/ }
+			],
+		}
+	);
+
+	passes(t, () => assertions.throws(() => { throw new Error('error') }, { message: /error/ }));
+
+	// Fails because the function in the message returns false
+	failsWith(
+		t,
+		() => assertions.throws(() => { throw new Error('error') }, { message: () => false }),
+		{
+			assertion: 'throws',
+			message: "",
+			values: [
+				{ label: 'Function threw unexpected exception:', formatted: /error/ },
+				{ label: 'Expected message to return true:', formatted: /Function/ }
+			],
+		}
+	);
+
+	passes(t, () => assertions.throws(() => { throw new Error('error') }, { message: () => true }));
 }));
 
 test('.throws() returns the thrown error', t => {

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -903,50 +903,74 @@ test('.throws()', gather(t => {
 	// Fails because the string in the message is incorrect
 	failsWith(
 		t,
-		() => assertions.throws(() => { throw new Error('error') }, { message: 'my error' }),
+		() =>
+			assertions.throws(
+				() => {
+					throw new Error('error');
+				},
+				{message: 'my error'},
+			),
 		{
 			assertion: 'throws',
-			message: "",
+			message: '',
 			values: [
-				{ label: 'Function threw unexpected exception:', formatted: /error/ },
-				{ label: 'Expected message to equal:', formatted: /my error/ }
+				{label: 'Function threw unexpected exception:', formatted: /error/},
+				{label: 'Expected message to equal:', formatted: /my error/},
 			],
-		}
+		},
 	);
 
-	passes(t, () => assertions.throws(() => { throw new Error('error') }, { message: 'error' }));
+	passes(t, () => assertions.throws(() => {
+		throw new Error('error');
+	}, {message: 'error'}));
 
 	// Fails because the regular expression in the message is incorrect
 	failsWith(
 		t,
-		() => assertions.throws(() => { throw new Error('error') }, { message: /my error/ }),
+		() =>
+			assertions.throws(
+				() => {
+					throw new Error('error');
+				},
+				{message: /my error/},
+			),
 		{
 			assertion: 'throws',
-			message: "",
+			message: '',
 			values: [
-				{ label: 'Function threw unexpected exception:', formatted: /error/ },
-				{ label: 'Expected message to match:', formatted: /my error/ }
+				{label: 'Function threw unexpected exception:', formatted: /error/},
+				{label: 'Expected message to match:', formatted: /my error/},
 			],
-		}
+		},
 	);
 
-	passes(t, () => assertions.throws(() => { throw new Error('error') }, { message: /error/ }));
+	passes(t, () => assertions.throws(() => {
+		throw new Error('error');
+	}, {message: /error/}));
 
 	// Fails because the function in the message returns false
 	failsWith(
 		t,
-		() => assertions.throws(() => { throw new Error('error') }, { message: () => false }),
+		() =>
+			assertions.throws(
+				() => {
+					throw new Error('error');
+				},
+				{message: () => false},
+			),
 		{
 			assertion: 'throws',
-			message: "",
+			message: '',
 			values: [
-				{ label: 'Function threw unexpected exception:', formatted: /error/ },
-				{ label: 'Expected message to return true:', formatted: /Function/ }
+				{label: 'Function threw unexpected exception:', formatted: /error/},
+				{label: 'Expected message to return true:', formatted: /Function/},
 			],
-		}
+		},
 	);
 
-	passes(t, () => assertions.throws(() => { throw new Error('error') }, { message: () => true }));
+	passes(t, () => assertions.throws(() => {
+		throw new Error('error');
+	}, {message: () => true}));
 }));
 
 test('.throws() returns the thrown error', t => {

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -1066,7 +1066,7 @@ test('.throws() fails if passed a bad expectation', t => {
 
 	failsWith(t, () => assertions.throws(() => {}, {message: null}), {
 		assertion: 'throws',
-		message: 'The `message` property of the second argument to `t.throws()` must be a string or regular expression',
+		message: 'The `message` property of the second argument to `t.throws()` must be a string, regular expression or a function',
 		values: [{label: 'Called with:', formatted: /message: null/}],
 	});
 
@@ -1136,7 +1136,7 @@ test('.throwsAsync() fails if passed a bad expectation', t => {
 
 	failsWith(t, () => assertions.throwsAsync(() => {}, {message: null}), {
 		assertion: 'throwsAsync',
-		message: 'The `message` property of the second argument to `t.throwsAsync()` must be a string or regular expression',
+		message: 'The `message` property of the second argument to `t.throwsAsync()` must be a string, regular expression or a function',
 		values: [{label: 'Called with:', formatted: /message: null/}],
 	}, {expectBoolean: false});
 

--- a/types/assertions.d.ts
+++ b/types/assertions.d.ts
@@ -12,7 +12,7 @@ export type ThrowsExpectation = {
 	is?: Error;
 
 	/** The thrown error must have a message that equals the given string, or matches the regular expression. */
-	message?: string | RegExp | Function;
+	message?: string | RegExp | ((message: string) => boolean);
 
 	/** The thrown error must have a name that equals the given string. */
 	name?: string;

--- a/types/assertions.d.ts
+++ b/types/assertions.d.ts
@@ -12,7 +12,7 @@ export type ThrowsExpectation = {
 	is?: Error;
 
 	/** The thrown error must have a message that equals the given string, or matches the regular expression. */
-	message?: string | RegExp;
+	message?: string | RegExp | Function;
 
 	/** The thrown error must have a name that equals the given string. */
 	name?: string;


### PR DESCRIPTION
Fixes #2978 

As per the issue #2978, I have added support for function in `throws`/`throwsAsync` assertion. I have also updated the docs regarding the same. I couldn't find any tests to be updated so I have left them.

How to use?

```js
await t.throwsAsync(async () => {
	throw new TypeError('🦄');
}, {
	message: message => ['🦄', '🐴'].includes(message)
});
```

Note: This is my first PR in ava so I may have missed something. Please let me know. I will fix it. For example, I am not sure about the [assertion message](https://github.com/il3ven/ava/blob/cbb8d584b358ddbf55824d935c1a151d9c67ba1a/lib/assert.js#L238-L249) to show in case of failure.