### PR TITLE
Remove use of the "del" package. This reduces total dependencies by 11%.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,7 +5,6 @@ import process from 'node:process';
 
 import arrify from 'arrify';
 import ciParallelVars from 'ci-parallel-vars';
-import {deleteAsync} from 'del';
 import figures from 'figures';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers'; // eslint-disable-line n/file-extension-in-import
@@ -261,14 +260,13 @@ export default async function loadCli() { // eslint-disable-line complexity
 	const {nonSemVerExperiments: experiments, projectDir} = conf;
 	if (resetCache) {
 		const cacheDir = path.join(projectDir, 'node_modules', '.cache', 'ava');
-
 		try {
-			const deletedFilePaths = await deleteAsync('*', {cwd: cacheDir});
-
-			if (deletedFilePaths.length === 0) {
-				console.log(`\n${chalk.green(figures.tick)} No cache files to remove`);
+			if (fs.existsSync(cacheDir)) {
+				fs.rmSync(cacheDir, {recursive: true, force: true});
+				fs.mkdirSync(cacheDir);
+				console.log(`\n${chalk.green(figures.tick)} Emptied AVA cache cache directory ${cacheDir}`);
 			} else {
-				console.log(`\n${chalk.green(figures.tick)} Removed AVA cache files in ${cacheDir}`);
+				console.log(`\n${chalk.green(figures.tick)} No cache directory to remove`);
 			}
 
 			process.exit(0); // eslint-disable-line unicorn/no-process-exit

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
 		"concordance": "^5.0.4",
 		"currently-unhandled": "^0.4.1",
 		"debug": "^4.3.4",
-		"del": "^7.0.0",
 		"emittery": "^1.0.1",
 		"figures": "^5.0.0",
 		"globby": "^13.1.3",

--- a/test-tap/api.js
+++ b/test-tap/api.js
@@ -3,7 +3,6 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import ciInfo from 'ci-info';
-import {deleteSync} from 'del';
 import {test} from 'tap';
 
 import Api from '../lib/api.js';
@@ -380,7 +379,10 @@ for (const opt of options) {
 	});
 
 	test(`caching is enabled by default - workerThreads: ${opt.workerThreads}`, async t => {
-		deleteSync(path.join(__dirname, 'fixture/caching/node_modules'));
+		const nodeModulesPath = path.join(__dirname, 'fixture/caching/node_modules');
+		if (fs.existsSync(nodeModulesPath)) {
+			fs.rmSync(nodeModulesPath, {recursive: true, force: true});
+		}
 
 		const api = await apiCreator({
 			...opt,
@@ -400,7 +402,10 @@ for (const opt of options) {
 	});
 
 	test(`caching can be disabled - workerThreads: ${opt.workerThreads}`, async t => {
-		deleteSync(path.join(__dirname, 'fixture/caching/node_modules'));
+		const nodeModulesPath = path.join(__dirname, 'fixture/caching/node_modules');
+		if (fs.existsSync(nodeModulesPath)) {
+			fs.rmSync(nodeModulesPath, {recursive: true, force: true});
+		}
 
 		const api = await apiCreator({
 			...opt,


### PR DESCRIPTION
https://craigahobbs.github.io/npm-dependency-explorer/#var.vDirect=1&var.vName='ava'&var.vSort='Dependencies'