### PR TITLE
When translating line numbers, check whether the source map entry has original values

### DIFF
--- a/lib/worker/line-numbers.js
+++ b/lib/worker/line-numbers.js
@@ -66,6 +66,13 @@ const translate = (sourceMap, pos) => {
 	}
 
 	const entry = sourceMap.findEntry(pos.line - 1, pos.column); // Source maps are 0-based
+
+	// When used with ts-node/register, we've seen entries without original values. Return the
+	// original position.
+	if (entry.originalLine === undefined || entry.originalColumn === undefined) {
+		return pos;
+	}
+
 	return {
 		line: entry.originalLine + 1, // Readjust for Acorn.
 		column: entry.originalColumn,


### PR DESCRIPTION
When used with `ts-node/register`, we've seen entries without original values. Return the original position.

See `ts.zip` reproduction in https://github.com/avajs/ava/issues/3049#issuecomment-1149431912.
