### PR TITLE
Update 03-assertions.md because of issue #2624

### DIFF
--- a/docs/03-assertions.md
+++ b/docs/03-assertions.md
@@ -35,7 +35,7 @@ Assertion plans ensure tests only pass when a specific number of assertions have
 
 If you do not specify an assertion plan, your test will still fail if no assertions are executed. Set the `failWithoutAssertions` option to `false` in AVA's [`package.json` configuration](./06-configuration.md) to disable this behavior.
 
-Note that, unlike [`tap`](https://www.npmjs.com/package/tap) and [`tape`](https://www.npmjs.com/package/tape), AVA does *not* automatically end a test when the planned assertion count is reached.
+Note that, unlike [`tap`](https://www.npmjs.com/package/tap) and [`tape`](https://www.npmjs.com/package/tape), AVA does *not* automatically end a test when the planned assertion count is reached. Note that ava assertions *don't* stop the test when they fail for better analysis of your code
 
 These examples will result in a passed test:
 


### PR DESCRIPTION
Adding text in assertion planning in order to inform about ava assertion not stopping even when they fail linked to issue 
#2624 Document that awa assertions don't throw |

I also have 3 of my friends using this tool, I also do. I was thinking why does it not stop and found an issue already. This minor change **will help the users very much**
