### PR TITLE
Keep test worker alive until explicitly freed

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -104,6 +104,11 @@ export default function loadFork(file, options, execArgv = process.execArgv) {
 			}
 
 			switch (message.ava.type) {
+				case 'worker-finished': {
+					send({type: 'worker-should-exit'});
+					break;
+				}
+
 				case 'ready-for-options': {
 					send({type: 'options', options});
 					break;

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -105,7 +105,7 @@ export default function loadFork(file, options, execArgv = process.execArgv) {
 
 			switch (message.ava.type) {
 				case 'worker-finished': {
-					send({type: 'worker-should-exit'});
+					send({type: 'free-worker'});
 					break;
 				}
 

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -122,11 +122,11 @@ const run = async options => {
 
 		channel.send({type: 'worker-finished'});
 
-		// As the channel has already been unreferenced
-		// we need to reference it again to wait for the worker-should-exit message.
-		// Otherwise the process may exit prematurely, especially on Windows.
+		// Reference the channel until the worker is freed. This should prevent Node.js from terminating the child process
+		// prematurely, which has been witnessed on Windows. See discussion at
+		// <https://github.com/avajs/ava/issues/3390#issuecomment-3056119361>.
 		channel.ref();
-		await channel.workerShouldExit;
+		await channel.workerFreed;
 		channel.unref();
 
 		nowAndTimers.setImmediate(() => {

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -120,6 +120,15 @@ const run = async options => {
 			return;
 		}
 
+		channel.send({type: 'worker-finished'});
+
+		// As the channel has already been unreferenced
+		// we need to reference it again to wait for the worker-should-exit message.
+		// Otherwise the process may exit prematurely, especially on Windows.
+		channel.ref();
+		await channel.workerShouldExit;
+		channel.unref();
+
 		nowAndTimers.setImmediate(() => {
 			const unhandled = currentlyUnhandled();
 			if (unhandled.length === 0) {

--- a/lib/worker/channel.cjs
+++ b/lib/worker/channel.cjs
@@ -107,7 +107,9 @@ handle.ref();
 
 exports.options = selectAvaMessage(handle.channel, 'options').then(message => message.ava.options);
 exports.peerFailed = selectAvaMessage(handle.channel, 'peer-failed');
+exports.workerShouldExit = selectAvaMessage(handle.channel, 'worker-should-exit');
 exports.send = handle.send.bind(handle);
+exports.ref = handle.ref.bind(handle);
 exports.unref = handle.unref.bind(handle);
 
 let channelCounter = 0;

--- a/lib/worker/channel.cjs
+++ b/lib/worker/channel.cjs
@@ -107,7 +107,7 @@ handle.ref();
 
 exports.options = selectAvaMessage(handle.channel, 'options').then(message => message.ava.options);
 exports.peerFailed = selectAvaMessage(handle.channel, 'peer-failed');
-exports.workerShouldExit = selectAvaMessage(handle.channel, 'worker-should-exit');
+exports.workerFreed = selectAvaMessage(handle.channel, 'free-worker');
 exports.send = handle.send.bind(handle);
 exports.ref = handle.ref.bind(handle);
 exports.unref = handle.unref.bind(handle);

--- a/test/child-process/fixtures/package.json
+++ b/test/child-process/fixtures/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "module"
+}

--- a/test/child-process/fixtures/test.js
+++ b/test/child-process/fixtures/test.js
@@ -1,0 +1,7 @@
+import test from 'ava';
+
+for (let i = 0; i < 50; i++) {
+	test('Test ' + (i + 1), t => {
+		t.true(true);
+	});
+}

--- a/test/child-process/test.js
+++ b/test/child-process/test.js
@@ -1,0 +1,9 @@
+import test from '@ava/test';
+
+import {fixture} from '../helpers/exec.js';
+
+// Regression test for https://github.com/avajs/ava/issues/3390
+test('running 50 tests in a child process works as expected', async t => {
+	const result = await fixture(['--no-worker-threads']);
+	t.is(result.stats.passed.length, 50);
+});


### PR DESCRIPTION
This change ensures that all messages from the worker are received by the main process before the worker exits.

It solves issues on Windows that are occurring with Node.js v20 and later when `workerThreads: false` is set in the AVA configuration.

Fixes: https://github.com/avajs/ava/issues/3390