### PR TITLE
Update t.like to support Symbol keys and ignore non-enumerable properties

### DIFF
--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -165,7 +165,7 @@ t.like({
 You can also use arrays, but note that any indices in `actual` that are not in `selector` are ignored:
 
 ```js
-t.like([1, 2, 3], [1, 2])
+t.like([1, 2, 3, 4], [1, , 3])
 ```
 
 Finally, this returns a boolean indicating whether the assertion passed.

--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -141,7 +141,7 @@ Assert that `actual` is not deeply equal to `expected`. The inverse of `.deepEqu
 
 Assert that `actual` is like `selector`. This is a variant of `.deepEqual()`, however `selector` does not need to have the same enumerable properties as `actual` does.
 
-Instead AVA derives a *comparable* value from `actual`, recursively based on the shape of `selector`. This value is then compared to `selector` using `.deepEqual()`.
+Instead AVA derives a *comparable* value from `actual`, recursively based on the enumerable shape of `selector`. This value is then compared to `selector` using `.deepEqual()`.
 
 Any values in `selector` that are not arrays or regular objects should be deeply equal to the corresponding values in `actual`.
 

--- a/lib/like-selector.js
+++ b/lib/like-selector.js
@@ -1,18 +1,17 @@
-const isPrimitive = val => val === null || typeof val !== 'object';
+const isPrimitive = value => value === null || typeof value !== 'object';
 
 export function isLikeSelector(selector) {
-	if (isPrimitive(selector)) {
+	// Require selector to be an array or plain object.
+	if (
+		isPrimitive(selector)
+		|| (!Array.isArray(selector) && Reflect.getPrototypeOf(selector) !== Object.prototype)
+	) {
 		return false;
 	}
 
-	const keyCount = Reflect.ownKeys(selector).length;
-	if (Array.isArray(selector)) {
-		// In addition to `length`, require at at least one element.
-		return keyCount > 1;
-	} else {
-		// Require a plain object with at least one property.
-		return Reflect.getPrototypeOf(selector) === Object.prototype && keyCount > 0;
-	}
+	// Also require at least one enumerable property.
+	const descriptors = Object.getOwnPropertyDescriptors(selector);
+	return Reflect.ownKeys(descriptors).some(key => descriptors[key].enumerable === true);
 }
 
 export const CIRCULAR_SELECTOR = new Error('Encountered a circular selector');
@@ -29,7 +28,9 @@ export function selectComparable(actual, selector, circular = new Set()) {
 	}
 
 	const comparable = Array.isArray(selector) ? [] : {};
-	for (const [key, subselector] of Object.entries(selector)) {
+	const enumerableSubselectors = {...selector};
+	for (const key of Reflect.ownKeys(enumerableSubselectors)) {
+		const subselector = enumerableSubselectors[key];
 		comparable[key] = isLikeSelector(subselector)
 			? selectComparable(Reflect.get(actual, key), subselector, circular)
 			: Reflect.get(actual, key);

--- a/lib/like-selector.js
+++ b/lib/like-selector.js
@@ -1,32 +1,38 @@
-const isObject = selector => Reflect.getPrototypeOf(selector) === Object.prototype;
+const isPrimitive = val => val === null || typeof val !== 'object';
 
 export function isLikeSelector(selector) {
-	if (selector === null || typeof selector !== 'object') {
+	if (isPrimitive(selector)) {
 		return false;
 	}
 
 	const keyCount = Reflect.ownKeys(selector).length;
-	return (Array.isArray(selector) && keyCount > 1) || (isObject(selector) && keyCount > 0);
+	if (Array.isArray(selector)) {
+		// In addition to `length`, require at at least one element.
+		return keyCount > 1;
+	} else {
+		// Require a plain object with at least one property.
+		return Reflect.getPrototypeOf(selector) === Object.prototype && keyCount > 0;
+	}
 }
 
 export const CIRCULAR_SELECTOR = new Error('Encountered a circular selector');
 
-export function selectComparable(lhs, selector, circular = new Set()) {
+export function selectComparable(actual, selector, circular = new Set()) {
 	if (circular.has(selector)) {
 		throw CIRCULAR_SELECTOR;
 	}
 
 	circular.add(selector);
 
-	if (lhs === null || typeof lhs !== 'object') {
-		return lhs;
+	if (isPrimitive(actual)) {
+		return actual;
 	}
 
 	const comparable = Array.isArray(selector) ? [] : {};
-	for (const [key, rhs] of Object.entries(selector)) {
-		comparable[key] = isLikeSelector(rhs)
-			? selectComparable(Reflect.get(lhs, key), rhs, circular)
-			: Reflect.get(lhs, key);
+	for (const [key, subselector] of Object.entries(selector)) {
+		comparable[key] = isLikeSelector(subselector)
+			? selectComparable(Reflect.get(actual, key), subselector, circular)
+			: Reflect.get(actual, key);
 	}
 
 	return comparable;

--- a/lib/like-selector.js
+++ b/lib/like-selector.js
@@ -28,9 +28,9 @@ export function selectComparable(actual, selector, circular = new Set()) {
 	}
 
 	const comparable = Array.isArray(selector) ? [] : {};
-	const enumerableSubselectors = {...selector};
-	for (const key of Reflect.ownKeys(enumerableSubselectors)) {
-		const subselector = enumerableSubselectors[key];
+	const enumerableKeys = Reflect.ownKeys(selector).filter(key => Reflect.getOwnPropertyDescriptor(selector, key).enumerable);
+	for (const key of enumerableKeys) {
+		const subselector = Reflect.get(selector, key);
 		comparable[key] = isLikeSelector(subselector)
 			? selectComparable(Reflect.get(actual, key), subselector, circular)
 			: Reflect.get(actual, key);

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -767,8 +767,10 @@ test('.like()', t => {
 
 	passes(t, () => assertions.like([1, 2, 3], [1, 2, 3]));
 	passes(t, () => assertions.like([1, 2, 3], [1, 2]));
+	passes(t, () => assertions.like([1, 2, 3], [1, , 3]));
 
 	fails(t, () => assertions.like([1, 2, 3], [3, 2, 1]));
+	fails(t, () => assertions.like([1, 2, 3], [1, , 4]));
 	fails(t, () => assertions.like([1, 2], [1, 2, 3]));
 
 	t.end();

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -720,7 +720,7 @@ test('.like()', t => {
 		return assertions.like({xc: [circular, 'c']}, {xc: [circular, 'd']});
 	});
 
-	failsWith(t, () => assertions.like({a: 'a'}, {}), {
+	failsWith(t, () => assertions.like({a: 'a'}, Object.defineProperties({}, {ignored: {}})), {
 		assertion: 'like',
 		message: '`t.like()` selector must be a non-empty object',
 		values: [{label: 'Called with:', formatted: '{}'}],
@@ -730,6 +730,15 @@ test('.like()', t => {
 		assertion: 'like',
 		message: '`t.like()` selector must be a non-empty object',
 		values: [{label: 'Called with:', formatted: '\'bar\''}],
+	});
+
+	passes(t, () => {
+		const specimen = {[Symbol.toStringTag]: 'Custom', extra: true};
+		const selector = Object.defineProperties(
+			{[Symbol.toStringTag]: 'Custom'},
+			{ignored: {value: true}},
+		);
+		return assertions.like(specimen, selector);
 	});
 
 	failsWith(t, () => {
@@ -767,9 +776,11 @@ test('.like()', t => {
 
 	passes(t, () => assertions.like([1, 2, 3], [1, 2, 3]));
 	passes(t, () => assertions.like([1, 2, 3], [1, 2]));
+	// eslint-disable-next-line no-sparse-arrays
 	passes(t, () => assertions.like([1, 2, 3], [1, , 3]));
 
 	fails(t, () => assertions.like([1, 2, 3], [3, 2, 1]));
+	// eslint-disable-next-line no-sparse-arrays
 	fails(t, () => assertions.like([1, 2, 3], [1, , 4]));
 	fails(t, () => assertions.like([1, 2], [1, 2, 3]));
 


### PR DESCRIPTION
Fixes #3208