### PR TITLE
Adds '--clear-screen' option to clear screen between watch runs

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -91,6 +91,12 @@ const FLAGS = {
 		description: 'Re-run tests when files change',
 		type: 'boolean',
 	},
+	'clear-screen': {
+		alias: 'C',
+		coerce: coerceLastValue,
+		description: 'Clears the screen before every test run',
+		type: 'boolean',
+	},
 };
 
 export default async function loadCli() { // eslint-disable-line complexity
@@ -465,6 +471,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 			reportStream: process.stdout,
 			stdStream: process.stderr,
 			watching: argv.watch,
+			clearScreen: argv['clear-screen'],
 		});
 	}
 

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -3,6 +3,7 @@ import path from 'node:path';
 import stream from 'node:stream';
 import {fileURLToPath} from 'node:url';
 
+import ansiEscapes from 'ansi-escapes';
 import figures from 'figures';
 import indentString from 'indent-string';
 import plur from 'plur';
@@ -73,12 +74,14 @@ export default class Reporter {
 		stdStream,
 		projectDir,
 		watching,
+		clearScreen,
 		durationThreshold,
 	}) {
 		this.extensions = extensions;
 		this.reportStream = reportStream;
 		this.stdStream = stdStream;
 		this.watching = watching;
+		this.clearScreen = clearScreen;
 		this.relativeFile = file => {
 			if (file.startsWith('file://')) {
 				file = fileURLToPath(file);
@@ -128,6 +131,10 @@ export default class Reporter {
 	}
 
 	startRun(plan) {
+		if (this.clearScreen) {
+			this.lineWriter.write(ansiEscapes.clearTerminal);
+		}
+
 		if (plan.bailWithoutReporting) {
 			return;
 		}


### PR DESCRIPTION
This is very slapped together, but I wanted it for myself and figured I'd start the conversation. If you are even open to mergin it let me know of any changes.

###### Usage:
```
npm test ava --watch --clear-scren 
```

###### What does this PR change?
Between test runs, it sends `this.lineWriter.write(ansiEscapes.clearTerminal)`, which clears the screen and scrollback buffer on all the terminal apps _I_ have handy.

I [promoted this same behaviour in TypeScript](https://github.com/microsoft/TypeScript/pull/57701), I guess it's my hill to die on 🤣 (in that case, `--watch` was already clearing the screen, this just changed/improved the behaviour).

Jest also clears the screen when using `--watch`. I prefer it, FWIW, but I've read the argument for keeping all those logs... I'm not convinced, but hey that's just me. I'd be happy w/ `--clear-screen` though it isn't exactly very discoverable atm.

WDYT?