### PR TITLE
Ensure watch mode works outside of its integration tests

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -522,7 +522,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 			providers,
 			reporter,
 			stdin: process.stdin,
-			signal: abortController.signal,
+			signal: abortController?.signal,
 		});
 	} else {
 		let debugWithoutSpecificFile = false;

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -370,15 +370,15 @@ async function * plan({api, filter, globs, projectDir, providers, stdin, abortSi
 		}
 	});
 
-	abortSignal.addEventListener('abort', () => {
+	abortSignal?.addEventListener('abort', () => {
 		signalChanged?.({});
 	});
 
 	// And finally, the watch loop.
-	while (!abortSignal.aborted) {
+	while (abortSignal?.aborted !== true) {
 		const {testFiles: files = [], runOnlyExclusive = false} = await changed; // eslint-disable-line no-await-in-loop
 
-		if (abortSignal.aborted) {
+		if (abortSignal?.aborted) {
 			break;
 		}
 


### PR DESCRIPTION
Somewhere between developing the watch mode and adding test coverage, a mechanism was introduced to control watch mode in its integration tests. Ironically watch mode relied on this mechanism and no longer worked in actual use.

Fixes #3270
