### PR TITLE
Remove workaround for worker.terminate() crashes

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -4,7 +4,6 @@ import {fileURLToPath} from 'node:url';
 import {Worker} from 'node:worker_threads';
 
 import Emittery from 'emittery';
-import {pEvent} from 'p-event';
 
 import {controlFlow} from './ipc-flow-control.cjs';
 import serializeError from './serialize-error.js';
@@ -35,13 +34,8 @@ const createWorker = (options, execArgv) => {
 		});
 		postMessage = worker.postMessage.bind(worker);
 
-		// Ensure we've seen this event before we terminate the worker thread, as a
-		// workaround for https://github.com/nodejs/node/issues/38418.
-		const starting = pEvent(worker, 'message', ({ava}) => ava?.type === 'starting');
-
 		close = async () => {
 			try {
-				await starting;
 				await worker.terminate();
 			} finally {
 				// No-op


### PR DESCRIPTION
Looks like the patch is included in all supported Node.js versions.
