### PR TITLE
Allow parallel builds to be disabled

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -59,6 +59,7 @@ Arguments passed to the CLI will always take precedence over the CLI options con
 - `timeout`: Timeouts in AVA behave differently than in other test frameworks. AVA resets a timer after each test, forcing tests to quit if no new test results were received within the specified timeout. This can be used to handle stalled tests. See our [timeout documentation](./07-test-timeouts.md) for more options.
 - `nodeArguments`: Configure Node.js arguments used to launch worker processes.
 - `sortTestFiles`: A comparator function to sort test files with. Available only when using a `ava.config.*` file. See an example use case [here](recipes/splitting-tests-ci.md).
+- `utilizeParallelBuilds`: If `false`, disable [parallel builds](/docs/recipes/splitting-tests-ci.md) (default: true)
 
 Note that providing files on the CLI overrides the `files` option.
 

--- a/docs/recipes/splitting-tests-ci.md
+++ b/docs/recipes/splitting-tests-ci.md
@@ -20,3 +20,7 @@ export default {
 	sortTestFiles: (file1, file2) => testData[file1].order - testData[file2].order,
 };
 ```
+
+**Disable parallel builds**
+
+To disable this feature, set `utilizeParallelBuilds` to `false` in your [AVA configuration](/docs/06-configuration.md#options).

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -393,7 +393,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 	}
 
 	let parallelRuns = null;
-	if (isCi && ciParallelVars) {
+	if (isCi && ciParallelVars && combined.utilizeParallelBuilds !== false) {
 		const {index: currentIndex, total: totalRuns} = ciParallelVars;
 		parallelRuns = {currentIndex, totalRuns};
 	}


### PR DESCRIPTION
Closes #2994 

This PR adds an option `utilizeParallelBuilds` to enable/disable parallel builds. By default, the value of `utilizeParallelBuilds` is true. Setting it to false will disable automatic parallel builds in CI.

For testing purposes I made a GitHub [repo](https://github.com/il3ven/ava-playground) and ran test cases in CI using the [branch](https://github.com/il3ven/ava/tree/parallelBuilds) of this PR.
- With `utilizeParallelBuilds` set to [undefined](https://github.com/il3ven/ava-playground/blob/6a1ec4505a53d0d8bd8fadc3014b6a302279a77d/ava.config.js). We can see test cases being executed in parallel. 
  Ref: https://github.com/il3ven/ava-playground/runs/5831541253 (Check npx ava)
- With `utilizeParallelBuilds` set to [false](https://github.com/il3ven/ava-playground/blob/b666d136c106f1de1e0741aa55e004c623461141/ava.config.js). We can see test cases *not* being executed in parallel.
  Ref: https://github.com/il3ven/ava-playground/runs/5831147820 (Check npx ava)

As usual, I am happy to incorporate any suggestions to this PR. 😄 