### PR TITLE
Add main field to package.json for compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"bin": {
 		"ava": "entrypoints/cli.mjs"
 	},
+  	"main": "./entrypoints/main.cjs",
 	"exports": {
 		".": {
 			"import": {


### PR DESCRIPTION
Linting with `eslint-plugin-import` currently breaks with the error `Unable to resolve path to module 'ava'  import/no-unresolved` when importing using CommonJS.

Since this package officially still supports CommonJS, adding back the main field will help with compatibility, and fix the above error.