### PR TITLE
Pro-actively write out code coverage

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import v8 from 'node:v8';
 
 import arrify from 'arrify';
 import figures from 'figures';
@@ -474,6 +475,12 @@ export default async function loadCli() { // eslint-disable-line complexity
 		reporter.startRun(plan);
 
 		plan.status.on('stateChange', evt => {
+			if (evt.type === 'end' || evt.type === 'interrupt') {
+				// Write out code coverage data when the run ends, lest a process
+				// interrupt causes it to be lost.
+				v8.takeCoverage();
+			}
+
 			if (evt.type === 'interrupt') {
 				reporter.endRun();
 				process.exit(1); // eslint-disable-line unicorn/no-process-exit


### PR DESCRIPTION
This helped recording coverage when testing AVA itself, but hopefully it also helps user projects.
