### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     paths-ignore:
       - "*.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - "media/**"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 jobs:
   nodejs:
     name: Node.js


### PR DESCRIPTION
- Don't run CI for tags. The new release workflow requires tests to pass before creating the tagged version commit; there's no need to test that commit.
- Cancel in-progress runs. We need the last run to pass in order to release, no sense waiting for older commits.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#982: An error occurred while trying to read the map file](https://oss.issuehunt.io/repos/26820798/issues/982)
- [#936: Ensure watch mode works when AVA is called outside the package root](https://oss.issuehunt.io/repos/26820798/issues/936)
- [#698: Report bad test() usage as a test failure, rather than a runtime error](https://oss.issuehunt.io/repos/26820798/issues/698)
- [#1997: Timeouts shouldn't hide assertion failures](https://oss.issuehunt.io/repos/26820798/issues/1997)
- [#2070: Feature request: pass test additional arguments to beforeEach function](https://oss.issuehunt.io/repos/26820798/issues/2070)
- [#1980: Wrong line number shown for failing assert](https://oss.issuehunt.io/repos/26820798/issues/1980)
- [#1109: Support to Run TypeScript test file(.ts) directly without Precompiling(tsc)](https://oss.issuehunt.io/repos/26820798/issues/1109)
---
</details>
<!-- /Issuehunt content-->