### PR TITLE
Infer thrown error from expectations

### DIFF
--- a/test-types/import-in-cts/throws.cts
+++ b/test-types/import-in-cts/throws.cts
@@ -12,15 +12,30 @@ class CustomError extends Error {
 }
 
 test('throws', t => {
-	expectType<Error | undefined>(t.throws(() => {}));
+	const error1 = t.throws(() => {});
+	expectType<Error | undefined>(error1);
 	const error2: CustomError | undefined = t.throws(() => {});
 	expectType<CustomError | undefined>(error2);
 	expectType<CustomError | undefined>(t.throws<CustomError>(() => {}));
+	const error3 = t.throws(() => {}, {instanceOf: CustomError});
+	expectType<CustomError | undefined>(error3);
+	const error4 = t.throws(() => {}, {is: new CustomError()});
+	expectType<CustomError | undefined>(error4);
+	const error5 = t.throws(() => {}, {instanceOf: CustomError, is: new CustomError()});
+	expectType<CustomError | undefined>(error5);
 });
 
 test('throwsAsync', async t => {
-	expectType<Error | undefined>(await t.throwsAsync(async () => {}));
+	const error1 = await t.throwsAsync(async () => {});
+	expectType<Error | undefined>(error1);
 	expectType<CustomError | undefined>(await t.throwsAsync<CustomError>(async () => {}));
-	expectType<Error | undefined>(await t.throwsAsync(Promise.reject()));
+	const error2 = await t.throwsAsync(Promise.reject());
+	expectType<Error | undefined>(error2);
 	expectType<CustomError | undefined>(await t.throwsAsync<CustomError>(Promise.reject()));
+	const error3 = await t.throwsAsync(async () => {}, {instanceOf: CustomError});
+	expectType<CustomError | undefined>(error3);
+	const error4 = await t.throwsAsync(async () => {}, {is: new CustomError()});
+	expectType<CustomError | undefined>(error4);
+	const error5 = await t.throwsAsync(async () => {}, {instanceOf: CustomError, is: new CustomError()});
+	expectType<CustomError | undefined>(error5);
 });

--- a/test-types/module/throws.ts
+++ b/test-types/module/throws.ts
@@ -12,15 +12,30 @@ class CustomError extends Error {
 }
 
 test('throws', t => {
-	expectType<Error | undefined>(t.throws(() => {}));
+	const error1 = t.throws(() => {});
+	expectType<Error | undefined>(error1);
 	const error2: CustomError | undefined = t.throws(() => {});
 	expectType<CustomError | undefined>(error2);
 	expectType<CustomError | undefined>(t.throws<CustomError>(() => {}));
+	const error3 = t.throws(() => {}, {instanceOf: CustomError});
+	expectType<CustomError | undefined>(error3);
+	const error4 = t.throws(() => {}, {is: new CustomError()});
+	expectType<CustomError | undefined>(error4);
+	const error5 = t.throws(() => {}, {instanceOf: CustomError, is: new CustomError()});
+	expectType<CustomError | undefined>(error5);
 });
 
 test('throwsAsync', async t => {
-	expectType<Error | undefined>(await t.throwsAsync(async () => {}));
+	const error1 = await t.throwsAsync(async () => {});
+	expectType<Error | undefined>(error1);
 	expectType<CustomError | undefined>(await t.throwsAsync<CustomError>(async () => {}));
-	expectType<Error | undefined>(await t.throwsAsync(Promise.reject()));
+	const error2 = await t.throwsAsync(Promise.reject());
+	expectType<Error | undefined>(error2);
 	expectType<CustomError | undefined>(await t.throwsAsync<CustomError>(Promise.reject()));
+	const error3 = await t.throwsAsync(async () => {}, {instanceOf: CustomError});
+	expectType<CustomError | undefined>(error3);
+	const error4 = await t.throwsAsync(async () => {}, {is: new CustomError()});
+	expectType<CustomError | undefined>(error4);
+	const error5 = await t.throwsAsync(async () => {}, {instanceOf: CustomError, is: new CustomError()});
+	expectType<CustomError | undefined>(error5);
 });

--- a/types/assertions.d.cts
+++ b/types/assertions.d.cts
@@ -1,15 +1,20 @@
-export type ErrorConstructor = new (...args: any[]) => Error;
+export type ErrorConstructor<ErrorType extends Error = Error> = {
+	new (...args: any[]): ErrorType;
+	readonly prototype: ErrorType;
+}
+
+export type ThrownError<ErrorType extends ErrorConstructor | Error> = ErrorType extends ErrorConstructor ? ErrorType['prototype'] : ErrorType;
 
 /** Specify one or more expectations the thrown error must satisfy. */
-export type ThrowsExpectation = {
+export type ThrowsExpectation<ErrorType extends ErrorConstructor | Error> = {
 	/** The thrown error must have a code that equals the given string or number. */
 	code?: string | number;
 
 	/** The thrown error must be an instance of this constructor. */
-	instanceOf?: ErrorConstructor;
+	instanceOf?: ErrorType extends ErrorConstructor ? ErrorType : ErrorType extends Error ? ErrorConstructor<ErrorType> : never;
 
 	/** The thrown error must be strictly equal to this value. */
-	is?: Error;
+	is?: ErrorType extends ErrorConstructor ? ErrorType['prototype'] : ErrorType;
 
 	/** The thrown error must have a message that equals the given string, or matches the regular expression. */
 	message?: string | RegExp | ((message: string) => boolean);
@@ -293,7 +298,7 @@ export type ThrowsAssertion = {
 	 * Assert that the function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error value.
 	 * The error must satisfy all expectations. Returns undefined when the assertion fails.
 	 */
-	<ThrownError extends Error>(fn: () => any, expectations?: ThrowsExpectation, message?: string): ThrownError | undefined;
+	<ErrorType extends ErrorConstructor | Error>(fn: () => any, expectations?: ThrowsExpectation<ErrorType>, message?: string): ThrownError<ErrorType> | undefined;
 
 	/** Skip this assertion. */
 	skip(fn: () => any, expectations?: any, message?: string): void;
@@ -304,14 +309,14 @@ export type ThrowsAsyncAssertion = {
 	 * Assert that the async function throws [an error](https://www.npmjs.com/package/is-error). If so, returns the error
 	 * value. Returns undefined when the assertion fails. You must await the result. The error must satisfy all expectations.
 	 */
-	<ThrownError extends Error>(fn: () => PromiseLike<any>, expectations?: ThrowsExpectation, message?: string): Promise<ThrownError | undefined>;
+	<ErrorType extends ErrorConstructor | Error>(fn: () => PromiseLike<any>, expectations?: ThrowsExpectation<ErrorType>, message?: string): Promise<ThrownError<ErrorType> | undefined>;
 
 	/**
 	 * Assert that the promise rejects with [an error](https://www.npmjs.com/package/is-error). If so, returns the
 	 * rejection reason. Returns undefined when the assertion fails. You must await the result. The error must satisfy all
 	 * expectations.
 	 */
-	<ThrownError extends Error>(promise: PromiseLike<any>, expectations?: ThrowsExpectation, message?: string): Promise<ThrownError | undefined>;
+	<ErrorType extends ErrorConstructor | Error>(promise: PromiseLike<any>, expectations?: ThrowsExpectation<ErrorType>, message?: string): Promise<ThrownError<ErrorType> | undefined>;
 
 	/** Skip this assertion. */
 	skip(thrower: any, expectations?: any, message?: string): void;


### PR DESCRIPTION
Updates type definitions to infer thrown error type from given expectations.

Writing `const error = t.throws<CustomError>(fn, { instanceOf: CustomError });` felt redundant and I thought there must be a way to infer the error type from the given `instanceOf` expectation. The tricky part was in making inference work for both `instanceOf` and `is` expectations.

I worked it out in [this playground](https://www.typescriptlang.org/play?ts=4.7.4#code/KYDwDg9gTgLgBDAnmYcCiUrQMIQHYDOMUArgMYzQA8GWUAKsqqDMHgCYHqbRwC83OgD5+cAN4BYAFABIPMADucABQA6dQEMoAcwIAuOBryIA2gF0AlAdrRGKANzSZUYBvb4ANojhgslJCjWPAxMjlIAvtLSoJCwCExw9AAWWAoEaODAFBowAJb4NMF2zCCsHFw2ULiExOSUUHAAPoLQIgKSsgD0AFTdiUmoMCkQCnhwwMFwALYkRHBJGgBuqBpwZBDsgwvwwACOJBoeXEOo2rnLY0RQuXjacLx4JFMARhOqcN2dTuubAPwGVxud2ajxeEzCTh6fWSW1SYwmdGms3gr0MYxuRCMZFQEAAZggkrkuOsaqQKNB3p8nBiYFjgAB5XH-FohFDjUpsTgs6pXOq8X4s4pwIJ0IUsTkVSYCyo82rkqCFUVMEQGeTLKAQrq9fqwkbwyYzOaowEULzjfaHBAQAlEuCLQ4kYCUr6yInMypijnlbn4XnyuDSopMEwAcl8EH8TBDZmFgtCUS10IGBLh4wNyPmSxW02ABAIGm0Wxy5oORwJp3ObDggNuABp7g0pjkyANjsmXNoSB4tOzfLmCPk8M6nFN+wXgMya8C4AAlYDaDJgJoqZSjvPjgHEIEWfgiZ4QCAeVx4CyamRQnUpvVpxGG+ALZaGOB4DSjgnFvaltsVi7Vre3YdZBfUdJ3-bQwnCTUYmgeAAlQZJUgIABBPMJjyfBRA6c9eicD44BQgg0PfWDk1xEg8AoQcrzSOATCMG9oDMZQkhgGAwH0TpOgUbjVDwMApgAKwIVR1imTowA0MgAGtx06IkAFoEWgCx3gASXxAgIHrFwYBIKBCHLBiGntDxHVUXCk2YdM5nzPICFxbxDg8XsslpdDCHeOddP0rhyM2XEbmAdg4AUAYxhOQxUNgKjcQ0XIjnM2QPhdGRFVsBJxW9GVfTlepl0qIRlFxPADGUHc+BEIxEHrGJXJyQcCGZBCRnSTJsnctLWWAIR6zXfNC1A65bisFQPQyr0uWy0k+QaQMlRQUNw0jFBo1jMaUB3Zo-OAAL5HYM8LwAZSk3IlyGW0NCi9zAJkAgTrAIqSpUcrKuMGq2rchrmSq3qxwGzchu0EbFggXJ9ukSCE02MhuxcNZuzzOBsGRCApkqdkykmyYsJcNxPEcgGgQgqGslh1ASTmIZEIMZq0gItDB01Cn4DwCB6TAdyCFUvBcQmdGBCplrlDK3dxHCU8E2ZuAbl5qAADEsCmbnMQohl8QF4Y0mFl6xfrMRpZqOlGQMZGiFR9HxaZnKDdlhXUdUrgNcQ7XRbEcI9el-Rn0UJGUbR4IRctyXrZliY7bR3ITgaJ2hZFirdfEA2VexY3fbN-26HrIlVR903KAz6BA4lqRpClptHkObABmkucBNc5XaVVxlREFtIqDz83gkKuORDdj2aSN3ERV4IOS6kMujFLKusik2v68d6iCHbv2Cpd+O+8T7PvaUSoi-sIA). It also shows that something like `const error = t.throws<CustomError>(() => {}, { instanceOf: Error });` is rejected by TS (if `CustomError` is structurally different to `Error`).