### PR TITLE
Expose internal events for custom reporters via config

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -471,10 +471,24 @@ export default async function loadCli() { // eslint-disable-line complexity
 		});
 	}
 
-	api.on('run', plan => {
+	api.on('run', async plan => {
+		if (combined.onInternalEvent) {
+			await combined.onInternalEvent({
+				type: 'run',
+				plan,
+			});
+		}
+
 		reporter.startRun(plan);
 
-		plan.status.on('stateChange', evt => {
+		plan.status.on('stateChange', async evt => {
+			if (combined.onInternalEvent) {
+				await combined.onInternalEvent({
+					type: 'stateChange',
+					stateChange: evt,
+				});
+			}
+
 			if (evt.type === 'end' || evt.type === 'interrupt') {
 				// Write out code coverage data when the run ends, lest a process
 				// interrupt causes it to be lost.

--- a/test/internal-events/fixtures/.gitignore
+++ b/test/internal-events/fixtures/.gitignore
@@ -1,0 +1,1 @@
+internal-events.json

--- a/test/internal-events/fixtures/ava.config.js
+++ b/test/internal-events/fixtures/ava.config.js
@@ -1,0 +1,16 @@
+import fs from 'node:fs/promises';
+
+const internalEvents = [];
+
+export default {
+	files: [
+		'test.js',
+	],
+	async onInternalEvent(event) {
+		internalEvents.push(event);
+
+		if (event.type === 'stateChange' && event.stateChange.type === 'end') {
+			await fs.writeFile('internal-events.json', JSON.stringify(internalEvents));
+		}
+	},
+};

--- a/test/internal-events/fixtures/package.json
+++ b/test/internal-events/fixtures/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "module"
+}

--- a/test/internal-events/fixtures/test.js
+++ b/test/internal-events/fixtures/test.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('placeholder', t => {
+	t.pass();
+});

--- a/test/internal-events/test.js
+++ b/test/internal-events/test.js
@@ -1,0 +1,38 @@
+import fs from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
+
+import test from '@ava/test';
+
+import {fixture} from '../helpers/exec.js';
+
+test('internal events are emitted', async t => {
+	await fixture();
+
+	const result = JSON.parse(await fs.readFile(fileURLToPath(new URL('fixtures/internal-events.json', import.meta.url))));
+
+	t.like(result[0], {
+		type: 'run',
+		plan: {
+			files: [
+				fileURLToPath(new URL('fixtures/test.js', import.meta.url)),
+			],
+		},
+	});
+
+	const testPassedEvent = result.find(event => event.type === 'stateChange' && event.stateChange.type === 'test-passed');
+	t.like(testPassedEvent, {
+		type: 'stateChange',
+		stateChange: {
+			type: 'test-passed',
+			title: 'placeholder',
+			testFile: fileURLToPath(new URL('fixtures/test.js', import.meta.url)),
+		},
+	});
+
+	t.like(result[result.length - 1], {
+		type: 'stateChange',
+		stateChange: {
+			type: 'end',
+		},
+	});
+});


### PR DESCRIPTION
We've been using a similar approach to this internally on a patched version of AVA for the last few weeks to pipe test runs to Datadog and it's been working great.

Alternatives:

- [use a Shared Worker](https://github.com/avajs/ava/discussions/3004): I think the solution here is much simpler than introducing a third type of worker (Shared Workers, Test Workers, and Suite(?) Workers) and covers most use cases I can think of.
- use [Diagnostic Channels](https://nodejs.org/api/diagnostics_channel.html): I'm not very familiar with this built-in, but looks like it could help reduce the performance impact of this?

Happy to add TS definitions for events if this is the route we want to go.