### PR TITLE
Parse for line numbers with latest supported ECMA version

### DIFF
--- a/lib/worker/line-numbers.js
+++ b/lib/worker/line-numbers.js
@@ -12,7 +12,7 @@ function parse(file) {
 	const walk = require('acorn-walk');
 
 	const ast = acorn.parse(fs.readFileSync(file, 'utf8'), {
-		ecmaVersion: 11,
+		ecmaVersion: 'latest',
 		locations: true,
 		sourceType: 'module',
 	});


### PR DESCRIPTION
This means the supported syntax changes depending on the installed Acorn version, which may change independently of the AVA version since we do not pin the dependency.
