### PR TITLE
Remove mentions of "callback mode" from docs

### DIFF
--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -2,7 +2,7 @@
 
 Translations: [Français](https://github.com/avajs/ava-docs/blob/main/fr_FR/docs/01-writing-tests.md)
 
-Tests are run concurrently. You can specify synchronous and asynchronous tests. Tests are considered synchronous unless you return a promise, an [observable](https://github.com/zenparsing/zen-observable), or declare it as a callback test.
+Tests are run concurrently. You can specify synchronous and asynchronous tests. Tests are considered synchronous unless you return a promise or an [observable](https://github.com/zenparsing/zen-observable).
 
 You must define all tests synchronously. They can't be defined inside `setTimeout`, `setImmediate`, etc.
 
@@ -72,8 +72,6 @@ test('promises the truth', async t => {
 ## Observable support
 
 AVA comes with built-in support for [observables](https://github.com/zenparsing/es-observable). If you return an observable from a test, AVA will automatically consume it to completion before ending the test.
-
-*You do not need to use "callback mode" or call `t.end()`.*
 
 ```js
 test('handles observables', t => {

--- a/docs/recipes/test-setup.md
+++ b/docs/recipes/test-setup.md
@@ -16,7 +16,7 @@ You could do all these things using plain setup functions, but there are tradeof
 |---|---
 | ⛔️ &nbsp; used for all tests| ✅ &nbsp; can change or skip depending on test
 | ⛔️ &nbsp; more overhead for beginners, "some magic"| ✅ &nbsp; easier for beginners, "no magic"
-| ✅ &nbsp; supports callback mode, built-in support for observables| ⛔️ &nbsp; must use promises for asynchronous behavior
+| ✅ &nbsp; built-in support for observables| ⛔️ &nbsp; must use promises for asynchronous behavior
 | ✅ &nbsp; failure has friendly output| ⛔️ &nbsp; errors are attributed to the test
 | ✅ &nbsp; corresponding `afterEach` and `afterEach.always` for cleanup| ⛔️ &nbsp; cannot easily clean up
 


### PR DESCRIPTION
This removes the mentions of "callback mode" from the documentation, following the removal of "callback mode" in [v4.0.0 of AVA](https://github.com/avajs/ava/releases/tag/v4.0.0) (see also [this comment](https://github.com/avajs/ava/issues/2929#issuecomment-1162377005)).