### PR TITLE
docs: add `serial` to config options

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -51,6 +51,7 @@ Arguments passed to the CLI will always take precedence over the CLI options con
 - `failFast`: stop running further tests once a test fails
 - `failWithoutAssertions`: if `false`, does not fail a test if it doesn't run [assertions](./03-assertions.md)
 - `environmentVariables`: specifies environment variables to be made available to the tests. The environment variables defined here override the ones from `process.env`
+- `serial`: if `true`, prevents parallel execution of tests within a file
 - `tap`: if `true`, enables the [TAP reporter](./05-command-line.md#tap-reporter)
 - `verbose`: if `true`, enables verbose output (though there currently non-verbose output is not supported)
 - `snapshotDir`: specifies a fixed location for storing snapshot files. Use this if your snapshots are ending up in the wrong location


### PR DESCRIPTION
all CLI options can be overridden but this one was omitted https://github.com/avajs/ava/blob/01ec2804ab9db0ab3ef11e3b5b0c5697d68f8bc5/lib/cli.js#L58-L63

I confirmed in code that it is observed
https://github.com/avajs/ava/blob/01ec2804ab9db0ab3ef11e3b5b0c5697d68f8bc5/lib/cli.js#L438

It wasn't clear to me what order to use so I put it before `tap` as it is in `cli.js`.

I'd suggest partitioning the options list into ones that are available in CLI and aren't, but I didn't know if that would be welcomed