### PR TITLE
Upgrade `xo` to `v0.57.0` and lint sources, tests, and examples

### DIFF
--- a/.xo-config.cjs
+++ b/.xo-config.cjs
@@ -29,6 +29,7 @@ module.exports = {
 		'import/newline-after-import': 'error',
 		'unicorn/require-post-message-target-origin': 'off',
 		'unicorn/prefer-event-target': 'off',
+		'unicorn/prevent-abbreviations': 'off',
 	},
 	overrides: [
 		{

--- a/examples/macros/test.js
+++ b/examples/macros/test.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 
-const {sum} = require('.');
+const {sum} = require('./index.js');
 
 function macro(t, a, b, expected) {
 	t.is(sum(a, b), expected);

--- a/examples/timeouts/test.js
+++ b/examples/timeouts/test.js
@@ -1,7 +1,7 @@
 'use strict';
 const test = require('ava');
 
-const {fetchUsers, fetchPosts, createPost} = require('.');
+const {fetchUsers, fetchPosts, createPost} = require('./index.js');
 
 test('retrieve users', async t => {
 	t.timeout(100);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -381,7 +381,9 @@ export default async function loadCli() { // eslint-disable-line complexity
 
 	let globs;
 	try {
-		globs = normalizeGlobs({files: conf.files, ignoredByWatcher: conf.watchMode?.ignoreChanges, extensions, providers});
+		globs = normalizeGlobs({
+			files: conf.files, ignoredByWatcher: conf.watchMode?.ignoreChanges, extensions, providers,
+		});
 	} catch (error) {
 		exit(error.message);
 	}

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -11,9 +11,7 @@ function startChain(name, call, defaults) {
 }
 
 function extendChain(previous, name, flag) {
-	if (!flag) {
-		flag = name;
-	}
+	flag ||= name;
 
 	const fn = (...args) => {
 		callWithFlag(previous, flag, args);
@@ -89,7 +87,9 @@ export default function createChain(fn, defaults, meta) {
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.
 	root.todo = startChain('test.todo', fn, {...defaults, type: 'test', todo: true});
-	root.serial.todo = startChain('test.serial.todo', fn, {...defaults, serial: true, type: 'test', todo: true});
+	root.serial.todo = startChain('test.serial.todo', fn, {
+		...defaults, serial: true, type: 'test', todo: true,
+	});
 
 	root.macro = options => {
 		if (typeof options === 'function') {

--- a/lib/eslint-plugin-helper-worker.js
+++ b/lib/eslint-plugin-helper-worker.js
@@ -48,7 +48,9 @@ const resolveGlobs = async (projectDir, overrideExtensions, overrideFiles) => {
 	}
 
 	const {conf, providers} = await configCache.get(projectDir);
-	return buildGlobs({conf, providers, projectDir, overrideExtensions, overrideFiles});
+	return buildGlobs({
+		conf, providers, projectDir, overrideExtensions, overrideFiles,
+	});
 };
 
 const data = new Uint8Array(workerData.dataBuffer);

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -35,7 +35,7 @@ const loadConfigFile = async ({projectDir, configFile}) => {
 
 function resolveConfigFile(configFile) {
 	if (configFile) {
-		configFile = path.resolve(configFile); // Relative to CWD
+		return path.resolve(configFile); // Relative to CWD
 	}
 
 	return configFile;
@@ -153,7 +153,9 @@ export async function loadConfig({configFile, resolveFrom = process.cwd(), defau
 		}
 	}
 
-	const config = {...defaults, nonSemVerExperiments: {}, ...fileConf, ...packageConf, projectDir, configFile};
+	const config = {
+		...defaults, nonSemVerExperiments: {}, ...fileConf, ...packageConf, projectDir, configFile,
+	};
 
 	const {nonSemVerExperiments: experiments} = config;
 	if (!isPlainObject(experiments)) {

--- a/lib/plugin-support/shared-worker-loader.js
+++ b/lib/plugin-support/shared-worker-loader.js
@@ -238,7 +238,7 @@ try {
 		},
 	});
 } catch (error) {
-	fatal = fatal ?? error;
+	fatal ??= error;
 } finally {
 	if (fatal !== undefined) {
 		process.nextTick(() => {

--- a/lib/snapshot-manager.js
+++ b/lib/snapshot-manager.js
@@ -292,9 +292,7 @@ class Manager {
 	}
 
 	recordSerialized({data, label, belongsTo, index}) {
-		let block = this.newBlocksByTitle.get(belongsTo);
-		block ||= {snapshots: []};
-
+		const block = this.newBlocksByTitle.get(belongsTo) ?? {snapshots: []};
 		const {snapshots} = block;
 
 		if (index > snapshots.length) {
@@ -340,9 +338,7 @@ class Manager {
 
 	skipSnapshot({belongsTo, index, deferRecording}) {
 		const oldBlock = this.oldBlocksByTitle.get(belongsTo);
-		let snapshot = oldBlock?.snapshots[index];
-
-		snapshot ||= {};
+		const snapshot = oldBlock?.snapshots[index] ?? {};
 
 		// Retain the label from the old snapshot, so as not to assume that the
 		// snapshot.skip() arguments are well-formed.

--- a/lib/snapshot-manager.js
+++ b/lib/snapshot-manager.js
@@ -220,7 +220,9 @@ export function extractCompressedSnapshot(buffer, snapPath) {
 	const compressedOffset = sha256sumOffset + SHA_256_HASH_LENGTH;
 	const compressed = buffer.slice(compressedOffset);
 
-	return {version, compressed, sha256sumOffset, compressedOffset};
+	return {
+		version, compressed, sha256sumOffset, compressedOffset,
+	};
 }
 
 function decodeSnapshots(buffer, snapPath) {
@@ -291,9 +293,7 @@ class Manager {
 
 	recordSerialized({data, label, belongsTo, index}) {
 		let block = this.newBlocksByTitle.get(belongsTo);
-		if (!block) {
-			block = {snapshots: []};
-		}
+		block ||= {snapshots: []};
 
 		const {snapshots} = block;
 
@@ -319,7 +319,9 @@ class Manager {
 
 		return () => { // Must be called in order!
 			this.hasChanges = true;
-			this.recordSerialized({data, label, belongsTo, index});
+			this.recordSerialized({
+				data, label, belongsTo, index,
+			});
 		};
 	}
 
@@ -340,9 +342,7 @@ class Manager {
 		const oldBlock = this.oldBlocksByTitle.get(belongsTo);
 		let snapshot = oldBlock?.snapshots[index];
 
-		if (!snapshot) {
-			snapshot = {};
-		}
+		snapshot ||= {};
 
 		// Retain the label from the old snapshot, so as not to assume that the
 		// snapshot.skip() arguments are well-formed.

--- a/lib/test.js
+++ b/lib/test.js
@@ -2,7 +2,9 @@ import concordance from 'concordance';
 import isPromise from 'is-promise';
 import plur from 'plur';
 
-import {AssertionError, Assertions, checkAssertionMessage, getAssertionStack} from './assert.js';
+import {
+	AssertionError, Assertions, checkAssertionMessage, getAssertionStack,
+} from './assert.js';
 import concordanceOptions from './concordance-options.js';
 import nowAndTimers from './now-and-timers.cjs';
 import parseTestArgs from './parse-test-args.js';
@@ -277,7 +279,9 @@ export default class Test {
 
 			const {deferredSnapshotRecordings, error, logs, passed, assertCount, snapshotCount} = await attempt.run();
 			const errors = error ? [error] : [];
-			return {assertCount, deferredSnapshotRecordings, errors, logs, passed, snapshotCount, startingSnapshotCount};
+			return {
+				assertCount, deferredSnapshotRecordings, errors, logs, passed, snapshotCount, startingSnapshotCount,
+			};
 		};
 
 		this.assertCount = 0;

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -7,7 +7,9 @@ import {nodeFileTrace} from '@vercel/nft';
 import createDebug from 'debug';
 
 import {chalk} from './chalk.js';
-import {applyTestFileFilter, classify, buildIgnoreMatcher, findTests} from './globs.js';
+import {
+	applyTestFileFilter, classify, buildIgnoreMatcher, findTests,
+} from './globs.js';
 import {levels as providerLevels} from './provider-manager.js';
 
 const debug = createDebug('ava:watcher');
@@ -34,7 +36,9 @@ export function available(projectDir) {
 
 export async function start({api, filter, globs, projectDir, providers, reporter, stdin, signal}) {
 	providers = providers.filter(({level}) => level >= providerLevels.ava6);
-	for await (const {files, ...runtimeOptions} of plan({api, filter, globs, projectDir, providers, stdin, abortSignal: signal})) {
+	for await (const {files, ...runtimeOptions} of plan({
+		api, filter, globs, projectDir, providers, stdin, abortSignal: signal,
+	})) {
 		await api.run({files, filter, runtimeOptions});
 		reporter.endRun();
 		reporter.lineWriter.writeLine(END_MESSAGE);
@@ -62,7 +66,9 @@ async function * plan({api, filter, globs, projectDir, providers, stdin, abortSi
 	const changeFromPath = path => {
 		const {isTest} = classify(path, cwdAndGlobs);
 		const stats = fileStats(path);
-		return {path, isTest, exists: stats !== undefined, isFile: stats?.isFile() ?? false};
+		return {
+			path, isTest, exists: stats !== undefined, isFile: stats?.isFile() ?? false,
+		};
 	};
 
 	// Begin a file trace in the background.

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
 				"tempy": "^3.1.0",
 				"tsd": "^0.30.4",
 				"typescript": "~5.3.3",
-				"xo": "^0.56.0",
+				"xo": "^0.57.0",
 				"zen-observable": "^0.10.0"
 			},
 			"engines": {
@@ -2324,16 +2324,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.1.tgz",
-			"integrity": "sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.19.1",
-				"@typescript-eslint/type-utils": "6.19.1",
-				"@typescript-eslint/utils": "6.19.1",
-				"@typescript-eslint/visitor-keys": "6.19.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/type-utils": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -2359,15 +2359,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.1.tgz",
-			"integrity": "sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.19.1",
-				"@typescript-eslint/types": "6.19.1",
-				"@typescript-eslint/typescript-estree": "6.19.1",
-				"@typescript-eslint/visitor-keys": "6.19.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2387,13 +2387,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
-			"integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.19.1",
-				"@typescript-eslint/visitor-keys": "6.19.1"
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2404,13 +2404,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
-			"integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.19.1",
-				"@typescript-eslint/utils": "6.19.1",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2431,9 +2431,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
-			"integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2444,13 +2444,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
-			"integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.19.1",
-				"@typescript-eslint/visitor-keys": "6.19.1",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2525,17 +2525,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
-			"integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.19.1",
-				"@typescript-eslint/types": "6.19.1",
-				"@typescript-eslint/typescript-estree": "6.19.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2550,12 +2550,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.19.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
-			"integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/types": "6.21.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -3024,6 +3024,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/array.prototype.filter": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
+			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array.prototype.find": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.2.tgz",
@@ -3034,6 +3053,25 @@
 				"define-properties": "^1.2.0",
 				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.findlastindex": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz",
+			"integrity": "sha512-hzvSHUshSpCflDR1QMUBLHGHP1VIEBegT4pix9H/Z92Xw3ySoy6c2qh7lJWTJnRJ8JCZ9bJNCgTyYaJGcJu6xQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.3.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3219,7 +3257,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001580",
 				"electron-to-chromium": "^1.4.648",
@@ -3448,8 +3485,7 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			],
-			"peer": true
+			]
 		},
 		"node_modules/cbor": {
 			"version": "9.0.1",
@@ -3812,6 +3848,19 @@
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
+		"node_modules/core-js-compat": {
+			"version": "3.35.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
+			"integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
 		"node_modules/cosmiconfig": {
 			"version": "8.3.6",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -4106,8 +4155,7 @@
 			"version": "1.4.648",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.648.tgz",
 			"integrity": "sha512-EmFMarXeqJp9cUKu/QEciEApn0S/xRcpZWuAm32U7NgoZCimjsilKXHRO9saeEW55eHZagIDg6XTUOv32w9pjg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/emittery": {
 			"version": "1.0.1",
@@ -4249,6 +4297,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-array-method-boxes-properly": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+			"dev": true
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-module-lexer": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
@@ -4383,9 +4446,9 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-			"integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+			"integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
@@ -4395,39 +4458,39 @@
 			}
 		},
 		"node_modules/eslint-config-xo": {
-			"version": "0.43.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.43.1.tgz",
-			"integrity": "sha512-azv1L2PysRA0NkZOgbndUpN+581L7wPqkgJOgxxw3hxwXAbJgD6Hqb/SjHRiACifXt/AvxCzE/jIKFAlI7XjvQ==",
+			"version": "0.44.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.44.0.tgz",
+			"integrity": "sha512-YG4gdaor0mJJi8UBeRJqDPO42MedTWYMaUyucF5bhm2pi/HS98JIxfFQmTLuyj6hGpQlAazNfyVnn7JuDn+Sew==",
 			"dev": true,
 			"dependencies": {
 				"confusing-browser-globals": "1.0.11"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			},
 			"peerDependencies": {
-				"eslint": ">=8.27.0"
+				"eslint": ">=8.56.0"
 			}
 		},
 		"node_modules/eslint-config-xo-typescript": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-1.0.1.tgz",
-			"integrity": "sha512-vPQssnRSUgBFOEfB/KY12CXwltwFSn4RSCfa+w7gjBC2PFQ7Yfgmyei+1XUZ3K+8LRGef2NMJUcxts7PldhDjg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-2.0.0.tgz",
+			"integrity": "sha512-Z6LxmerEsGzLH4niSgfD/ZfqnCkOWZmE1XPnbU9gyYRQbHFZUkjstvi2prvGF9ToXkTDBiBZWvAWwNw9F2lFHg==",
 			"dev": true,
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": ">=6.0.0",
-				"@typescript-eslint/parser": ">=6.0.0",
-				"eslint": ">=8.0.0",
-				"typescript": ">=4.7"
+				"@typescript-eslint/eslint-plugin": ">=6.21.0",
+				"@typescript-eslint/parser": ">=6.21.0",
+				"eslint": ">=8.56.0",
+				"typescript": ">=5.0.0"
 			}
 		},
 		"node_modules/eslint-formatter-pretty": {
@@ -4771,26 +4834,28 @@
 			}
 		},
 		"node_modules/eslint-plugin-import": {
-			"version": "2.27.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+			"integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
 			"dev": true,
 			"dependencies": {
-				"array-includes": "^3.1.6",
-				"array.prototype.flat": "^1.3.1",
-				"array.prototype.flatmap": "^1.3.1",
+				"array-includes": "^3.1.7",
+				"array.prototype.findlastindex": "^1.2.3",
+				"array.prototype.flat": "^1.3.2",
+				"array.prototype.flatmap": "^1.3.2",
 				"debug": "^3.2.7",
 				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.7",
-				"eslint-module-utils": "^2.7.4",
-				"has": "^1.0.3",
-				"is-core-module": "^2.11.0",
+				"eslint-import-resolver-node": "^0.3.9",
+				"eslint-module-utils": "^2.8.0",
+				"hasown": "^2.0.0",
+				"is-core-module": "^2.13.1",
 				"is-glob": "^4.0.3",
 				"minimatch": "^3.1.2",
-				"object.values": "^1.1.6",
-				"resolve": "^1.22.1",
-				"semver": "^6.3.0",
-				"tsconfig-paths": "^3.14.1"
+				"object.fromentries": "^2.0.7",
+				"object.groupby": "^1.0.1",
+				"object.values": "^1.1.7",
+				"semver": "^6.3.1",
+				"tsconfig-paths": "^3.15.0"
 			},
 			"engines": {
 				"node": ">=4"
@@ -4818,23 +4883,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-			"dev": true,
-			"dependencies": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/semver": {
@@ -4907,20 +4955,21 @@
 			}
 		},
 		"node_modules/eslint-plugin-unicorn": {
-			"version": "48.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-48.0.1.tgz",
-			"integrity": "sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==",
+			"version": "51.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-51.0.1.tgz",
+			"integrity": "sha512-MuR/+9VuB0fydoI0nIn2RDA5WISRn4AsJyNSaNKLVwie9/ONvQhxOBbkfSICBPnzKrB77Fh6CZZXjgTt/4Latw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"ci-info": "^3.8.0",
+				"@eslint/eslintrc": "^2.1.4",
+				"ci-info": "^4.0.0",
 				"clean-regexp": "^1.0.0",
+				"core-js-compat": "^3.34.0",
 				"esquery": "^1.5.0",
 				"indent-string": "^4.0.0",
 				"is-builtin-module": "^3.2.1",
 				"jsesc": "^3.0.2",
-				"lodash": "^4.17.21",
 				"pluralize": "^8.0.0",
 				"read-pkg-up": "^7.0.1",
 				"regexp-tree": "^0.1.27",
@@ -4935,22 +4984,7 @@
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
 			},
 			"peerDependencies": {
-				"eslint": ">=8.44.0"
-			}
-		},
-		"node_modules/eslint-plugin-unicorn/node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"engines": {
-				"node": ">=8"
+				"eslint": ">=8.56.0"
 			}
 		},
 		"node_modules/eslint-plugin-unicorn/node_modules/indent-string": {
@@ -5382,16 +5416,16 @@
 			}
 		},
 		"node_modules/find-cache-dir": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
-			"integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-5.0.0.tgz",
+			"integrity": "sha512-OuWNfjfP05JcpAP3JPgAKUhWefjMRfI5iAoSsvE24ANYWJaepAtlSgWECSVEuRgSXpyNEc9DJwG/TZpgcOqyig==",
 			"dev": true,
 			"dependencies": {
 				"common-path-prefix": "^3.0.0",
 				"pkg-dir": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5957,15 +5991,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/has": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-			"integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4.0"
 			}
 		},
 		"node_modules/has-bigints": {
@@ -8387,8 +8412,7 @@
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/nofilter": {
 			"version": "3.1.0",
@@ -8618,6 +8642,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.fromentries": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
+			"integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.groupby": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.2.tgz",
+			"integrity": "sha512-bzBq58S+x+uo0VjurFT0UktpKHOZmv4/xePiOA1nbB9pMqpGK7rUPNgf+1YC+7mE+0HzhTMqNUuCqvKhj6FnBw==",
+			"dev": true,
+			"dependencies": {
+				"array.prototype.filter": "^1.0.3",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.0.0"
 			}
 		},
 		"node_modules/object.values": {
@@ -9077,8 +9131,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
 			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/picomatch": {
 			"version": "3.0.1",
@@ -9157,9 +9210,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-			"integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -10038,9 +10091,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -11058,12 +11111,12 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
 			"dev": true,
 			"engines": {
-				"node": ">=16.13.0"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
@@ -11448,7 +11501,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"escalade": "^3.1.1",
 				"picocolors": "^1.0.0"
@@ -12020,56 +12072,79 @@
 			}
 		},
 		"node_modules/xo": {
-			"version": "0.56.0",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.56.0.tgz",
-			"integrity": "sha512-ohzSqgQ8POgZ3KNaEK/gxDovb6h3cglxv8+xi9Dn7gmRe8g4qotpOZpMs5ACJhvkJDmJOhiKbk6Uq6Mx1Di9DA==",
+			"version": "0.57.0",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.57.0.tgz",
+			"integrity": "sha512-QTdiZMYtRZZlhlzJI7MVBsW43EYizm2KbXqvw6GRS1oYgHTF3Lq7Z2BK9sjrn+E/wqRVYOC99pOxXlaXuFr/2w==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^2.1.0",
-				"@typescript-eslint/eslint-plugin": "^6.0.0",
-				"@typescript-eslint/parser": "^6.0.0",
+				"@eslint/eslintrc": "^3.0.0",
+				"@typescript-eslint/eslint-plugin": "^6.21.0",
+				"@typescript-eslint/parser": "^6.21.0",
 				"arrify": "^3.0.0",
-				"cosmiconfig": "^8.2.0",
+				"cosmiconfig": "^8.3.6",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^8.45.0",
-				"eslint-config-prettier": "^8.8.0",
-				"eslint-config-xo": "^0.43.1",
-				"eslint-config-xo-typescript": "^1.0.0",
-				"eslint-formatter-pretty": "^5.0.0",
-				"eslint-import-resolver-webpack": "^0.13.2",
+				"eslint": "^8.53.0",
+				"eslint-config-prettier": "^9.1.0",
+				"eslint-config-xo": "^0.44.0",
+				"eslint-config-xo-typescript": "^2.0.0",
+				"eslint-formatter-pretty": "^6.0.1",
+				"eslint-import-resolver-webpack": "^0.13.8",
 				"eslint-plugin-ava": "^14.0.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
-				"eslint-plugin-import": "~2.27.5",
-				"eslint-plugin-n": "^16.0.1",
+				"eslint-plugin-import": "^2.29.1",
+				"eslint-plugin-n": "^16.6.2",
 				"eslint-plugin-no-use-extend-native": "^0.5.0",
-				"eslint-plugin-prettier": "^5.0.0",
-				"eslint-plugin-unicorn": "^48.0.0",
-				"esm-utils": "^4.1.2",
-				"find-cache-dir": "^4.0.0",
-				"find-up": "^6.3.0",
+				"eslint-plugin-prettier": "^5.1.3",
+				"eslint-plugin-unicorn": "^51.0.0",
+				"esm-utils": "^4.2.1",
+				"find-cache-dir": "^5.0.0",
+				"find-up-simple": "^1.0.0",
 				"get-stdin": "^9.0.0",
-				"get-tsconfig": "^4.6.2",
-				"globby": "^13.2.2",
+				"get-tsconfig": "^4.7.2",
+				"globby": "^14.0.0",
 				"imurmurhash": "^0.1.4",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash-es": "^4.17.21",
-				"meow": "^12.0.1",
+				"meow": "^13.1.0",
 				"micromatch": "^4.0.5",
-				"open-editor": "^4.0.0",
-				"prettier": "^3.0.0",
-				"semver": "^7.5.4",
+				"open-editor": "^4.1.1",
+				"prettier": "^3.2.5",
+				"semver": "^7.6.0",
 				"slash": "^5.1.0",
 				"to-absolute-glob": "^3.0.0",
-				"typescript": "^5.1.6"
+				"typescript": "^5.3.3"
 			},
 			"bin": {
 				"xo": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/xo/node_modules/@eslint/eslintrc": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.0.1.tgz",
+			"integrity": "sha512-xXm39r1RgOSmPCqlhn+E10KPJ7JKrpuBwsAVw/++5dS/Sa4GAi0smby0r0wfTN4gNpkk9iij2hssJMXHSmQ89w==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^10.0.1",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/xo/node_modules/@types/eslint": {
@@ -12082,102 +12157,29 @@
 				"@types/json-schema": "*"
 			}
 		},
-		"node_modules/xo/node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/xo/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/xo/node_modules/color-convert": {
+		"node_modules/xo/node_modules/argparse": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/xo/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
 		"node_modules/xo/node_modules/eslint-formatter-pretty": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-5.0.0.tgz",
-			"integrity": "sha512-Uick451FoL22/wXqyScX3inW8ZlD/GQO7eFXj3bqb6N/ZtuuF00/CwSNIKLbFCJPrX5V4EdQBSgJ/UVnmLRnug==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-6.0.1.tgz",
+			"integrity": "sha512-znAUcXmBthdIUmlnRkPSxz3zSJHFUhfHF/nJPcCMVKg/mOa4yUie2Olqg1Ghbi5JJRBZVU3rIgzWSObvIspxMA==",
 			"dev": true,
 			"dependencies": {
-				"@types/eslint": "^8.0.0",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.1.0",
+				"@types/eslint": "^8.44.6",
+				"ansi-escapes": "^6.2.0",
+				"chalk": "^5.3.0",
 				"eslint-rule-docs": "^1.1.235",
-				"log-symbols": "^4.0.0",
-				"plur": "^4.0.0",
-				"string-width": "^4.2.0",
-				"supports-hyperlinks": "^2.0.0"
+				"log-symbols": "^6.0.0",
+				"plur": "^5.1.0",
+				"string-width": "^7.0.0",
+				"supports-hyperlinks": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -12213,45 +12215,39 @@
 				}
 			}
 		},
-		"node_modules/xo/node_modules/find-up": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^7.1.0",
-				"path-exists": "^5.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/globby": {
-			"version": "13.2.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-			"dev": true,
-			"dependencies": {
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.3.0",
-				"ignore": "^5.2.4",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/globby/node_modules/slash": {
+		"node_modules/xo/node_modules/eslint-visitor-keys": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/xo/node_modules/espree": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+			"integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.3",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/xo/node_modules/is-unicode-supported": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -12260,144 +12256,57 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/locate-path": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+		"node_modules/xo/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
 			"dependencies": {
-				"p-locate": "^6.0.0"
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/xo/node_modules/log-symbols": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+			"integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"is-unicode-supported": "^1.3.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xo/node_modules/meow": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
 			"dev": true,
 			"engines": {
-				"node": ">=16.10"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/p-limit": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+		"node_modules/xo/node_modules/supports-hyperlinks": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+			"integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
 			"dev": true,
 			"dependencies": {
-				"yocto-queue": "^1.0.0"
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/p-locate": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/path-exists": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-			"integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/plur": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
-			"integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
-			"dev": true,
-			"dependencies": {
-				"irregular-plurals": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/yocto-queue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=14.18"
 			}
 		},
 		"node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"tempy": "^3.1.0",
 		"tsd": "^0.30.4",
 		"typescript": "~5.3.3",
-		"xo": "^0.56.0",
+		"xo": "^0.57.0",
 		"zen-observable": "^0.10.0"
 	},
 	"peerDependencies": {

--- a/test-tap/api.js
+++ b/test-tap/api.js
@@ -12,12 +12,14 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const ROOT_DIR = path.join(__dirname, '..');
 
 async function apiCreator(options = {}) {
-	options.projectDir = options.projectDir ?? ROOT_DIR;
+	options.projectDir ??= ROOT_DIR;
 	options.chalkOptions = {level: 0};
 	options.concurrency = 2;
-	options.extensions = options.extensions ?? ['cjs'];
+	options.extensions ??= ['cjs'];
 	options.experiments = {};
-	options.globs = normalizeGlobs({files: options.files, ignoredByWatcher: options.watchMode?.ignoreChanges, extensions: options.extensions, providers: []});
+	options.globs = normalizeGlobs({
+		files: options.files, ignoredByWatcher: options.watchMode?.ignoreChanges, extensions: options.extensions, providers: [],
+	});
 	const instance = new Api(options);
 
 	return instance;
@@ -97,10 +99,12 @@ for (const opt of options) {
 			});
 		});
 
-		return api.run({files: [
-			path.join(__dirname, 'fixture/fail-fast/multiple-files/fails.cjs'),
-			path.join(__dirname, 'fixture/fail-fast/multiple-files/passes.cjs'),
-		]})
+		return api.run({
+			files: [
+				path.join(__dirname, 'fixture/fail-fast/multiple-files/fails.cjs'),
+				path.join(__dirname, 'fixture/fail-fast/multiple-files/passes.cjs'),
+			],
+		})
 			.then(runStatus => {
 				t.ok(api.options.failFast);
 				t.strictSame(tests, [{
@@ -214,10 +218,12 @@ for (const opt of options) {
 			});
 		});
 
-		return api.run({files: [
-			path.join(__dirname, 'fixture/fail-fast/crash/crashes.cjs'),
-			path.join(__dirname, 'fixture/fail-fast/crash/passes.cjs'),
-		]})
+		return api.run({
+			files: [
+				path.join(__dirname, 'fixture/fail-fast/crash/crashes.cjs'),
+				path.join(__dirname, 'fixture/fail-fast/crash/passes.cjs'),
+			],
+		})
 			.then(runStatus => {
 				t.ok(api.options.failFast);
 				t.strictSame(tests, []);
@@ -270,11 +276,13 @@ for (const opt of options) {
 			});
 		});
 
-		return api.run({files: [
-			path.join(__dirname, 'fixture/fail-fast/timeout/fails.cjs'),
-			path.join(__dirname, 'fixture/fail-fast/timeout/passes.cjs'),
-			path.join(__dirname, 'fixture/fail-fast/timeout/passes-slow.cjs'),
-		]})
+		return api.run({
+			files: [
+				path.join(__dirname, 'fixture/fail-fast/timeout/fails.cjs'),
+				path.join(__dirname, 'fixture/fail-fast/timeout/passes.cjs'),
+				path.join(__dirname, 'fixture/fail-fast/timeout/passes-slow.cjs'),
+			],
+		})
 			.then(runStatus => {
 				t.ok(api.options.failFast);
 				t.strictSame(tests, []);
@@ -290,10 +298,12 @@ for (const opt of options) {
 			failFast: true,
 		});
 
-		return api.run({files: [
-			path.join(__dirname, 'fixture/fail-fast/without-error/a.cjs'),
-			path.join(__dirname, 'fixture/fail-fast/without-error/b.cjs'),
-		]})
+		return api.run({
+			files: [
+				path.join(__dirname, 'fixture/fail-fast/without-error/a.cjs'),
+				path.join(__dirname, 'fixture/fail-fast/without-error/b.cjs'),
+			],
+		})
 			.then(runStatus => {
 				t.ok(api.options.failFast);
 				t.equal(runStatus.stats.passedTests, 2);
@@ -423,11 +433,13 @@ for (const opt of options) {
 
 		const api = await apiCreator(opt);
 
-		return api.run({files: [
-			path.join(__dirname, 'fixture/test-count.cjs'),
-			path.join(__dirname, 'fixture/test-count-2.cjs'),
-			path.join(__dirname, 'fixture/test-count-3.cjs'),
-		]}).then(runStatus => {
+		return api.run({
+			files: [
+				path.join(__dirname, 'fixture/test-count.cjs'),
+				path.join(__dirname, 'fixture/test-count-2.cjs'),
+				path.join(__dirname, 'fixture/test-count-3.cjs'),
+			],
+		}).then(runStatus => {
 			t.equal(runStatus.stats.passedTests, 4, 'pass count');
 			t.equal(runStatus.stats.failedTests, 3, 'fail count');
 			t.equal(runStatus.stats.skippedTests, 3, 'skip count');
@@ -452,11 +464,13 @@ for (const opt of options) {
 			});
 		});
 
-		return api.run({files: [
-			path.join(__dirname, 'fixture/match-no-match.cjs'),
-			path.join(__dirname, 'fixture/match-no-match-2.cjs'),
-			path.join(__dirname, 'fixture/test-count.cjs'),
-		]}).then(runStatus => {
+		return api.run({
+			files: [
+				path.join(__dirname, 'fixture/match-no-match.cjs'),
+				path.join(__dirname, 'fixture/match-no-match-2.cjs'),
+				path.join(__dirname, 'fixture/test-count.cjs'),
+			],
+		}).then(runStatus => {
 			t.equal(runStatus.stats.passedTests, 1);
 		});
 	});

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -538,13 +538,21 @@ test('.deepEqual()', t => {
 			{foo: {z: 100, y: 200, x: 300}},
 			'bar',
 			11,
-			{baz: {d: 4, a: 1, b: 2, c: 3}},
+			{
+				baz: {
+					d: 4, a: 1, b: 2, c: 3,
+				},
+			},
 		],
 		[
 			{foo: {x: 300, y: 200, z: 100}},
 			'bar',
 			11,
-			{baz: {c: 3, b: 2, a: 1, d: 4}},
+			{
+				baz: {
+					c: 3, b: 2, a: 1, d: 4,
+				},
+			},
 		],
 	));
 
@@ -778,7 +786,9 @@ test('.like()', t => {
 
 	passes(t, () => {
 		const array = ['c1', 'c2'];
-		return assertions.like({a: 'a', b: 'b', c: ['c1', 'c2'], d: ['c1', 'c2']}, {b: 'b', d: array, c: array});
+		return assertions.like({
+			a: 'a', b: 'b', c: ['c1', 'c2'], d: ['c1', 'c2'],
+		}, {b: 'b', d: array, c: array});
 	});
 
 	failsWith(t, () => {
@@ -1227,7 +1237,9 @@ test('.throws() fails if passed a bad expectation', t => {
 		formattedDetails: [{label: 'Called with:', formatted: /name: null/}],
 	});
 
-	failsWith(t, () => assertions.throws(() => {}, {is: {}, message: '', name: '', of() {}, foo: null}), {
+	failsWith(t, () => assertions.throws(() => {}, {
+		is: {}, message: '', name: '', of() {}, foo: null,
+	}), {
 		assertion: 't.throws()',
 		message: 'The second argument to `t.throws()` contains unexpected properties',
 		formattedDetails: [{label: 'Called with:', formatted: /foo: null/}],
@@ -1303,7 +1315,9 @@ test('.throwsAsync() fails if passed a bad expectation', async t => {
 		formattedDetails: [{label: 'Called with:', formatted: /name: null/}],
 	});
 
-	await failsWithAsync(t, () => assertions.throwsAsync(() => {}, {is: {}, message: '', name: '', of() {}, foo: null}), {
+	await failsWithAsync(t, () => assertions.throwsAsync(() => {}, {
+		is: {}, message: '', name: '', of() {}, foo: null,
+	}), {
 		assertion: 't.throwsAsync()',
 		message: 'The second argument to `t.throwsAsync()` contains unexpected properties',
 		formattedDetails: [{label: 'Called with:', formatted: /foo: null/}],

--- a/test-tap/code-excerpt.js
+++ b/test-tap/code-excerpt.js
@@ -16,7 +16,9 @@ test('read code excerpt', t => {
 	alert();
 }`));
 
-	const excerpt = codeExcerpt({file, line: 2, isWithinProject: true, isDependency: false});
+	const excerpt = codeExcerpt({
+		file, line: 2, isWithinProject: true, isDependency: false,
+	});
 	const expected = [
 		` ${chalk.grey('1:')} function a() {`,
 		chalk.bgRed.bold(' 2:   alert();    '),
@@ -32,7 +34,9 @@ test('truncate lines', t => {
 	alert();
 }`));
 
-	const excerpt = codeExcerpt({file, line: 2, isWithinProject: true, isDependency: false}, {maxWidth: 14});
+	const excerpt = codeExcerpt({
+		file, line: 2, isWithinProject: true, isDependency: false,
+	}, {maxWidth: 14});
 	const expected = [
 		` ${chalk.grey('1:')} functio…`,
 		chalk.bgRed.bold(' 2:   alert…'),
@@ -56,7 +60,9 @@ function a() {
 	alert();
 }`));
 
-	const excerpt = codeExcerpt({file, line: 10, isWithinProject: true, isDependency: false});
+	const excerpt = codeExcerpt({
+		file, line: 10, isWithinProject: true, isDependency: false,
+	});
 	const expected = [
 		` ${chalk.grey(' 9:')} function a() {`,
 		chalk.bgRed.bold(' 10:   alert();    '),
@@ -69,7 +75,9 @@ function a() {
 
 test('noop if file cannot be read', t => {
 	const file = pathToFileURL(temporaryFile());
-	const excerpt = codeExcerpt({file, line: 10, isWithinProject: true, isDependency: false});
+	const excerpt = codeExcerpt({
+		file, line: 10, isWithinProject: true, isDependency: false,
+	});
 	t.equal(excerpt, null);
 	t.end();
 });
@@ -81,7 +89,9 @@ test('noop if file is not within project', t => {
 });
 
 test('noop if file is a dependency', t => {
-	const excerpt = codeExcerpt({isWithinProject: true, isDependency: true, file: import.meta.url, line: 1});
+	const excerpt = codeExcerpt({
+		isWithinProject: true, isDependency: true, file: import.meta.url, line: 1,
+	});
 	t.equal(excerpt, null);
 	t.end();
 });

--- a/test-tap/reporters/tap.regular.v18.log
+++ b/test-tap/reporters/tap.regular.v18.log
@@ -113,7 +113,7 @@ not ok 12 - test › no longer failing
     message: >-
       Test was expected to fail, but succeeded, you should stop marking the test as
       failing
-    at: 'Test.finish (/lib/test.js:629:28)'
+    at: 'Test.finish (/lib/test.js:633:28)'
   ...
 ---tty-stream-chunk-separator
 not ok 13 - test › logs
@@ -144,7 +144,7 @@ not ok 15 - test › implementation throws non-error
     details:
       'Error thrown in test:': 'null'
     message: Error thrown in test
-    at: 'Test.run (/lib/test.js:542:25)'
+    at: 'Test.run (/lib/test.js:546:25)'
   ...
 ---tty-stream-chunk-separator
 not ok 16 - traces-in-t-throws › throws

--- a/test-tap/reporters/tap.regular.v20.log
+++ b/test-tap/reporters/tap.regular.v20.log
@@ -113,7 +113,7 @@ not ok 12 - test › no longer failing
     message: >-
       Test was expected to fail, but succeeded, you should stop marking the test as
       failing
-    at: 'Test.finish (/lib/test.js:629:28)'
+    at: 'Test.finish (/lib/test.js:633:28)'
   ...
 ---tty-stream-chunk-separator
 not ok 13 - test › logs
@@ -144,7 +144,7 @@ not ok 15 - test › implementation throws non-error
     details:
       'Error thrown in test:': 'null'
     message: Error thrown in test
-    at: 'Test.run (/lib/test.js:542:25)'
+    at: 'Test.run (/lib/test.js:546:25)'
   ...
 ---tty-stream-chunk-separator
 not ok 16 - traces-in-t-throws › throws

--- a/test-tap/reporters/tap.regular.v21.log
+++ b/test-tap/reporters/tap.regular.v21.log
@@ -113,7 +113,7 @@ not ok 12 - test › no longer failing
     message: >-
       Test was expected to fail, but succeeded, you should stop marking the test as
       failing
-    at: 'Test.finish (/lib/test.js:629:28)'
+    at: 'Test.finish (/lib/test.js:633:28)'
   ...
 ---tty-stream-chunk-separator
 not ok 13 - test › logs
@@ -144,7 +144,7 @@ not ok 15 - test › implementation throws non-error
     details:
       'Error thrown in test:': 'null'
     message: Error thrown in test
-    at: 'Test.run (/lib/test.js:542:25)'
+    at: 'Test.run (/lib/test.js:546:25)'
   ...
 ---tty-stream-chunk-separator
 not ok 16 - traces-in-t-throws › throws

--- a/test/helpers/exec.js
+++ b/test/helpers/exec.js
@@ -65,7 +65,9 @@ const initState = () => {
 		},
 	};
 
-	return {errors, logs, stats, stdout: '', stderr: ''};
+	return {
+		errors, logs, stats, stdout: '', stderr: '',
+	};
 };
 
 const sortStats = stats => {
@@ -121,7 +123,9 @@ export async function * exec(args, options) {
 		const item = await Promise.race([done, statusEvents.next()]); // eslint-disable-line no-await-in-loop
 		if (item.execa) {
 			sortStats(stats);
-			yield {process: execaProcess, stats, stdout, stderr, runCount};
+			yield {
+				process: execaProcess, stats, stdout, stderr, runCount,
+			};
 			break;
 		}
 
@@ -134,7 +138,9 @@ export async function * exec(args, options) {
 			case 'end': {
 				sortStats(stats);
 				runCount++;
-				yield {process: execaProcess, stats, stdout, stderr, runCount};
+				yield {
+					process: execaProcess, stats, stdout, stderr, runCount,
+				};
 				({errors, logs, stats, stdout, stderr} = initState());
 				break;
 			}


### PR DESCRIPTION
Disabled `unicorn/prevent-abbreviations` because it introduces too many opinionated changes.