### PR TITLE
Replace md5sum with sha512sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
       - name: Test package-lock for unexpected modifications
         run: |
           npm -v
-          checksum=$(md5sum package-lock.json)
+          checksum=$(sha512sum package-lock.json)
           npm install --package-lock-only --no-audit
-          if ! echo ${checksum} | md5sum --quiet -c -; then
+          if ! echo ${checksum} | sha512sum --quiet -c -; then
             echo "package-lock.json was modified unexpectedly. Please rebuild it using npm@$(npm -v) and commit the changes."
             exit 1
           fi


### PR DESCRIPTION
Update the hashing algorithm used for the `package-lock.json` checksum in the CI from MD5 to SHA512 - the same algorithm used by npm for the integrity check in the `package-lock.json` file itself.

My motivation for doing this is that MD5 is considered an insecure hash algorithm nowadays (ref. [the MD5 Wikipedia page](https://en.wikipedia.org/wiki/MD5) or [RFC 6151](https://datatracker.ietf.org/doc/html/rfc6151)). I do not intend to start a discussion on whether that's relevant in this particular case. I believe that regardless of ones point of view on the matter, upgrading to SHA512 is harmless (considering that this project is already using SHA512 through the lockfile).