### PR TITLE
Watch mode refinements

### DIFF
--- a/docs/recipes/watch-mode.md
+++ b/docs/recipes/watch-mode.md
@@ -20,7 +20,7 @@ AVA uses `fs.watch()`. Support for `recursive` mode is required. Note that this 
 
 ## Ignoring changes
 
-By default AVA watches for changes to all files, except for those with a `.snap.md` extension, `ava.config.*` and files in [certain directories](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) as provided by the [`ignore-by-default`] package.
+By default AVA watches for changes to all files, except for those with `.snap.md` or `.tsbuildinfo` extensions, `ava.config.*` and files in [certain directories](https://github.com/novemberborn/ignore-by-default/blob/master/index.js) as provided by the [`ignore-by-default`] package.
 
 You can configure additional patterns for files to ignore in the [`ava` section of your `package.json`, or `ava.config.*` file][config], using the `ignoreChanges` key within the `watchMode` object:
 

--- a/lib/globs.js
+++ b/lib/globs.js
@@ -25,6 +25,7 @@ export {
 
 const defaultIgnoredByWatcherPatterns = [
 	'**/*.snap.md', // No need to rerun tests when the Markdown files change.
+	'**/*.tsbuildinfo', // No need to rerun tests when TypeScript build info files change.
 	'ava.config.js', // Config is not reloaded so avoid rerunning tests when it changes.
 	'ava.config.cjs', // Config is not reloaded so avoid rerunning tests when it changes.
 	'ava.config.mjs', // Config is not reloaded so avoid rerunning tests when it changes.

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -258,8 +258,11 @@ async function * plan({
 				case 'uncaught-exception':
 				case 'unhandled-rejection':
 				case 'worker-failed': {
-					const path = nodePath.relative(projectDir, evt.testFile);
-					failureCounts.set(path, 1 + (failureCounts.get(path) ?? 0));
+					if (evt.testFile) {
+						const path = nodePath.relative(projectDir, evt.testFile);
+						failureCounts.set(path, 1 + (failureCounts.get(path) ?? 0));
+					}
+
 					break;
 				}
 

--- a/test/watch-mode/helpers/watch.js
+++ b/test/watch-mode/helpers/watch.js
@@ -32,7 +32,7 @@ export const withFixture = fixture => async (t, task) => {
 	let completedTask = false;
 	try {
 		await temporaryDirectoryTask(async dir => {
-			await fs.cp(cwd(fixture), dir, {recursive: true});
+			await fs.cp(cwd(fixture), dir, {recursive: true, filter: src => !src.includes('/node_modules/')});
 
 			async function * run(args = [], options = {}) {
 				yield * exec(['--watch', ...args], {...options, cwd: dir, env: {AVA_FORCE_CI: 'not-ci', ...options.env}});


### PR DESCRIPTION
- Ignore changes to `*.tsbuildinfo` files
- Don't track failures when the event did not originate from a test file
- Exclude any `node_modules` directories when preparing fixtures
