### PR TITLE
Detect process.exit() called from tests

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -111,7 +111,6 @@ export default class Reporter {
 
 		this.failures = [];
 		this.internalErrors = [];
-		this.interrupts = [];
 		this.knownFailures = [];
 		this.lineNumberErrors = [];
 		this.sharedWorkerErrors = [];
@@ -194,7 +193,6 @@ export default class Reporter {
 			}
 
 			case 'interrupt': {
-				this.interrupts.push(event);
 				this.lineWriter.writeLine(colors.error(`\n${figures.cross} Exiting due to SIGINT`));
 				this.lineWriter.writeLine('');
 				this.writePendingTests(event);
@@ -236,8 +234,6 @@ export default class Reporter {
 			}
 
 			case 'process-exit': {
-				this.interrupts.push(event);
-
 				if (event.testFile) {
 					this.write(colors.error(`${figures.cross} Exiting due to process.exit() when running ${this.relativeFile(event.testFile)}`));
 				} else {

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -240,9 +240,8 @@ export default class Reporter {
 					this.write(colors.error(`${figures.cross} Exiting due to process.exit()`));
 				}
 
-				this.lineWriter.writeLine(colors.stack(event.err.summary));
-				this.lineWriter.writeLine(colors.errorStack(event.err.stack));
 				this.lineWriter.writeLine();
+				this.lineWriter.writeLine(colors.errorStack(event.stack));
 				this.lineWriter.writeLine();
 
 				break;

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -234,11 +234,7 @@ export default class Reporter {
 			}
 
 			case 'process-exit': {
-				if (event.testFile) {
-					this.write(colors.error(`${figures.cross} Exiting due to process.exit() when running ${this.relativeFile(event.testFile)}`));
-				} else {
-					this.write(colors.error(`${figures.cross} Exiting due to process.exit()`));
-				}
+				this.write(colors.error(`${figures.cross} Exiting due to process.exit() when running ${this.relativeFile(event.testFile)}`));
 
 				this.lineWriter.writeLine();
 				this.lineWriter.writeLine(colors.errorStack(event.stack));

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -111,6 +111,7 @@ export default class Reporter {
 
 		this.failures = [];
 		this.internalErrors = [];
+		this.interrupts = [];
 		this.knownFailures = [];
 		this.lineNumberErrors = [];
 		this.sharedWorkerErrors = [];
@@ -193,6 +194,7 @@ export default class Reporter {
 			}
 
 			case 'interrupt': {
+				this.interrupts.push(event);
 				this.lineWriter.writeLine(colors.error(`\n${figures.cross} Exiting due to SIGINT`));
 				this.lineWriter.writeLine('');
 				this.writePendingTests(event);
@@ -230,6 +232,23 @@ export default class Reporter {
 				this.filesWithMissingAvaImports.add(event.testFile);
 
 				this.write(colors.error(`${figures.cross} No tests found in ${this.relativeFile(event.testFile)}, make sure to import "ava" at the top of your test file`));
+				break;
+			}
+
+			case 'process-exit': {
+				this.interrupts.push(event);
+
+				if (event.testFile) {
+					this.write(colors.error(`${figures.cross} Exiting due to process.exit() when running ${this.relativeFile(event.testFile)}`));
+				} else {
+					this.write(colors.error(`${figures.cross} Exiting due to process.exit()`));
+				}
+
+				this.lineWriter.writeLine(colors.stack(event.err.summary));
+				this.lineWriter.writeLine(colors.errorStack(event.err.stack));
+				this.lineWriter.writeLine();
+				this.lineWriter.writeLine();
+
 				break;
 			}
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -158,6 +158,9 @@ export default class TapReporter {
 				this.filesWithMissingAvaImports.add(evt.testFile);
 				this.writeCrash(evt, `No tests found in ${this.relativeFile(evt.testFile)}, make sure to import "ava" at the top of your test file`);
 				break;
+			case 'process-exit':
+				this.writeCrash(evt);
+				break;
 			case 'selected-test':
 				if (evt.skip) {
 					this.writeTest(evt, {passed: true, todo: false, skip: true});

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -128,6 +128,17 @@ export default class TapReporter {
 		}
 	}
 
+	writeProcessExit(evt) {
+		const error = new Error(`Exiting due to process.exit() when running ${this.relativeFile(evt.testFile)}`);
+		error.stack = evt.stack;
+
+		for (const [testFile, tests] of evt.pendingTests) {
+			for (const title of tests) {
+				this.writeTest({testFile, title, err: error}, {passed: false, todo: false, skip: false});
+			}
+		}
+	}
+
 	writeTimeout(evt) {
 		const error = new Error(`Exited because no new tests completed within the last ${evt.period}ms of inactivity`);
 
@@ -159,7 +170,7 @@ export default class TapReporter {
 				this.writeCrash(evt, `No tests found in ${this.relativeFile(evt.testFile)}, make sure to import "ava" at the top of your test file`);
 				break;
 			case 'process-exit':
-				this.writeCrash(evt);
+				this.writeProcessExit(evt);
 				break;
 			case 'selected-test':
 				if (evt.skip) {

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -62,6 +62,7 @@ export default class RunStatus extends Emittery {
 		worker.onStateChange(data => this.emitStateChange(data));
 	}
 
+	// eslint-disable-next-line complexity
 	emitStateChange(event) {
 		const {stats} = this;
 		const fileStats = stats.byFile.get(event.testFile);
@@ -134,6 +135,10 @@ export default class RunStatus extends Emittery {
 				event.pendingTests = this.pendingTests;
 				this.pendingTests = new Map();
 				break;
+			case 'process-exit':
+				event.pendingTests = this.pendingTests;
+				this.pendingTests = new Map();
+				break;
 			case 'uncaught-exception':
 				stats.uncaughtExceptions++;
 				fileStats.uncaughtExceptions++;
@@ -175,6 +180,7 @@ export default class RunStatus extends Emittery {
 			|| this.stats.failedHooks > 0
 			|| this.stats.failedTests > 0
 			|| this.stats.failedWorkers > 0
+			|| this.stats.remainingTests > 0
 			|| this.stats.sharedWorkerErrors > 0
 			|| this.stats.timeouts > 0
 			|| this.stats.uncaughtExceptions > 0

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -294,6 +294,7 @@ export default class Watcher {
 				switch (evt.type) {
 					case 'hook-failed':
 					case 'internal-error':
+					case 'process-exit':
 					case 'test-failed':
 					case 'uncaught-exception':
 					case 'unhandled-rejection':

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -19,6 +19,35 @@ import {flags, refs, sharedWorkerTeardowns} from './state.cjs';
 import {isRunningInThread, isRunningInChildProcess} from './utils.cjs';
 
 const currentlyUnhandled = setUpCurrentlyUnhandled();
+let runner = Object.create(null);
+
+// Override process.exit with an undetectable replacement
+// to report when it is called from a test (which it should never be).
+const {apply} = Reflect;
+const realExit = process.exit;
+
+async function exit(code, forceSync = false) {
+	dependencyTracking.flush();
+	if (!forceSync) {
+		await channel.flush();
+	}
+
+	apply(realExit, process, [code]);
+}
+
+process.exit = new Proxy(realExit, {
+	apply(fn, receiver, args) {
+		channel.send({type: 'internal-error', err: serializeError('Forced exit error', false, new Error('Unexpected process.exit()'), runner.file)});
+
+		// Make sure to extract the code only from `args` rather than e.g. `Array.prototype`.
+		// This level of paranoia is usually unwarranted, but we're dealing with test code
+		// that has already colored outside the lines.
+		const code = args.length > 0 ? args[0] : undefined;
+
+		// Force a synchronous exit as guaranteed by the real process.exit().
+		exit(code, true);
+	},
+});
 
 const run = async options => {
 	setOptions(options);
@@ -27,16 +56,6 @@ const run = async options => {
 	if (options.chalkOptions.level > 0) {
 		const {stdout, stderr} = process;
 		global.console = Object.assign(global.console, new console.Console({stdout, stderr, colorMode: true}));
-	}
-
-	async function exit(code) {
-		if (!process.exitCode) {
-			process.exitCode = code;
-		}
-
-		dependencyTracking.flush();
-		await channel.flush();
-		process.exit(); // eslint-disable-line unicorn/no-process-exit
 	}
 
 	let checkSelectedByLineNumbers;
@@ -50,7 +69,7 @@ const run = async options => {
 		checkSelectedByLineNumbers = () => false;
 	}
 
-	const runner = new Runner({
+	runner = new Runner({
 		checkSelectedByLineNumbers,
 		experiments: options.experiments,
 		failFast: options.failFast,

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -28,8 +28,9 @@ const realExit = process.exit;
 
 async function exit(code, forceSync = false) {
 	dependencyTracking.flush();
+	const flushing = channel.flush();
 	if (!forceSync) {
-		await channel.flush();
+		await flushing;
 	}
 
 	apply(realExit, process, [code]);

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -19,7 +19,7 @@ import {flags, refs, sharedWorkerTeardowns} from './state.cjs';
 import {isRunningInThread, isRunningInChildProcess} from './utils.cjs';
 
 const currentlyUnhandled = setUpCurrentlyUnhandled();
-let runner = Object.create(null);
+let runner;
 
 // Override process.exit with an undetectable replacement
 // to report when it is called from a test (which it should never be).
@@ -37,7 +37,7 @@ async function exit(code, forceSync = false) {
 
 process.exit = new Proxy(realExit, {
 	apply(fn, receiver, args) {
-		channel.send({type: 'internal-error', err: serializeError('Forced exit error', false, new Error('Unexpected process.exit()'), runner.file)});
+		channel.send({type: 'internal-error', err: serializeError('Forced exit error', false, new Error('Unexpected process.exit()'), runner?.file)});
 
 		// Make sure to extract the code only from `args` rather than e.g. `Array.prototype`.
 		// This level of paranoia is usually unwarranted, but we're dealing with test code

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -37,7 +37,7 @@ async function exit(code, forceSync = false) {
 
 process.exit = new Proxy(realExit, {
 	apply(fn, receiver, args) {
-		channel.send({type: 'internal-error', err: serializeError('Forced exit error', false, new Error('Unexpected process.exit()'), runner?.file)});
+		channel.send({type: 'process-exit', err: serializeError('Forced exit error', false, new Error('Unexpected process.exit()'), runner?.file)});
 
 		// Make sure to extract the code only from `args` rather than e.g. `Array.prototype`.
 		// This level of paranoia is usually unwarranted, but we're dealing with test code

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -36,9 +36,9 @@ async function exit(code, forceSync = false) {
 	apply(realExit, process, [code]);
 }
 
-const proxyApply = (fn, receiver, args) => {
+const handleProcessExit = (fn, receiver, args) => {
 	const error = new Error('Unexpected process.exit()');
-	Error.captureStackTrace(error, proxyApply);
+	Error.captureStackTrace(error, handleProcessExit);
 	const {stack} = serializeError('', true, error);
 	channel.send({type: 'process-exit', stack});
 
@@ -52,7 +52,7 @@ const proxyApply = (fn, receiver, args) => {
 };
 
 process.exit = new Proxy(realExit, {
-	apply: proxyApply,
+	apply: handleProcessExit,
 });
 
 const run = async options => {

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -35,18 +35,23 @@ async function exit(code, forceSync = false) {
 	apply(realExit, process, [code]);
 }
 
+const proxyApply = (fn, receiver, args) => {
+	const error = new Error('Unexpected process.exit()');
+	Error.captureStackTrace(error, proxyApply);
+	const {stack} = serializeError('', true, error);
+	channel.send({type: 'process-exit', stack});
+
+	// Make sure to extract the code only from `args` rather than e.g. `Array.prototype`.
+	// This level of paranoia is usually unwarranted, but we're dealing with test code
+	// that has already colored outside the lines.
+	const code = args.length > 0 ? args[0] : undefined;
+
+	// Force a synchronous exit as guaranteed by the real process.exit().
+	exit(code, true);
+};
+
 process.exit = new Proxy(realExit, {
-	apply(fn, receiver, args) {
-		channel.send({type: 'process-exit', err: serializeError('Forced exit error', false, new Error('Unexpected process.exit()'), runner?.file)});
-
-		// Make sure to extract the code only from `args` rather than e.g. `Array.prototype`.
-		// This level of paranoia is usually unwarranted, but we're dealing with test code
-		// that has already colored outside the lines.
-		const code = args.length > 0 ? args[0] : undefined;
-
-		// Force a synchronous exit as guaranteed by the real process.exit().
-		exit(code, true);
-	},
+	apply: proxyApply,
 });
 
 const run = async options => {

--- a/test-tap/fixture/fail-fast/multiple-files/fails.cjs
+++ b/test-tap/fixture/fail-fast/multiple-files/fails.cjs
@@ -1,13 +1,20 @@
 const test = require('../../../../entrypoints/main.cjs');
 
+// Allow some time for all workers to launch.
+const grace = new Promise(resolve => {
+	setTimeout(resolve, 500);
+});
+
 test('first pass', t => {
 	t.pass();
 });
 
-test('second fail', t => {
+test('second fail', async t => {
+	await grace;
 	t.fail();
 });
 
-test('third pass', t => {
+test('third pass', async t => {
+	await grace;
 	t.pass();
 });

--- a/test/helpers/exec.js
+++ b/test/helpers/exec.js
@@ -70,6 +70,7 @@ export const fixture = async (args, options = {}) => {
 		failed: [],
 		failedHooks: [],
 		internalErrors: [],
+		interrupts: [],
 		passed: [],
 		selectedTestCount: 0,
 		sharedWorkerErrors: [],
@@ -99,6 +100,14 @@ export const fixture = async (args, options = {}) => {
 				const statObject = {file: normalizePath(workingDir, testFile)};
 				errors.set(statObject, statusEvent.err);
 				stats.internalErrors.push(statObject);
+				break;
+			}
+
+			case 'process-exit': {
+				const {testFile} = statusEvent;
+				const statObject = {file: normalizePath(workingDir, testFile)};
+				errors.set(statObject, statusEvent.err);
+				stats.interrupts.push(statObject);
 				break;
 			}
 

--- a/test/helpers/exec.js
+++ b/test/helpers/exec.js
@@ -70,7 +70,7 @@ export const fixture = async (args, options = {}) => {
 		failed: [],
 		failedHooks: [],
 		internalErrors: [],
-		interrupts: [],
+		processExits: [],
 		passed: [],
 		selectedTestCount: 0,
 		sharedWorkerErrors: [],
@@ -106,8 +106,7 @@ export const fixture = async (args, options = {}) => {
 			case 'process-exit': {
 				const {testFile} = statusEvent;
 				const statObject = {file: normalizePath(workingDir, testFile)};
-				errors.set(statObject, statusEvent.err);
-				stats.interrupts.push(statObject);
+				stats.processExits.push(statObject);
 				break;
 			}
 

--- a/test/helpers/exec.js
+++ b/test/helpers/exec.js
@@ -69,7 +69,9 @@ export const fixture = async (args, options = {}) => {
 	const stats = {
 		failed: [],
 		failedHooks: [],
+		internalErrors: [],
 		passed: [],
+		selectedTestCount: 0,
 		sharedWorkerErrors: [],
 		skipped: [],
 		todo: [],
@@ -92,7 +94,16 @@ export const fixture = async (args, options = {}) => {
 				break;
 			}
 
+			case 'internal-error': {
+				const {testFile} = statusEvent;
+				const statObject = {file: normalizePath(workingDir, testFile)};
+				errors.set(statObject, statusEvent.err);
+				stats.internalErrors.push(statObject);
+				break;
+			}
+
 			case 'selected-test': {
+				stats.selectedTestCount++;
 				if (statusEvent.skip) {
 					const {title, testFile} = statusEvent;
 					stats.skipped.push({title, file: normalizePath(workingDir, testFile)});

--- a/test/test-process-exit/fixtures/ava.config.js
+++ b/test/test-process-exit/fixtures/ava.config.js
@@ -1,0 +1,3 @@
+export default {
+	files: ['*.js'],
+};

--- a/test/test-process-exit/fixtures/package.json
+++ b/test/test-process-exit/fixtures/package.json
@@ -1,0 +1,8 @@
+{
+	"type": "module",
+	"ava": {
+		"files": [
+			"*.js"
+		]
+	}
+}

--- a/test/test-process-exit/fixtures/package.json
+++ b/test/test-process-exit/fixtures/package.json
@@ -1,8 +1,3 @@
 {
-	"type": "module",
-	"ava": {
-		"files": [
-			"*.js"
-		]
-	}
+	"type": "module"
 }

--- a/test/test-process-exit/fixtures/process-exit.js
+++ b/test/test-process-exit/fixtures/process-exit.js
@@ -1,0 +1,17 @@
+import test from 'ava';
+
+test('good', t => {
+	t.pass();
+});
+
+test('process.exit', async t => {
+	t.pass();
+	await new Promise(resolve => {
+		setImmediate(resolve);
+	});
+	process.exit(0); // eslint-disable-line unicorn/no-process-exit
+});
+
+test('still good', t => {
+	t.pass();
+});

--- a/test/test-process-exit/test.js
+++ b/test/test-process-exit/test.js
@@ -1,0 +1,13 @@
+import test from '@ava/test';
+
+import {fixture} from '../helpers/exec.js';
+
+test('process.exit is intercepted', async t => {
+	const result = await t.throwsAsync(fixture(['process-exit.js']));
+	t.true(result.failed);
+	t.like(result, {timedOut: false, isCanceled: false, killed: false});
+	t.is(result.stats.selectedTestCount, 3);
+	t.is(result.stats.passed.length, 2);
+	const error = result.stats.getError(result.stats.internalErrors[0]);
+	t.is(error.message, 'Unexpected process.exit()');
+});

--- a/test/test-process-exit/test.js
+++ b/test/test-process-exit/test.js
@@ -8,6 +8,5 @@ test('process.exit is intercepted', async t => {
 	t.like(result, {timedOut: false, isCanceled: false, killed: false});
 	t.is(result.stats.selectedTestCount, 3);
 	t.is(result.stats.passed.length, 2);
-	const error = result.stats.getError(result.stats.interrupts[0]);
-	t.is(error.message, 'Unexpected process.exit()');
+	t.is(result.stats.processExits.length, 1);
 });

--- a/test/test-process-exit/test.js
+++ b/test/test-process-exit/test.js
@@ -8,6 +8,6 @@ test('process.exit is intercepted', async t => {
 	t.like(result, {timedOut: false, isCanceled: false, killed: false});
 	t.is(result.stats.selectedTestCount, 3);
 	t.is(result.stats.passed.length, 2);
-	const error = result.stats.getError(result.stats.internalErrors[0]);
+	const error = result.stats.getError(result.stats.interrupts[0]);
 	t.is(error.message, 'Unexpected process.exit()');
 });


### PR DESCRIPTION
Fixes #861


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#861: Override `process.exit` to give some context when it's called unexpectedly in a test.](https://oss.issuehunt.io/repos/26820798/issues/861)
---
</details>
<!-- /Issuehunt content-->