### PR TITLE
ci: run tests on latest node 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [^14.19, ^16.15, ^18]
+        node-version: [^14.19, ^16.15, ^18, ^19]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We're using ava and run tests against node 19. As of node > 19.5.0 the tests are failing because of 

```sh
  TypeError [ERR_INVALID_ARG_TYPE]: The "payload" argument must be of type object. Received null

  › file:///home/runner/work/ui5-tooling-extensions/ui5-tooling-extensions/node_modules/mem/dist/index.js:42:27
  › file:///home/runner/work/ui5-tooling-extensions/ui5-tooling-extensions/node_modules/mem/dist/index.js:42:27
```

See full job details here https://github.com/SAP/ui5-tooling-extensions/actions/runs/4689838073/jobs/8312104201?pr=70

This PR enables ci tests for node 19 to ensure ava runs also smoothly on node 19. 