### PR TITLE
Fix import typo

### DIFF
--- a/entrypoints/internal.d.mts
+++ b/entrypoints/internal.d.mts
@@ -1,4 +1,4 @@
-import type {StateChangeEvent} from '../types/state-change-events.d';
+import type {StateChangeEvent} from '../types/state-change-events.d.cts';
 
 export type Event = StateChangeEvent;
 


### PR DESCRIPTION
We finally started building on top of the API [I added last year](https://github.com/avajs/ava/pull/3247) and discovered a small typo. The `ava/internal` type import was failing until I made this change.