### PR TITLE
Examples now use AVA 4

### DIFF
--- a/examples/endpoint-testing/ava.config.js
+++ b/examples/endpoint-testing/ava.config.js
@@ -1,0 +1,3 @@
+module.exports = { // eslint-disable-line import/no-anonymous-default-export
+	files: ['test.*'],
+};

--- a/examples/endpoint-testing/package.json
+++ b/examples/endpoint-testing/package.json
@@ -1,12 +1,13 @@
 {
 	"name": "ava-endpoint-testing",
 	"description": "Example for endpoint testing",
+	"type": "commonjs",
 	"scripts": {
 		"test": "ava"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"got": "^11.8.2",
+		"ava": "^4.2.0",
+		"got": "^12.0.4",
 		"test-listen": "^1.1.0"
 	}
 }

--- a/examples/endpoint-testing/test.js
+++ b/examples/endpoint-testing/test.js
@@ -2,22 +2,24 @@
 const http = require('http');
 
 const test = require('ava');
-const got = require('got');
 const listen = require('test-listen');
 
 const app = require('./app.js');
 
-test.before(async t => {
-	t.context.server = http.createServer(app);
-	t.context.prefixUrl = await listen(t.context.server);
+import('got').then(({got}) => {
+	test.before(async t => {
+		t.context.server = http.createServer(app);
+		t.context.prefixUrl = await listen(t.context.server);
+	});
+
+	test.after.always(t => {
+		t.context.server.close();
+	});
+
+	test.serial('get /user', async t => {
+		const {email} = await got('user', {prefixUrl: t.context.prefixUrl}).json();
+
+		t.is(email, 'ava@rocks.com');
+	});
 });
 
-test.after.always(t => {
-	t.context.server.close();
-});
-
-test.serial('get /user', async t => {
-	const {email} = await got('user', {prefixUrl: t.context.prefixUrl}).json();
-
-	t.is(email, 'ava@rocks.com');
-});

--- a/examples/macros/ava.config.js
+++ b/examples/macros/ava.config.js
@@ -1,0 +1,3 @@
+export default { // eslint-disable-line import/no-anonymous-default-export
+	files: ['test.*'],
+};

--- a/examples/macros/index.js
+++ b/examples/macros/index.js
@@ -1,1 +1,1 @@
-exports.sum = (a, b) => a + b;
+export const sum = (a, b) => a + b;

--- a/examples/macros/package.json
+++ b/examples/macros/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "ava-macros",
 	"description": "Example for reusing test logic through macros",
+	"type": "module",
 	"scripts": {
 		"test": "ava"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0"
+		"ava": "^4.2.0"
 	}
 }

--- a/examples/macros/test.js
+++ b/examples/macros/test.js
@@ -1,13 +1,13 @@
-const test = require('ava');
+import test from 'ava'
 
-const {sum} = require('.');
+import { sum } from './index.js'
 
 function macro(t, a, b, expected) {
-	t.is(sum(a, b), expected);
+	t.is(sum(a, b), expected)
 }
 
-macro.title = (providedTitle, a, b, expected) => `${providedTitle || ''} ${a}+${b} = ${expected}`.trim();
+macro.title = (providedTitle, a, b, expected) => `${providedTitle || ''} ${a}+${b} = ${expected}`.trim()
 
-test(macro, 2, 2, 4);
-test(macro, 3, 3, 6);
-test('providedTitle', macro, 4, 4, 8);
+test(macro, 2, 2, 4)
+test(macro, 3, 3, 6)
+test('providedTitle', macro, 4, 4, 8)

--- a/examples/matching-titles/ava.config.js
+++ b/examples/matching-titles/ava.config.js
@@ -1,0 +1,3 @@
+export default { // eslint-disable-line import/no-anonymous-default-export
+	files: ['test.*'],
+};

--- a/examples/matching-titles/package.json
+++ b/examples/matching-titles/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "ava-matching-titles",
 	"description": "Example for running tests with matching titles",
+	"type": "module",
 	"scripts": {
 		"test": "ava --match='*oo*'"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0"
+		"ava": "^4.2.0"
 	}
 }

--- a/examples/matching-titles/test.js
+++ b/examples/matching-titles/test.js
@@ -1,5 +1,5 @@
 'use strict';
-const test = require('ava');
+import test from 'ava';
 
 test('foo will run', t => {
 	t.pass();
@@ -12,3 +12,25 @@ test('moo will also run', t => {
 test.only('boo will run but not exclusively', t => {
 	t.pass();
 });
+
+test('this will not run', t => {
+	t.fail();
+});
+
+test.only('neither will this...', t => {
+	t.fail();
+});
+
+
+const macro = test.macro({
+	exec(t, input, expected) {
+		t.is(eval(input), expected);
+	},
+	title(providedTitle = '', input, expected) {
+		return `${providedTitle} ${input} = ${expected}`.trim();
+	}
+});
+
+// Will not run, no title provided
+test(macro, '2 + 2', 4);
+test('goo will run', macro, '2 + 2', 4);

--- a/examples/specific-line-numbers/package.json
+++ b/examples/specific-line-numbers/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "ava-specific-line-numbers",
 	"description": "Example for running tests at specific line numbers",
+	"type": "commonjs",
 	"scripts": {
 		"test": "ava test.js:5"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0"
+		"ava": "^4.2.0"
 	}
 }

--- a/examples/tap-reporter/ava.config.js
+++ b/examples/tap-reporter/ava.config.js
@@ -1,0 +1,3 @@
+export default { // eslint-disable-line import/no-anonymous-default-export
+	files: ['test.*'],
+};

--- a/examples/tap-reporter/package.json
+++ b/examples/tap-reporter/package.json
@@ -1,11 +1,12 @@
 {
 	"name": "ava-tap-reporter",
 	"description": "Example for a custom TAP reporter",
+	"type": "module",
 	"scripts": {
 		"test": "ava --tap | tap-nyan"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
+		"ava": "^4.2.0",
 		"tap-nyan": "^1.1.0"
 	}
 }

--- a/examples/tap-reporter/test.js
+++ b/examples/tap-reporter/test.js
@@ -1,5 +1,5 @@
 'use strict';
-const test = require('ava');
+import test from 'ava';
 
 test('unicorn', t => {
 	t.pass();

--- a/examples/timeouts/ava.config.js
+++ b/examples/timeouts/ava.config.js
@@ -1,0 +1,3 @@
+export default { // eslint-disable-line import/no-anonymous-default-export
+	files: ['test.*'],
+};

--- a/examples/timeouts/index.js
+++ b/examples/timeouts/index.js
@@ -4,7 +4,7 @@ const delay = ms => new Promise(resolve => {
 	setTimeout(resolve, ms);
 });
 
-exports.fetchUsers = async () => {
+export const fetchUsers = async () => {
 	await delay(50);
 
 	return [
@@ -17,7 +17,7 @@ exports.fetchUsers = async () => {
 	];
 };
 
-exports.fetchPosts = async userId => {
+export const fetchPosts = async userId => {
 	await delay(200);
 
 	return [
@@ -29,7 +29,7 @@ exports.fetchPosts = async userId => {
 	];
 };
 
-exports.createPost = async message => {
+export const createPost = async message => {
 	await delay(3000);
 
 	return {

--- a/examples/timeouts/package.json
+++ b/examples/timeouts/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "ava-timeouts",
 	"description": "Example for test timeouts",
+	"type": "module",
 	"scripts": {
 		"test": "ava --timeout=2s --verbose"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0"
+		"ava": "^4.2.0"
 	}
 }

--- a/examples/timeouts/test.js
+++ b/examples/timeouts/test.js
@@ -1,7 +1,7 @@
 'use strict';
-const test = require('ava');
+import test from 'ava';
 
-const {fetchUsers, fetchPosts, createPost} = require('.');
+import {fetchUsers, fetchPosts, createPost} from './index.js';
 
 test('retrieve users', async t => {
 	t.timeout(100);

--- a/examples/typescript-basic/ava.config.js
+++ b/examples/typescript-basic/ava.config.js
@@ -1,0 +1,9 @@
+module.exports = { // eslint-disable-line import/no-anonymous-default-export
+	files: ['**/test.*'],
+	typescript: {
+		compile: "tsc",
+		rewritePaths: {
+			"source/": "build/"
+		}
+	}
+};

--- a/examples/typescript-basic/package.json
+++ b/examples/typescript-basic/package.json
@@ -5,17 +5,9 @@
 		"test": "ava"
 	},
 	"devDependencies": {
-		"@ava/typescript": "^2.0.0",
-		"@sindresorhus/tsconfig": "^1.0.2",
-		"ava": "^3.15.0",
-		"typescript": "^4.3.4"
-	},
-	"ava": {
-		"typescript": {
-			"compile": "tsc",
-			"rewritePaths": {
-				"source/": "build/"
-			}
-		}
+		"@ava/typescript": "^3.0.1",
+		"@sindresorhus/tsconfig": "^2.0.0",
+		"ava": "^4.2.0",
+		"typescript": "^4.4.4"
 	}
 }

--- a/examples/typescript-context/ava.config.js
+++ b/examples/typescript-context/ava.config.js
@@ -1,0 +1,9 @@
+module.exports = { // eslint-disable-line import/no-anonymous-default-export
+	files: ['**/test.*'],
+	typescript: {
+		compile: "tsc",
+		rewritePaths: {
+			"source/": "build/"
+		}
+	}
+};

--- a/examples/typescript-context/package.json
+++ b/examples/typescript-context/package.json
@@ -5,17 +5,9 @@
 		"test": "ava"
 	},
 	"devDependencies": {
-		"@ava/typescript": "^2.0.0",
-		"@sindresorhus/tsconfig": "^1.0.2",
-		"ava": "^3.15.0",
-		"typescript": "^4.3.4"
-	},
-	"ava": {
-		"typescript": {
-			"compile": "tsc",
-			"rewritePaths": {
-				"source/": "build/"
-			}
-		}
+		"@ava/typescript": "^3.0.1",
+		"@sindresorhus/tsconfig": "^2.0.0",
+		"ava": "^4.2.0",
+		"typescript": "^4.4.4"
 	}
 }

--- a/examples/typescript-context/source/test.ts
+++ b/examples/typescript-context/source/test.ts
@@ -1,8 +1,8 @@
-import anyTest, {TestInterface} from 'ava';
+import anyTest, {TestFn} from 'ava';
 
 import {concat} from '.';
 
-const test = anyTest as TestInterface<{sort: (a: string, b: string) => number}>;
+const test = anyTest as TestFn<{sort: (a: string, b: string) => number}>;
 
 test.beforeEach(t => {
 	t.context = {


### PR DESCRIPTION
Resolves #2993

- I've updated some of the examples to "module", while others were left as "commonjs" ... thought it would be good to see both
- Seemed like I needed a `ava.config.js` file for most examples (assuming this is for monorepo behavior mentioned in the ESM Support sections of 4.X releases). If there's a more preferred way please let me know and I'll update
- Any new examples you'd like me to create for new v4 features, more than willing... still catching up, last used AVA when it was v1-v2