### PR TITLE
Improve typing of teardown methods

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -41,7 +41,7 @@ export namespace SharedWorker {
 		readonly file: string;
 		publish: (data: Data) => PublishedMessage<Data>;
 		subscribe: () => AsyncIterableIterator<ReceivedMessage<Data>>;
-		teardown: <TeardownFn extends () => void> (fn: TeardownFn) => TeardownFn;
+		teardown: (fn: (() => Promise<void>) | (() => void)) => () => Promise<void>;
 	};
 
 	export namespace Plugin {

--- a/test-d/plugin.ts
+++ b/test-d/plugin.ts
@@ -5,5 +5,13 @@ import * as plugin from '../plugin'; // eslint-disable-line import/extensions
 expectType<plugin.SharedWorker.Plugin.Protocol>(plugin.registerSharedWorker({filename: '', supportedProtocols: ['ava-4']}));
 
 const factory: plugin.SharedWorker.Factory = ({negotiateProtocol}) => { // eslint-disable-line @typescript-eslint/no-unused-vars
-	expectType<plugin.SharedWorker.Protocol>(negotiateProtocol(['ava-4']));
+	const protocol = negotiateProtocol(['ava-4']);
+	expectType<plugin.SharedWorker.Protocol>(protocol);
+
+	(async () => {
+		for await (const w of protocol.testWorkers()) {
+			expectType<() => Promise<void>>(w.teardown(() => {})); // eslint-disable-line @typescript-eslint/no-empty-function
+			expectType<() => Promise<void>>(w.teardown(async () => {})); // eslint-disable-line @typescript-eslint/no-empty-function
+		}
+	})();
 };

--- a/test-d/teardown.ts
+++ b/test-d/teardown.ts
@@ -1,0 +1,6 @@
+import test from '..';
+
+test('test', t => {
+	t.teardown(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+	t.teardown(async () => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+});

--- a/types/test-fn.d.ts
+++ b/types/test-fn.d.ts
@@ -46,7 +46,7 @@ export interface PlanFn {
 export type TimeoutFn = (ms: number, message?: string) => void;
 
 /** Declare a function to be run after the test has ended. */
-export type TeardownFn = (fn: () => void) => void;
+export type TeardownFn = (fn: (() => Promise<void>) | (() => void)) => void;
 
 export type ImplementationFn<Args extends unknown[], Context = unknown> =
 	((t: ExecutionContext<Context>, ...args: Args) => PromiseLike<void>) |


### PR DESCRIPTION
- Explicitly type t.teardown() functions to return a promise
- Fix typing of plugin teardown. The returned method always returns Promise<void>.

The teardown functions may or may not return a promise. Support both to help with the @typescript-eslint/no-misused-promises ESLint rule.
