### PR TITLE
Explicitly configure script name for CLI

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -140,6 +140,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 
 	let resetCache = false;
 	const {argv} = yargs(hideBin(process.argv))
+		.scriptName('ava')
 		.version(pkg.version)
 		.parserConfiguration({
 			'boolean-negation': true,


### PR DESCRIPTION
Currently, the help command/option prints `cli.mjs` as the script name. This PR sets it to `ava` so that it's in line with the [CLI doc](https://github.com/avajs/ava/blob/main/docs/05-command-line.md).