### PR TITLE
Enable to type `t.context` by extending module interface

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -151,6 +151,20 @@ test('an actual test', t => {
 });
 ```
 
+Alternatively, you can extend the type globally:
+
+```ts
+declare module 'ava' {
+    interface AvaContext {
+        foo: string;
+    }
+}
+
+test.beforeEach(t => {
+	t.context = {foo: 'bar'};
+});
+```
+
 Note that, despite the type cast above, when executing `t.context` is an empty object unless it's assigned.
 
 ## Typing `throws` assertions

--- a/types/test-fn.d.cts
+++ b/types/test-fn.d.cts
@@ -72,7 +72,9 @@ export type Macro<Args extends unknown[], Context = unknown> = {
 /** A test or hook implementation. */
 export type Implementation<Args extends unknown[], Context = unknown> = ImplementationFn<Args, Context> | Macro<Args, Context>;
 
-export type TestFn<Context = unknown> = {
+interface AvaContext {}
+
+export type TestFn<Context = AvaContext> = {
 	/** Declare a concurrent test. Additional arguments are passed to the implementation or macro. */
 	<Args extends unknown[]>(title: string, implementation: Implementation<Args, Context>, ...args: Args): void;
 


### PR DESCRIPTION
Thank you for the great tool.

## Summary

This Pull Request introduces a new **AvaContext** interface that can be augmented by library users. By allowing developers to declare custom fields in their test context, this change provides greater flexibility and type safety when writing tests in TypeScript.

## Details of Changes

- Added AvaContext Interface
   - Introduced a new `AvaContext` interface
   - Updated `TestFn` to default its generic `Context` to `AvaContext`
- Updated corresponding docs

Library users can now directly extend the `AvaContext` interface to add custom properties in tests, which could be impressive when using shared context:

```ts
declare module 'ava' {
  interface AvaContext {
    foo: string;
  }
}
````

## Difference between `TestFn`

There is already a guide to type `t.context`:

```ts
const test = anyTest as TestFn<{foo: string}>;
```

This PR provides another method to type the context without creating a new variable, which make users ease to use context values.