### PR TITLE
Count timeouts separately from the timed out tests

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -668,8 +668,8 @@ export default class Reporter {
 			this.lineWriter.writeLine(colors.error(`${this.stats.uncaughtExceptions} uncaught ${plur('exception', this.stats.uncaughtExceptions)}`));
 		}
 
-		if (this.stats.timeouts > 0) {
-			this.lineWriter.writeLine(colors.error(`${this.stats.timeouts} ${plur('test', this.stats.timeouts)} remained pending after a timeout`));
+		if (this.stats.timedOutTests > 0) {
+			this.lineWriter.writeLine(colors.error(`${this.stats.timedOutTests} ${plur('test', this.stats.timedOutTests)} remained pending after a timeout`));
 		}
 
 		if (this.previousFailures > 0) {

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -33,6 +33,7 @@ export default class RunStatus extends Emittery {
 			selectedTests: 0,
 			sharedWorkerErrors: 0,
 			skippedTests: 0,
+			timedOutTests: 0,
 			timeouts: 0,
 			todoTests: 0,
 			uncaughtExceptions: 0,
@@ -124,10 +125,11 @@ export default class RunStatus extends Emittery {
 				this.removePendingTest(event);
 				break;
 			case 'timeout':
+				stats.timeouts++;
 				event.pendingTests = this.pendingTests;
 				this.pendingTests = new Map();
 				for (const testsInFile of event.pendingTests.values()) {
-					stats.timeouts += testsInFile.size;
+					stats.timedOutTests += testsInFile.size;
 				}
 
 				break;


### PR DESCRIPTION
This ensures AVA exits with code 1 if any timeout occurs, even if there were no pending tests.

Fixes #3098.
