### PR TITLE
Add related test selection

### DIFF
--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -35,6 +35,8 @@ Options:
   -m, --match              Only run tests with matching title (can be repeated)
                                                                         [string]
       --no-worker-threads  Don't use worker threads                    [boolean]
+      --related            Treat provided paths as changed source files and run
+                           related tests                               [boolean]
       --node-arguments     Additional Node.js arguments for launching worker
                            processes (specify as a single string)       [string]
   -s, --serial             Run tests serially                          [boolean]
@@ -79,6 +81,16 @@ Files inside `node_modules` are *always* ignored. So are files starting with `_`
 * `**/tests/**/fixtures/**/*`
 
 When using `npm test`, you can pass positional arguments directly `npm test test2.js`, but flags needs to be passed like `npm test -- --verbose`.
+
+## Running tests related to changed files
+
+Use the `--related` flag to treat positional arguments as changed source files instead of test file filters. AVA traces the configured test files and runs the tests that depend on the provided files:
+
+```console
+npx ava --related src/index.js src/api.js
+```
+
+If AVA cannot determine which tests depend on a changed file it runs all configured tests. This matches watch mode's conservative behavior.
 
 ## Running tests with matching titles
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -150,7 +150,7 @@ export default class Api extends Emittery {
 		try {
 			testFiles = await globs.findTests({cwd: this.options.projectDir, ...apiOptions.globs});
 			if (typeof testFileSelector === 'function') {
-				selectedFiles = testFileSelector(testFiles, selectedFiles);
+				selectedFiles = await testFileSelector(testFiles, selectedFiles);
 			} else if (selectedFiles.length === 0) {
 				selectedFiles = filter.length === 0
 					? testFiles

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -49,6 +49,11 @@ const FLAGS = {
 		description: 'Don\'t use worker threads',
 		type: 'boolean',
 	},
+	related: {
+		coerce: coerceLastValue,
+		description: 'Treat provided paths as changed source files and run related tests',
+		type: 'boolean',
+	},
 	'node-arguments': {
 		coerce: coerceLastValue,
 		description: 'Additional Node.js arguments for launching worker processes (specify as a single string)',
@@ -290,6 +295,10 @@ export default async function loadCli() { // eslint-disable-line complexity
 			exit('The TAP reporter is not available when using watch mode.');
 		}
 
+		if (combined.related) {
+			exit('The --related flag is not available when using watch mode.');
+		}
+
 		if (isCi) {
 			exit('Watch mode is not available in CI, as it prevents AVA from terminating.');
 		}
@@ -302,6 +311,10 @@ export default async function loadCli() { // eslint-disable-line complexity
 	if (debug !== null) {
 		if (argv.tap && !conf.tap) {
 			exit('The TAP reporter is not available when debugging.');
+		}
+
+		if (combined.related) {
+			exit('The --related flag is not available when debugging.');
 		}
 
 		if (isCi) {
@@ -403,6 +416,21 @@ export default async function loadCli() { // eslint-disable-line complexity
 			pattern: normalizePattern(path.relative(projectDir, path.resolve(process.cwd(), pattern))),
 			...rest,
 		}));
+
+	let relatedTestFileSelector;
+	if (combined.related) {
+		if (input.length === 0) {
+			exit('The --related flag requires at least one changed source file path.');
+		}
+
+		if (filter.some(({lineNumbers}) => lineNumbers !== null)) {
+			exit('Line numbers cannot be used with the --related flag.');
+		}
+
+		const {selectRelatedTests} = await import('./related-tests.js');
+		const changedFiles = filter.map(({pattern}) => pattern);
+		relatedTestFileSelector = testFiles => selectRelatedTests({changedFiles, projectDir, testFiles});
+	}
 
 	const api = new Api({
 		cacheEnabled: combined.cache !== false,
@@ -523,7 +551,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 			}
 		});
 
-		const runStatus = await api.run({filter});
+		const runStatus = await api.run({filter, testFileSelector: relatedTestFileSelector});
 
 		if (debugWithoutSpecificFile && !debug.active) {
 			exit('Provide the path to the test file you wish to debug');

--- a/lib/related-tests.js
+++ b/lib/related-tests.js
@@ -1,0 +1,76 @@
+import path from 'node:path';
+
+import {nodeFileTrace} from '@vercel/nft';
+
+const toRelativePath = (projectDir, file) => path.relative(projectDir, path.resolve(projectDir, file));
+
+const traceOptions = projectDir => ({
+	analysis: {
+		emitGlobs: false,
+		computeFileReferences: false,
+		evaluatePureExpressions: true,
+	},
+	base: projectDir,
+	conditions: ['node'],
+	exportsOnly: true,
+	ignore: ['**/node_modules/**'],
+});
+
+function findDependingTests({changedFile, reasons, testFiles}) {
+	const dependingTests = new Set();
+	const visited = new Set();
+	const todo = [changedFile];
+
+	while (todo.length > 0) {
+		const file = todo.pop();
+		if (visited.has(file)) {
+			continue;
+		}
+
+		visited.add(file);
+		if (testFiles.has(file)) {
+			dependingTests.add(file);
+			continue;
+		}
+
+		const reason = reasons.get(file);
+		if (reason === undefined) {
+			return null;
+		}
+
+		todo.push(...reason.parents);
+	}
+
+	return dependingTests;
+}
+
+export async function selectRelatedTests({changedFiles, projectDir, testFiles}) {
+	const relativeTestFiles = new Map(testFiles.map(file => [toRelativePath(projectDir, file), file]));
+	const relativeChangedFiles = changedFiles.map(file => toRelativePath(projectDir, file));
+	const selected = new Set();
+	const {fileList, reasons} = await nodeFileTrace([...relativeTestFiles.keys()], traceOptions(projectDir));
+	const tracedFiles = new Set(fileList);
+	const testFileSet = new Set(relativeTestFiles.keys());
+
+	for (const changedFile of relativeChangedFiles) {
+		if (relativeTestFiles.has(changedFile)) {
+			selected.add(relativeTestFiles.get(changedFile));
+			continue;
+		}
+
+		if (!tracedFiles.has(changedFile)) {
+			return testFiles;
+		}
+
+		const dependingTests = findDependingTests({changedFile, reasons, testFiles: testFileSet});
+		if (dependingTests === null || dependingTests.size === 0) {
+			return testFiles;
+		}
+
+		for (const testFile of dependingTests) {
+			selected.add(relativeTestFiles.get(testFile));
+		}
+	}
+
+	return [...selected];
+}

--- a/test/related-tests/fixtures/basic/not-depended-on.js
+++ b/test/related-tests/fixtures/basic/not-depended-on.js
@@ -1,0 +1,1 @@
+export default 'unknown';

--- a/test/related-tests/fixtures/basic/other.js
+++ b/test/related-tests/fixtures/basic/other.js
@@ -1,0 +1,1 @@
+export default 'other';

--- a/test/related-tests/fixtures/basic/other.test.js
+++ b/test/related-tests/fixtures/basic/other.test.js
@@ -1,0 +1,7 @@
+import other from './other.js';
+
+const {default: test} = await import(process.env.TEST_AVA_IMPORT_FROM);
+
+test('other', t => {
+	t.is(other, 'other');
+});

--- a/test/related-tests/fixtures/basic/package.json
+++ b/test/related-tests/fixtures/basic/package.json
@@ -1,0 +1,8 @@
+{
+	"type": "module",
+	"ava": {
+		"files": [
+			"*.test.js"
+		]
+	}
+}

--- a/test/related-tests/fixtures/basic/source.js
+++ b/test/related-tests/fixtures/basic/source.js
@@ -1,0 +1,1 @@
+export default 'source';

--- a/test/related-tests/fixtures/basic/source.test.js
+++ b/test/related-tests/fixtures/basic/source.test.js
@@ -1,0 +1,7 @@
+import source from './source.js';
+
+const {default: test} = await import(process.env.TEST_AVA_IMPORT_FROM);
+
+test('source', t => {
+	t.is(source, 'source');
+});

--- a/test/related-tests/test.js
+++ b/test/related-tests/test.js
@@ -1,0 +1,40 @@
+import test from '@ava/test';
+
+import {cleanOutput, cwd, fixture} from '../helpers/exec.js';
+
+test('runs tests related to a changed source file', async t => {
+	const result = await fixture(['--related', 'source.js'], {cwd: cwd('basic')});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('runs a changed test file directly', async t => {
+	const result = await fixture(['--related', 'source.test.js'], {cwd: cwd('basic')});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('runs all tests if the changed file is not in the dependency graph', async t => {
+	const result = await fixture(['--related', 'not-depended-on.js'], {cwd: cwd('basic')});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'other.test.js', title: 'other'},
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('requires a changed source file path', async t => {
+	const result = await t.throwsAsync(fixture(['--related'], {cwd: cwd('basic')}));
+
+	t.regex(cleanOutput(result.stderr), /requires at least one changed source file path/);
+});
+
+test('rejects line numbers', async t => {
+	const result = await t.throwsAsync(fixture(['--related', 'source.js:1'], {cwd: cwd('basic')}));
+
+	t.regex(cleanOutput(result.stderr), /Line numbers cannot be used with the --related flag/);
+});


### PR DESCRIPTION
Fixes #1986.

IssueHunt bounty: https://issuehunt.io/repos/26820798/issues/1986

## Summary
- add `--related` so positional paths can be treated as changed source files
- trace configured test files with AVA's existing `@vercel/nft` dependency tracer
- run directly changed test files, run dependent tests for known source files, and conservatively run all tests when a changed file is not in the dependency graph
- document the new command-line mode and cover it with fixture tests

## Verification
- `npx test-ava test/related-tests/test.js`
- `npx test-ava test/related-tests/test.js test/watch-mode/scenarios.js test/globs/test.js`
- `npx tsc --noEmit`
- `npx xo` (exits 0; existing TODO warnings only)
- `node --check lib/related-tests.js && node --check lib/cli.js && node --check lib/api.js && node --check test/related-tests/test.js`
- `git diff --check`


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1986: Analyze source & test dependencies to figure out which tests to run (first)](https://oss.issuehunt.io/repos/26820798/issues/1986)
---
</details>
<!-- /Issuehunt content-->