### PR TITLE
Update TypeScript recipe to remove ts-node recommendation

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -19,8 +19,8 @@ Broadly speaking, there are two ways to run tests written in TypeScript:
 
 There are two components to a setup like this:
 
-1. [Make sure AVA recognizes the extensions of your TypeScript files](./06-configuration.md#configuring-module-formats)
-2. Install the loader [through `nodeArguments`](https://github.com/avajs/ava/blob/main/docs/06-configuration.md#node-arguments)
+1. [Make sure AVA recognizes the extensions of your TypeScript files](../06-configuration.md#configuring-module-formats)
+2. Install the loader [through `nodeArguments`](../06-configuration.md#node-arguments)
 
 [`tsx`](https://github.com/esbuild-kit/tsx) may be the best loader available. The setup, assuming your TypeScript config outputs ES modules, would look like this:
 

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -59,21 +59,19 @@ If this is not to your liking there is an _experimental_ option in Node.js that 
 
 #### For packages without type "module"
 
-If your `package.json` does not have `"type": "module"`, then this is the AVA configuration you need:
+If your `package.json` does not have `"type": "module"`, then you should use the [`tsx`](https://github.com/esbuild-kit/tsx) loader. To utilize this loader, after installing it to your dev dependencies, use this AVA configuration:
 
 `package.json`:
 
 ```json
-{
-	"ava": {
-		"extensions": [
-			"ts"
-		],
-		"require": [
-			"ts-node/register"
-		]
-	}
-}
+"ava": {
+    "extensions": {
+      "ts": "module"
+    },
+    "nodeArguments": [
+      "--loader=tsx"
+    ]
+  }
 ```
 
 It's worth noting that with this configuration, tests will fail if there are TypeScript build errors. Suppose you want to test while ignoring these errors. In that case, you can use `ts-node/register/transpile-only` instead of `ts-node/register` or add an environment variable for ts-node to log errors to stderr instead of throwing an exception.


### PR DESCRIPTION
adds a recipe to use the `tsx` loader from esbuild

closes #2593;