### PR TITLE
Improve reporter message for pre-declaration failures

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -302,6 +302,10 @@ export default class Reporter {
 				}
 
 				if (!this.filesWithMissingAvaImports.has(event.testFile)) {
+					if (fileStats.declaredTests === 0) {
+						this.lineWriter.writeLine(colors.error(`${figures.cross} No tests were declared before the test file failed.`));
+					}
+
 					if (event.err) {
 						this.lineWriter.writeLine(colors.error(`${figures.cross} ${this.relativeFile(event.testFile)} exited due to an error:`));
 						this.lineWriter.writeLine();

--- a/test-tap/reporters/default-worker-failed.js
+++ b/test-tap/reporters/default-worker-failed.js
@@ -1,0 +1,59 @@
+import {EventEmitter} from 'node:events';
+import {fileURLToPath} from 'node:url';
+
+import {test} from 'tap';
+
+import Reporter from '../../lib/reporters/default.js';
+import TTYStream from '../helper/tty-stream.js';
+
+test('default reporter says when a worker failed before declaring tests', t => {
+	t.plan(1);
+
+	const testFile = fileURLToPath(new URL('../fixture/report/regular/bad-test-chain.js', import.meta.url));
+	const tty = new TTYStream({columns: 200});
+	const reporter = new Reporter({
+		extensions: ['js'],
+		projectDir: fileURLToPath(new URL('../fixture/report/regular/', import.meta.url)),
+		durationThreshold: 60_000,
+		reportStream: tty,
+		stdStream: tty,
+		watching: false,
+	});
+
+	const status = new EventEmitter();
+	reporter.startRun({
+		failFastEnabled: false,
+		filePathPrefix: '',
+		files: [testFile],
+		matching: false,
+		previousFailures: 0,
+		status: {
+			emptyParallelRun: false,
+			on: status.on.bind(status),
+			selectionInsights: {
+				ignoredFilterPatternFiles: [],
+				selectionCount: 1,
+				testFileCount: 1,
+			},
+		},
+	});
+
+	status.emit('stateChange', {
+		data: {
+			stats: {
+				byFile: new Map([[testFile, {declaredTests: 0}]]),
+			},
+			type: 'stats',
+		},
+	});
+	status.emit('stateChange', {
+		data: {
+			nonZeroExitCode: 1,
+			testFile,
+			type: 'worker-failed',
+		},
+	});
+
+	tty.end();
+	t.match(tty.asBuffer().toString('utf8'), 'No tests were declared before the test file failed.');
+});

--- a/test-tap/reporters/default.edgecases.v22.log
+++ b/test-tap/reporters/default.edgecases.v22.log
@@ -10,6 +10,7 @@
   SyntaxError: Unexpected token 'do'
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ ast-syntax-error.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ No tests found in ava-import-no-test-declaration.js[39m
@@ -28,6 +29,7 @@
   [90m› file://test-tap/fixture/report/edgecases/import-and-use-test-member.js:3:1[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ import-and-use-test-member.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ No tests found in no-ava-import.js, make sure to import "ava" at the top of your test file[39m
@@ -47,6 +49,7 @@
   [90m› Object.<anonymous> (test-tap/fixture/report/edgecases/throws.js:1:7)[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ throws.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [90m─[39m

--- a/test-tap/reporters/default.edgecases.v24.log
+++ b/test-tap/reporters/default.edgecases.v24.log
@@ -10,6 +10,7 @@
   SyntaxError: Unexpected token 'do'
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ ast-syntax-error.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ No tests found in ava-import-no-test-declaration.js[39m
@@ -28,6 +29,7 @@
   [90m› file://test-tap/fixture/report/edgecases/import-and-use-test-member.js:3:1[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ import-and-use-test-member.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ No tests found in no-ava-import.js, make sure to import "ava" at the top of your test file[39m
@@ -47,6 +49,7 @@
   [90m› Object.<anonymous> (test-tap/fixture/report/edgecases/throws.js:1:7)[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ throws.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [90m─[39m

--- a/test-tap/reporters/default.edgecases.v25.log
+++ b/test-tap/reporters/default.edgecases.v25.log
@@ -10,6 +10,7 @@
   SyntaxError: Unexpected token 'do'
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ ast-syntax-error.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ No tests found in ava-import-no-test-declaration.js[39m
@@ -28,6 +29,7 @@
   [90m› file://test-tap/fixture/report/edgecases/import-and-use-test-member.js:3:1[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ import-and-use-test-member.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ No tests found in no-ava-import.js, make sure to import "ava" at the top of your test file[39m
@@ -47,6 +49,7 @@
   [90m› Object.<anonymous> (test-tap/fixture/report/edgecases/throws.js:1:7)[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ throws.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [90m─[39m

--- a/test-tap/reporters/default.regular.v22.log
+++ b/test-tap/reporters/default.regular.v22.log
@@ -13,6 +13,7 @@
   [90m› file://test-tap/fixture/report/regular/bad-test-chain.js:3:13[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ [fail]:[39m nested-objects [90m[2m›[22m[39m format with max depth 4

--- a/test-tap/reporters/default.regular.v24.log
+++ b/test-tap/reporters/default.regular.v24.log
@@ -13,6 +13,7 @@
   [90m› file://test-tap/fixture/report/regular/bad-test-chain.js:3:13[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ [fail]:[39m nested-objects [90m[2m›[22m[39m format with max depth 4

--- a/test-tap/reporters/default.regular.v25.log
+++ b/test-tap/reporters/default.regular.v25.log
@@ -13,6 +13,7 @@
   [90m› file://test-tap/fixture/report/regular/bad-test-chain.js:3:13[39m
 
 ---tty-stream-chunk-separator
+  [31m✘ No tests were declared before the test file failed.[39m
   [31m✘ bad-test-chain.js exited with a non-zero exit code: 1[39m
 ---tty-stream-chunk-separator
   [31m✘ [fail]:[39m nested-objects [90m[2m›[22m[39m format with max depth 4


### PR DESCRIPTION
## Summary
- report explicitly when a test worker fails before any tests are declared
- cover the worker-failed reporter path with a focused regression test

## Test plan
- npx tap test-tap/reporters/default-worker-failed.js --disable-coverage
- npx xo lib/reporters/default.js test-tap/reporters/default-worker-failed.js

Addresses one reporter item from #2501.