### PR TITLE
Document that AVA 4 cannot be run globally

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,8 @@ Alternatively you can install `ava` manually:
 npm install --save-dev ava
 ```
 
+Note that AVA 4 cannot be run globally.
+
 Don't forget to configure the `test` script in your `package.json` as per above.
 
 ### Create your test file

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Alternatively you can install `ava` manually:
 npm install --save-dev ava
 ```
 
-Note that AVA 4 cannot be run globally.
+*Make sure to install AVA locally. As of AVA 4 it can no longer be run globally.*
 
 Don't forget to configure the `test` script in your `package.json` as per above.
 


### PR DESCRIPTION
Resolves #3026

I added the note to `/readme.md`, instead of to `/docs/08-common-pitfalls.md` as discussed. I did this so I could put it directly under the installation instructions, which seemed the most appropriate place.