### PR TITLE
Address error in tap reporter when originalError is undefined

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -24,7 +24,9 @@ function dumpError({
 		};
 	}
 
-	originalError.name = name; // Restore the original name.
+	if (originalError) {
+		originalError.name = name; // Restore the original name.
+	}
 
 	if (type === 'ava') {
 		if (assertion) {


### PR DESCRIPTION
This is a follow up from the discussion in https://github.com/avajs/ava/discussions/3322. The tap reporter was failing when ava timed out because of https://github.com/avajs/ava/blob/01ec2804ab9db0ab3ef11e3b5b0c5697d68f8bc5/lib/reporters/tap.js#L27
being undefined.

The suggestion was to use optional chaining on the left side of the assignment, but I ran into the tests failing, so I wrapped the assignment in an if condition. 