### PR TITLE
Fix potential bug with watch mode when no failed test files are written

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -303,7 +303,9 @@ export default class Api extends Emittery {
 			// Allow shared workers to clean up before the run ends.
 			await Promise.all(deregisteredSharedWorkers);
 			const files = scheduler.storeFailedTestFiles(runStatus, this.options.cacheEnabled === false ? null : this._createCacheDir());
-			runStatus.emitStateChange({type: 'touched-files', files});
+			if (files) {
+				runStatus.emitStateChange({type: 'touched-files', files});
+			}
 		} catch (error) {
 			runStatus.emitStateChange({type: 'internal-error', err: serializeError(error)});
 		}


### PR DESCRIPTION
Don't emit the 'touched-files' event, since the watcher assumes that comes with a files value.

Fixes #3285
