### PR TITLE
De-register all shared workers

### DIFF
--- a/lib/plugin-support/shared-workers.js
+++ b/lib/plugin-support/shared-workers.js
@@ -48,64 +48,63 @@ function launchWorker(filename, initialData) {
 	return launched;
 }
 
+/**
+ * Handles the shared worker lifecycle within a test worker thread.
+ */
 export async function observeWorkerProcess(fork, runStatus) {
-	let registrationCount = 0;
-	let signalDeregistered;
-	const launchedWorkerMap = new Map();
-	const degregisterWorker = (filename) => {
-		launchedWorkerMap.get(filename)?.worker.unref();
-			launchedWorkerMap.delete(filename);
+	let signalAllDeregistered;
 
-		registrationCount--;
+	const launchedSharedWorkerMap = new Map();
 
-		if (registrationCount === 0) {
-			signalDeregistered();
+	/**
+	 * If a filename is provided, unreferences the shared worker associated with that filename. Otherwise unreferences all shared workers.
+	 * Resolves the main de-registration promise if all shared workers have been unregistered.
+	 */
+	const deregisterSharedWorker = filename => {
+		if (filename) {
+			launchedSharedWorkerMap.get(filename)?.worker.unref();
+			launchedSharedWorkerMap.delete(filename);
+		} else {
+			for (const filename of launchedSharedWorkerMap.keys()) {
+				deregisterSharedWorker(filename);
+			}
 		}
-	}
+
+		if (launchedSharedWorkerMap.size === 0) {
+			signalAllDeregistered();
+		}
+	};
 
 	const deregistered = new Promise(resolve => {
-		signalDeregistered = () => {
-			// Only unref the worker once all test workers have been deregistered, otherwise the worker may exit before test workers are deregistered
+		signalAllDeregistered = () => {
 			resolve();
 		};
 	});
 
 	fork.promise.finally(() => {
-		if (registrationCount === 0) {
-			signalDeregistered();
-		}
+		deregisterSharedWorker();
 	});
 
 	fork.onConnectSharedWorker(async ({filename, initialData, port, signalError}) => {
 		const launched = launchWorker(filename, initialData);
 
-		launchedWorkerMap.set(filename, launched);
+		launchedSharedWorkerMap.set(filename, launched);
 
 		const handleWorkerMessage = async message => {
 			if (message.type === 'deregistered-test-worker' && message.id === fork.threadId) {
-				// launched.worker.off('message', handleWorkerMessage);
-
-				// registrationCount--;
-				// if (registrationCount === 0) {
-				// 	signalDeregistered(filename);
-				// }
-
-				degregisterWorker(filename);
+				deregisterSharedWorker(filename);
 			}
 		};
 
 		launched.statePromises.error.then(error => {
 			launched.worker.off('message', handleWorkerMessage);
-			degregisterWorker(filename);
-			signalDeregistered();
+			deregisterSharedWorker(filename);
 			runStatus.emitStateChange({type: 'shared-worker-error', err: serializeError('Shared worker error', true, error)});
 			signalError();
 		});
 
 		try {
 			await launched.statePromises.available;
-
-			registrationCount++;
 
 			port.postMessage({type: 'ready'});
 

--- a/lib/plugin-support/shared-workers.js
+++ b/lib/plugin-support/shared-workers.js
@@ -51,11 +51,21 @@ function launchWorker(filename, initialData) {
 export async function observeWorkerProcess(fork, runStatus) {
 	let registrationCount = 0;
 	let signalDeregistered;
-	let launched;
+	const launchedWorkerMap = new Map();
+	const degregisterWorker = (filename) => {
+		launchedWorkerMap.get(filename)?.worker.unref();
+			launchedWorkerMap.delete(filename);
+
+		registrationCount--;
+
+		if (registrationCount === 0) {
+			signalDeregistered();
+		}
+	}
+
 	const deregistered = new Promise(resolve => {
 		signalDeregistered = () => {
 			// Only unref the worker once all test workers have been deregistered, otherwise the worker may exit before test workers are deregistered
-			launched?.worker.unref();
 			resolve();
 		};
 	});
@@ -67,22 +77,27 @@ export async function observeWorkerProcess(fork, runStatus) {
 	});
 
 	fork.onConnectSharedWorker(async ({filename, initialData, port, signalError}) => {
-		launched = launchWorker(filename, initialData);
+		const launched = launchWorker(filename, initialData);
+
+		launchedWorkerMap.set(filename, launched);
 
 		const handleWorkerMessage = async message => {
 			if (message.type === 'deregistered-test-worker' && message.id === fork.threadId) {
-				launched.worker.off('message', handleWorkerMessage);
+				// launched.worker.off('message', handleWorkerMessage);
 
-				registrationCount--;
-				if (registrationCount === 0) {
-					signalDeregistered();
-				}
+				// registrationCount--;
+				// if (registrationCount === 0) {
+				// 	signalDeregistered(filename);
+				// }
+
+				degregisterWorker(filename);
 			}
 		};
 
 		launched.statePromises.error.then(error => {
-			signalDeregistered();
 			launched.worker.off('message', handleWorkerMessage);
+			degregisterWorker(filename);
+			signalDeregistered();
 			runStatus.emitStateChange({type: 'shared-worker-error', err: serializeError('Shared worker error', true, error)});
 			signalError();
 		});

--- a/lib/plugin-support/shared-workers.js
+++ b/lib/plugin-support/shared-workers.js
@@ -48,57 +48,55 @@ function launchWorker(filename, initialData) {
 	return launched;
 }
 
-/**
- * Handles the shared worker lifecycle within a test worker thread.
- */
 export async function observeWorkerProcess(fork, runStatus) {
-	let signalAllDeregistered;
+	let signalDone;
 
-	const launchedSharedWorkerMap = new Map();
-
-	/**
-	 * If a filename is provided, unreferences the shared worker associated with that filename. Otherwise unreferences all shared workers.
-	 * Resolves the main de-registration promise if all shared workers have been unregistered.
-	 */
-	const deregisterSharedWorker = filename => {
-		if (filename) {
-			launchedSharedWorkerMap.get(filename)?.worker.unref();
-			launchedSharedWorkerMap.delete(filename);
-		} else {
-			for (const filename of launchedSharedWorkerMap.keys()) {
-				deregisterSharedWorker(filename);
-			}
-		}
-
-		if (launchedSharedWorkerMap.size === 0) {
-			signalAllDeregistered();
-		}
-	};
-
-	const deregistered = new Promise(resolve => {
-		signalAllDeregistered = () => {
+	const done = new Promise(resolve => {
+		signalDone = () => {
 			resolve();
 		};
 	});
 
+	const activeInstances = new Set();
+
+	const removeInstance = instance => {
+		instance.worker.unref();
+		activeInstances.delete(instance);
+
+		if (activeInstances.size === 0) {
+			signalDone();
+		}
+	};
+
+	const removeAllInstances = () => {
+		if (activeInstances.size === 0) {
+			signalDone();
+			return;
+		}
+
+		for (const instance of activeInstances) {
+			removeInstance(instance);
+		}
+	};
+
 	fork.promise.finally(() => {
-		deregisterSharedWorker();
+		removeAllInstances();
 	});
 
 	fork.onConnectSharedWorker(async ({filename, initialData, port, signalError}) => {
 		const launched = launchWorker(filename, initialData);
-
-		launchedSharedWorkerMap.set(filename, launched);
+		activeInstances.add(launched);
 
 		const handleWorkerMessage = async message => {
 			if (message.type === 'deregistered-test-worker' && message.id === fork.threadId) {
-				deregisterSharedWorker(filename);
+				launched.worker.off('message', handleWorkerMessage);
+				removeInstance(launched);
 			}
 		};
 
 		launched.statePromises.error.then(error => {
 			launched.worker.off('message', handleWorkerMessage);
-			deregisterSharedWorker(filename);
+			removeAllInstances();
 			runStatus.emitStateChange({type: 'shared-worker-error', err: serializeError('Shared worker error', true, error)});
 			signalError();
 		});
@@ -126,5 +124,5 @@ export async function observeWorkerProcess(fork, runStatus) {
 		} catch {}
 	});
 
-	return deregistered;
+	return done;
 }

--- a/test/shared-workers/multiple-workers-are-loaded/fixtures/package.json
+++ b/test/shared-workers/multiple-workers-are-loaded/fixtures/package.json
@@ -1,0 +1,8 @@
+{
+	"type": "module",
+	"ava": {
+		"files": [
+			"*.js"
+		]
+	}
+}

--- a/test/shared-workers/multiple-workers-are-loaded/fixtures/test.js
+++ b/test/shared-workers/multiple-workers-are-loaded/fixtures/test.js
@@ -1,0 +1,26 @@
+import test from 'ava';
+import {registerSharedWorker} from 'ava/plugin';
+
+const worker1 = registerSharedWorker({
+	filename: new URL('worker.mjs#1', import.meta.url),
+	supportedProtocols: ['ava-4'],
+	initialData: {
+		id: '1',
+	},
+});
+
+const worker2 = registerSharedWorker({
+	filename: new URL('worker.mjs#2', import.meta.url),
+	supportedProtocols: ['ava-4'],
+	initialData: {
+		id: '2',
+	},
+});
+
+test('can load multiple workers', async t => {
+	const {value: {data: dataFromWorker1}} = await worker1.subscribe().next();
+	const {value: {data: dataFromWorker2}} = await worker2.subscribe().next();
+
+	t.deepEqual(dataFromWorker1, {id: '1'});
+	t.deepEqual(dataFromWorker2, {id: '2'});
+});

--- a/test/shared-workers/multiple-workers-are-loaded/fixtures/test.js
+++ b/test/shared-workers/multiple-workers-are-loaded/fixtures/test.js
@@ -17,10 +17,14 @@ const worker2 = registerSharedWorker({
 	},
 });
 
+const messageFromWorker1 = worker1.subscribe().next();
+const messageFromWorker2 = worker2.subscribe().next();
+
 test('can load multiple workers', async t => {
-	const {value: {data: dataFromWorker1}} = await worker1.subscribe().next();
-	const {value: {data: dataFromWorker2}} = await worker2.subscribe().next();
+	const {value: {data: dataFromWorker1}} = await messageFromWorker1;
+	const {value: {data: dataFromWorker2}} = await messageFromWorker2;
 
 	t.deepEqual(dataFromWorker1, {id: '1'});
 	t.deepEqual(dataFromWorker2, {id: '2'});
+	t.pass();
 });

--- a/test/shared-workers/multiple-workers-are-loaded/fixtures/worker.mjs
+++ b/test/shared-workers/multiple-workers-are-loaded/fixtures/worker.mjs
@@ -1,0 +1,9 @@
+export default async ({negotiateProtocol}) => {
+	const protocol = negotiateProtocol(['ava-4']);
+
+	await protocol.ready();
+
+	for await (const testWorker of protocol.testWorkers()) {
+		testWorker.publish(protocol.initialData);
+	}
+};

--- a/test/shared-workers/multiple-workers-are-loaded/test.js
+++ b/test/shared-workers/multiple-workers-are-loaded/test.js
@@ -1,0 +1,9 @@
+import test from '@ava/test';
+
+import {fixture} from '../../helpers/exec.js';
+
+test('can load multiple workers', async t => {
+	await fixture();
+
+	t.pass();
+});


### PR DESCRIPTION
This fixes the bug introduced in https://github.com/avajs/ava/pull/3149 that I briefly mentioned.

Since we were assigning the launched shared worker to a single variable per test worker, we inadvertently assumed that a test worker would launch a maximum of 1 shared worker.

I tested this patch with two of our internal codebases that heavily use shared workers and everything's working as expected now.

Sorry for the previous buggy PR!