### PR TITLE
Make `assert`, `truthy` and `falsy` typeguards

### DIFF
--- a/test-types/import-in-cts/assertions-as-type-guards.cts
+++ b/test-types/import-in-cts/assertions-as-type-guards.cts
@@ -42,7 +42,7 @@ test('false', t => {
 });
 
 test('falsy', t => {
-	type Actual = Expected | undefined | null | false | 0 | '' | 0n;
+	type Actual = Expected | undefined | false | 0 | '' | 0n;
 	const actual = undefined as Actual;
 	if (t.falsy(actual)) {
 		expectType<Exclude<Actual, Expected>>(actual);

--- a/test-types/import-in-cts/assertions-as-type-guards.cts
+++ b/test-types/import-in-cts/assertions-as-type-guards.cts
@@ -4,6 +4,15 @@ import {expectType} from 'tsd';
 type Expected = {foo: 'bar'};
 const expected: Expected = {foo: 'bar'};
 
+test('assert', t => {
+	const actual = expected as Expected | undefined;
+	if (t.truthy(actual)) {
+		expectType<Expected>(actual);
+	} else {
+		expectType<undefined>(actual);
+	}
+});
+
 test('deepEqual', t => {
 	const actual: unknown = {};
 	if (t.deepEqual(actual, expected)) {
@@ -32,9 +41,28 @@ test('false', t => {
 	}
 });
 
+test('falsy', t => {
+	type Actual = Expected | undefined | null | false | 0 | '' | 0n;
+	const actual = undefined as Actual;
+	if (t.falsy(actual)) {
+		expectType<Exclude<Actual, Expected>>(actual);
+	} else {
+		expectType<Expected>(actual);
+	}
+});
+
 test('true', t => {
 	const actual: unknown = false;
 	if (t.true(actual)) {
 		expectType<true>(actual);
+	}
+});
+
+test('truthy', t => {
+	const actual = expected as Expected | undefined;
+	if (t.truthy(actual)) {
+		expectType<Expected>(actual);
+	} else {
+		expectType<undefined>(actual);
 	}
 });

--- a/test-types/module/assertions-as-type-guards.ts
+++ b/test-types/module/assertions-as-type-guards.ts
@@ -43,7 +43,7 @@ test('false', t => {
 });
 
 test('falsy', t => {
-	type Actual = Expected | undefined | null | false | 0 | '' | 0n;
+	type Actual = Expected | undefined | false | 0 | '' | 0n;
 	const actual = undefined as Actual;
 	if (t.falsy(actual)) {
 		expectType<Exclude<Actual, Expected>>(actual);

--- a/test-types/module/assertions-as-type-guards.ts
+++ b/test-types/module/assertions-as-type-guards.ts
@@ -5,6 +5,15 @@ import test from '../../entrypoints/main.mjs';
 type Expected = {foo: 'bar'};
 const expected: Expected = {foo: 'bar'};
 
+test('assert', t => {
+	const actual = expected as Expected | undefined;
+	if (t.truthy(actual)) {
+		expectType<Expected>(actual);
+	} else {
+		expectType<undefined>(actual);
+	}
+});
+
 test('deepEqual', t => {
 	const actual: unknown = {};
 	if (t.deepEqual(actual, expected)) {
@@ -33,9 +42,28 @@ test('false', t => {
 	}
 });
 
+test('falsy', t => {
+	type Actual = Expected | undefined | null | false | 0 | '' | 0n;
+	const actual = undefined as Actual;
+	if (t.falsy(actual)) {
+		expectType<Exclude<Actual, Expected>>(actual);
+	} else {
+		expectType<Expected>(actual);
+	}
+});
+
 test('true', t => {
 	const actual: unknown = false;
 	if (t.true(actual)) {
 		expectType<true>(actual);
+	}
+});
+
+test('truthy', t => {
+	const actual = expected as Expected | undefined;
+	if (t.truthy(actual)) {
+		expectType<Expected>(actual);
+	} else {
+		expectType<undefined>(actual);
 	}
 });

--- a/types/assertions.d.cts
+++ b/types/assertions.d.cts
@@ -124,7 +124,7 @@ export type Assertions = {
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
 	 * 
-	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
+	 * Note: An `else` clause using this as a type guard will be subtly incorrect for `string` and `number` types and will not give `0` or `''` as a potential value in an `else` clause.
 	 */
 	truthy: TruthyAssertion;
 };
@@ -137,7 +137,7 @@ export type AssertAssertion = {
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
 	 * 
-	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
+	 * Note: An `else` clause using this as a type guard will be subtly incorrect for `string` and `number` types and will not give `0` or `''` as a potential value in an `else` clause.
 	 */
 	<T>(actual: T, message?: string): actual is T extends Falsy<T> ? never : T;
 
@@ -346,7 +346,7 @@ export type TruthyAssertion = {
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
 	 * 
-	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
+	 * Note: An `else` clause using this as a type guard will be subtly incorrect for `string` and `number` types and will not give `0` or `''` as a potential value in an `else` clause.
 	 */
 	<T>(actual: T, message?: string):  actual is T extends Falsy<T> ? never : T;
 

--- a/types/assertions.d.cts
+++ b/types/assertions.d.cts
@@ -27,6 +27,8 @@ export type Assertions = {
 	/**
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
+	 * 
+	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
 	 */
 	assert: AssertAssertion;
 
@@ -121,18 +123,23 @@ export type Assertions = {
 	/**
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
+	 * 
+	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
 	 */
 	truthy: TruthyAssertion;
 };
 
-type Falsy = false | 0 | 0n | '' | null | undefined;
+type FalsyValue = false | 0 | 0n | '' | null | undefined;
+type Falsy<T> = T extends Exclude<T, FalsyValue> ? (T extends number | string | bigint ? T & FalsyValue : never) : T;
 
 export type AssertAssertion = {
 	/**
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
+	 * 
+	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
 	 */
-	<T>(actual: T, message?: string): actual is Exclude<T, Falsy>;
+	<T>(actual: T, message?: string): actual is T extends Falsy<T> ? never : T;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
@@ -194,7 +201,7 @@ export type FalsyAssertion = {
 	 * Assert that `actual` is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy), returning a boolean
 	 * indicating whether the assertion passed.
 	 */
-	<T>(actual: T, message?: string): actual is T extends Falsy ? T :never;
+	<T>(actual: T, message?: string): actual is Falsy<T>;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
@@ -338,8 +345,10 @@ export type TruthyAssertion = {
 	/**
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
+	 * 
+	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
 	 */
-	<T>(actual: T, message?: string): actual is Exclude<T, Falsy>;
+	<T>(actual: T, message?: string):  actual is T extends Falsy<T> ? never : T;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;

--- a/types/assertions.d.cts
+++ b/types/assertions.d.cts
@@ -125,7 +125,7 @@ export type Assertions = {
 	truthy: TruthyAssertion;
 };
 
-type Falsy = false | 0 | -0 | 0n | '' | null | undefined;
+type Falsy = false | 0 | 0n | '' | null | undefined;
 
 export type AssertAssertion = {
 	/**

--- a/types/assertions.d.cts
+++ b/types/assertions.d.cts
@@ -28,7 +28,7 @@ export type Assertions = {
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
 	 * 
-	 * Note: with typescript, an `else` clause using this as a typeguard will be subtly incorrect for string and number types and will not give `0` or `''` as a potential value in an `else` clause
+	 * Note: An `else` clause using this as a type guard will be subtly incorrect for `string` and `number` types and will not give `0` or `''` as a potential value in an `else` clause.
 	 */
 	assert: AssertAssertion;
 

--- a/types/assertions.d.cts
+++ b/types/assertions.d.cts
@@ -125,12 +125,14 @@ export type Assertions = {
 	truthy: TruthyAssertion;
 };
 
+type Falsy = false | 0 | -0 | 0n | '' | null | undefined;
+
 export type AssertAssertion = {
 	/**
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
 	 */
-	(actual: any, message?: string): boolean;
+	<T>(actual: T, message?: string): actual is Exclude<T, Falsy>;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
@@ -192,7 +194,7 @@ export type FalsyAssertion = {
 	 * Assert that `actual` is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy), returning a boolean
 	 * indicating whether the assertion passed.
 	 */
-	(actual: any, message?: string): boolean;
+	<T>(actual: T, message?: string): actual is T extends Falsy ? T :never;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;
@@ -337,7 +339,7 @@ export type TruthyAssertion = {
 	 * Assert that `actual` is [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), returning a boolean
 	 * indicating whether the assertion passed.
 	 */
-	(actual: any, message?: string): boolean;
+	<T>(actual: T, message?: string): actual is Exclude<T, Falsy>;
 
 	/** Skip this assertion. */
 	skip(actual: any, message?: string): void;


### PR DESCRIPTION
This will make ava easier to use with typescript and allow for removing redundant checks.

```ts
// with change
const actual = 3 as number | undefined;
if (t.assert(actual)) {
    // actual is `number` here
} else {
    // actual is `undefined` here
}
```
```ts
// before change
const actual = 3 as number | undefined;
t.assert(actual);
// Need a separate if branch from the assertion
if (actual) {
    // actual is `number` here
} else {
    // actual is `undefined` here
}
```

Since ava is a library and to reduce any type errors in existing projects, it's best to use the most exact approach to the typeguards as possible. For most use cases something akin to `actual is NonNullable<T>` is completely valid, but in this case it's very likely that things like `boolean` will be passed in.

Unfortunately typescript doesn't have convenient `Falsy` or `Truthy` utility types, so the best approach I've seen so far is to enumerate all possibilities (except `NaN`) to make up `Falsy` and then use that to Exclude `Falsy` types. `NaN` doesn't have it's own type, so the typeguard won't be able to differentiate between them no matter what we do.