### PR TITLE
Add number of timeouts in test summary

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -659,6 +659,10 @@ export default class Reporter {
 			this.lineWriter.writeLine(colors.error(`${this.stats.uncaughtExceptions} uncaught ${plur('exception', this.stats.uncaughtExceptions)}`));
 		}
 
+		if (this.stats.timeouts > 0) {
+			this.lineWriter.writeLine(colors.error(`${this.stats.timeouts} ${plur('test', this.stats.timeouts)} remained pending after a timeout`));
+		}
+
 		if (this.previousFailures > 0) {
 			this.lineWriter.writeLine(colors.error(`${this.previousFailures} previous ${plur('failure', this.previousFailures)} in test files that were not rerun`));
 		}

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -125,7 +125,7 @@ export default class RunStatus extends Emittery {
 			case 'timeout':
 				event.pendingTests = this.pendingTests;
 				this.pendingTests = new Map();
-				stats.timeouts++;
+				event.pendingTests.forEach((testsInFile) => stats.timeouts += testsInFile.size);
 				break;
 			case 'interrupt':
 				event.pendingTests = this.pendingTests;

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -125,7 +125,7 @@ export default class RunStatus extends Emittery {
 			case 'timeout':
 				event.pendingTests = this.pendingTests;
 				this.pendingTests = new Map();
-				for (const [, testsInFile] of event.pendingTests.entries()) {
+				for (const testsInFile of event.pendingTests.values()) {
 					stats.timeouts += testsInFile.size;
 				}
 

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -125,7 +125,10 @@ export default class RunStatus extends Emittery {
 			case 'timeout':
 				event.pendingTests = this.pendingTests;
 				this.pendingTests = new Map();
-				event.pendingTests.forEach((testsInFile) => stats.timeouts += testsInFile.size);
+				for (const [, testsInFile] of event.pendingTests.entries()) {
+					stats.timeouts += testsInFile.size;
+				}
+
 				break;
 			case 'interrupt':
 				event.pendingTests = this.pendingTests;

--- a/test-tap/reporters/default.timeoutinmultiplefiles.v12.log
+++ b/test-tap/reporters/default.timeoutinmultiplefiles.v12.log
@@ -30,4 +30,5 @@
   [90m─[39m
 
   [32m4 tests passed[39m
+  [31m5 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutinmultiplefiles.v14.log
+++ b/test-tap/reporters/default.timeoutinmultiplefiles.v14.log
@@ -30,4 +30,5 @@
   [90m─[39m
 
   [32m4 tests passed[39m
+  [31m5 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutinmultiplefiles.v16.log
+++ b/test-tap/reporters/default.timeoutinmultiplefiles.v16.log
@@ -30,4 +30,5 @@
   [90m─[39m
 
   [32m4 tests passed[39m
+  [31m5 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutinmultiplefiles.v17.log
+++ b/test-tap/reporters/default.timeoutinmultiplefiles.v17.log
@@ -30,4 +30,5 @@
   [90m─[39m
 
   [32m4 tests passed[39m
+  [31m5 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutinsinglefile.v12.log
+++ b/test-tap/reporters/default.timeoutinsinglefile.v12.log
@@ -16,4 +16,5 @@
   [90m─[39m
 
   [32m2 tests passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutinsinglefile.v14.log
+++ b/test-tap/reporters/default.timeoutinsinglefile.v14.log
@@ -16,4 +16,5 @@
   [90m─[39m
 
   [32m2 tests passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutinsinglefile.v16.log
+++ b/test-tap/reporters/default.timeoutinsinglefile.v16.log
@@ -16,4 +16,5 @@
   [90m─[39m
 
   [32m2 tests passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutinsinglefile.v17.log
+++ b/test-tap/reporters/default.timeoutinsinglefile.v17.log
@@ -16,4 +16,5 @@
   [90m─[39m
 
   [32m2 tests passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutwithmatch.v12.log
+++ b/test-tap/reporters/default.timeoutwithmatch.v12.log
@@ -14,4 +14,5 @@
   [90m─[39m
 
   [32m1 test passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutwithmatch.v14.log
+++ b/test-tap/reporters/default.timeoutwithmatch.v14.log
@@ -14,4 +14,5 @@
   [90m─[39m
 
   [32m1 test passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutwithmatch.v16.log
+++ b/test-tap/reporters/default.timeoutwithmatch.v16.log
@@ -14,4 +14,5 @@
   [90m─[39m
 
   [32m1 test passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator

--- a/test-tap/reporters/default.timeoutwithmatch.v17.log
+++ b/test-tap/reporters/default.timeoutwithmatch.v17.log
@@ -14,4 +14,5 @@
   [90m─[39m
 
   [32m1 test passed[39m
+  [31m2 tests remained pending after a timeout[39m
 ---tty-stream-chunk-separator


### PR DESCRIPTION
This PR adds a line in test summary to indicate the number of tests that failed due to timeout. Fixes #2639.

> 5 tests remained pending after a timeout

I have modified `stats.timeout` to represent the number of timed-out tests. I couldn't find what `stats.timeout` was supposed to represent but I changed it to what I expect from it by looking at the context.

```diff
diff --git a/lib/run-status.js b/lib/run-status.js
index a18f4e1af..b6128cda7 100644
--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -125,7 +125,10 @@ export default class RunStatus extends Emittery {
 			case 'timeout':
 				event.pendingTests = this.pendingTests;
 				this.pendingTests = new Map();
-				stats.timeouts++;
+				for (const [, testsInFile] of event.pendingTests.entries()) {
+					stats.timeouts += testsInFile.size;
+				}
+
 				break;
 			case 'interrupt':
 				event.pendingTests = this.pendingTests;
```

<details>
<summary>Sample terminal output</summary>

```console
➜  ava-test-timed-out git:(master) ✗ npx ava

  ✔ another test that is simply passing
  
  ✖ Timed out while running tests

  1 tests were pending in test/index_test.js

  ◌ a test that times out

  ─

  1 test passed
  1 test remained pending after a timeout
```

This output is the result of running https://github.com/TimDaub/ava-test-timed-out/blob/master/test/index_test.js.
</details>