### PR TITLE
Avoid crash when --openssl-legacy-provider or --max-old-space-size are set

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -81,7 +81,8 @@ export default function loadFork(file, options, execArgv = process.execArgv) {
 		...options,
 	};
 
-	const {worker, postMessage, close} = createWorker(options, execArgv);
+	const filteredArgv = execArgv.filter(v => !/^--(openssl-legacy-provider|max-old-space-size=)/.test(v));
+	const {worker, postMessage, close} = createWorker(options, filteredArgv);
 	worker.stdout.on('data', chunk => {
 		emitStateChange({type: 'worker-stdout', chunk});
 	});


### PR DESCRIPTION
When `nodeArguments` includes either `--openssl-legacy-provider` or `--max-old-space-size` (e.g. `--max-old-space-size=8192`), testing fails with an internal error:

```
  ✖ Internal error
  Error [ERR_WORKER_INVALID_EXEC_ARGV]: Initiated Worker with invalid execArgv flags: --openssl-legacy-provider
  Error [ERR_WORKER_INVALID_EXEC_ARGV]: Initiated Worker with invalid execArgv flags: --openssl-legacy-provider
      at new NodeError (node:internal/errors:372:5)
      at new Worker (node:internal/worker:191:13)
      at createWorker (file:///.../ava/lib/fork.js:24:12)
      at loadFork (file:///.../ava/lib/fork.js:88:39)
      at pMap.concurrency.concurrency (file:///.../ava/lib/api.js:286:20)
      at file:///.../ava/node_modules/p-map/index.js:100:26
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This happens for [any `execArgv` options not supported by Workers](https://nodejs.org/api/worker_threads.html#new-workerfilename-options): 

> V8 options (such as --max-old-space-size) and options that affect the process (such as --title) are not supported.

At least for `--openssl-legacy-provider`, the worker threads inherit the setting from the parent process anyways. In my case, I need `--openssl-legacy-provider` enabled to support `ripemd160` hashing on Node v18.0.0:

`/path/to/test.mjs`:

```js
import crypto from 'node:crypto';
console.log(`Empty ripemd160 hash: ${crypto.createHash('ripemd160').digest().toString('hex')}`);
```

Running `node` (without `--openssl-legacy-provider`), this test script throws an error:

```
❯ node
Welcome to Node.js v18.0.0.
Type ".help" for more information.
> new worker_threads.Worker('/path/to/test.mjs', {execArgv: ['--openssl-legacy-provider']})
Worker { ... }
> Uncaught Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:67:19)
    at Object.createHash (node:crypto:133:10)
    at file:///path/to/test.mjs:5:6
    at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:409:24)
    at async loadESM (node:internal/process/esm_loader:85:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED',
  domainEmitter: Worker { ... }
```

If we use `node --openssl-legacy-provider`, the test script works:

```
❯ node --openssl-legacy-provider
Welcome to Node.js v18.0.0.
Type ".help" for more information.
> console.log(`Empty ripemd160 hash: ${crypto.createHash('ripemd160').digest().toString('hex')}`);
Empty ripemd160 hash: 9c1185a5c5e9fc54612808977ee8f548b2258d31
```

However, attempting to pass `--openssl-legacy-provider` into `Worker` fails:

```
❯ node
Welcome to Node.js v18.0.0.
Type ".help" for more information.
> new worker_threads.Worker('/path/to/test.mjs', {execArgv: ['--openssl-legacy-provider']})
Uncaught:
Error [ERR_WORKER_INVALID_EXEC_ARGV]: Initiated Worker with invalid execArgv flags: --openssl-legacy-provider
    at __node_internal_captureLargerStackTrace (node:internal/errors:465:5)
    at new NodeError (node:internal/errors:372:5)
    at new Worker (node:internal/worker:191:13) {
  code: 'ERR_WORKER_INVALID_EXEC_ARGV'
}
```

But that's fine because the `Worker` inherits the `--openssl-legacy-provider` setting:

```
❯ node --openssl-legacy-provider
Welcome to Node.js v18.0.0.
Type ".help" for more information.
> new worker_threads.Worker('/path/to/test.mjs', {execArgv: ['']})
Worker { ... }
> Empty ripemd160 hash: 9c1185a5c5e9fc54612808977ee8f548b2258d31
```

This PR handles the issue in the same way as https://github.com/parcel-bundler/parcel/pull/5017/ – we can just filter out unsupported `nodeArguments` before passing them to Worker `options.execArgv`.