### PR TITLE
Update TypeScript recipe for mocks, Node.js 20

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -56,7 +56,7 @@ Mocking with `tsx` (such as with [`esmock`](https://github.com/iambumblehead/esm
 }
 ```
 
-### Node.js 20
+#### Node.js 20
 
 In Node.js 20, custom loaders must be specified via the `NODE_OPTIONS` environment variable:
 

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -28,13 +28,43 @@ There are two components to a setup like this:
 
 ```json
 "ava": {
-    "extensions": {
-      "ts": "module"
-    },
-    "nodeArguments": [
-      "--loader=tsx"
-    ]
-  }
+	"extensions": {
+		"ts": "module"
+	},
+	"nodeArguments": [
+		"--loader=tsx"
+	]
+}
+```
+
+### Mocking
+
+Mocking with `tsx` (such as with [`esmock`](https://github.com/iambumblehead/esmock)) isn't currently possible (https://github.com/esbuild-kit/tsx/issues/264). [`ts-node`](https://github.com/TypeStrong/ts-node) can be used instead:
+
+`package.json`:
+
+```json
+"ava": {
+	"extensions": {
+		"ts": "module"
+	},
+	"nodeArguments": [
+		"--loader=ts-node/esm",
+		"--loader=esmock"
+	]
+}
+```
+
+### Node.js 20
+
+In Node.js 20, custom loaders must be specified via the `NODE_OPTIONS` environment variable:
+
+`package.json`:
+
+```json
+"scripts": {
+	"test": "NODE_OPTIONS='--loader=tsx' ava"
+}
 ```
 
 ## Writing tests

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -36,8 +36,9 @@ There are two components to a setup like this:
 	]
 }
 ```
+### When using custom loaders
 
-### Mocking
+#### Mocking
 
 Mocking with `tsx` (such as with [`esmock`](https://github.com/iambumblehead/esmock)) isn't currently possible (https://github.com/esbuild-kit/tsx/issues/264). [`ts-node`](https://github.com/TypeStrong/ts-node) can be used instead:
 


### PR DESCRIPTION
Adds info to the TypeScript recipe about potential issues with using `esmock` with `tsx` (https://github.com/esbuild-kit/tsx/issues/264) and using a TypeScript loader in Node.js 20 (https://github.com/avajs/ava/issues/2593#issuecomment-1524846453).