### PR TITLE
feat: add `sourceMaps` option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -60,6 +60,11 @@ const FLAGS = {
 		description: 'Run tests serially',
 		type: 'boolean',
 	},
+	'source-maps': {
+		coerce: coerceLastValue,
+		description: 'Enable source maps support (true by default)',
+		type: 'boolean',
+	},
 	tap: {
 		alias: 't',
 		coerce: coerceLastValue,
@@ -228,6 +233,8 @@ export default async function loadCli() { // eslint-disable-line complexity
 				combined.failFast = argv[flag];
 			} else if (flag === 'update-snapshots') {
 				combined.updateSnapshots = argv[flag];
+			} else if (flag === 'source-maps') {
+				combined.sourceMaps = argv[flag];
 			} else if (flag !== 'node-arguments') {
 				combined[flag] = argv[flag];
 			}
@@ -429,6 +436,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 		nodeArguments,
 		parallelRuns,
 		sortTestFiles: conf.sortTestFiles,
+		sourceMaps: combined.sourceMaps,
 		projectDir,
 		providers,
 		ranFromCli: true,

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -13,17 +13,20 @@ export function _testOnlyReplaceWorkerPath(replacement) {
 	workerPath = replacement;
 }
 
-const additionalExecArgv = ['--enable-source-maps'];
-
 const createWorker = (options, execArgv) => {
 	let worker;
 	let postMessage;
 	let close;
+
+	if (options.sourceMaps !== false) {
+		execArgv = [...execArgv, '--enable-source-maps'];
+	}
+
 	if (options.workerThreads) {
 		worker = new Worker(workerPath, {
 			argv: options.workerArgv,
 			env: {NODE_ENV: 'test', ...process.env, ...options.environmentVariables},
-			execArgv: [...execArgv, ...additionalExecArgv],
+			execArgv,
 			workerData: {
 				options,
 			},
@@ -46,7 +49,7 @@ const createWorker = (options, execArgv) => {
 			cwd: options.projectDir,
 			silent: true,
 			env: {NODE_ENV: 'test', ...process.env, ...options.environmentVariables},
-			execArgv: [...execArgv, ...additionalExecArgv],
+			execArgv,
 			serialization: 'advanced',
 		});
 		postMessage = controlFlow(worker);


### PR DESCRIPTION
When this option is false, the --enable-source-maps Node.js flag is not set for worker threads.