### PR TITLE
Add cleanup hook API

### DIFF
--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -178,6 +178,8 @@ AVA lets you register hooks that are run before and after your tests. This allow
 
 `test.beforeEach()` registers a hook to be run before each test in your test file. Similarly `test.afterEach()` registers a hook to be run after each test. Use `test.afterEach.always()` to register an after hook that is called even if other test hooks, or the test itself, fail.
 
+`test.cleanup()` registers a hook to be run once before the first test and again as an `after.always()` hook. Use it to make cleanup idempotent: the first run removes state left behind by a previous interrupted run, and the second run removes state created by this run.
+
 If a test is skipped with the `.skip` modifier, the respective `.beforeEach()`, `.afterEach()` and `.afterEach.always()` hooks are not run. Likewise, if all tests in a test file are skipped `.before()`, `.after()` and `.after.always()` hooks for the file are not run.
 
 *You may not need to use `.afterEach.always()` hooks to clean up after a test.* You can use [`t.teardown()`](./02-execution-context.md#tteardownfn) to undo side-effects *within* a particular test. Or use [`registerCompletionHandler()`](./08-common-pitfalls.md#timeouts-because-a-file-failed-to-exit) to run cleanup code after AVA has completed its work.
@@ -209,6 +211,10 @@ test.after('cleanup', t => {
 
 test.after.always('guaranteed cleanup', t => {
 	// This will always run, regardless of earlier failures
+});
+
+test.cleanup('remove temporary files', t => {
+	// This runs before all tests and again after all tests are done
 });
 
 test.beforeEach(t => {

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -118,6 +118,11 @@ function createHookChain(hook, isAfterHook) {
 	return hook;
 }
 
+function createCleanupChain(cleanup) {
+	extendChain(cleanup, 'skip', 'skipped');
+	return cleanup;
+}
+
 export default function createChain(fn, defaults, meta) {
 	// Test chaining rules:
 	// * `serial` must come at the start
@@ -146,11 +151,40 @@ export default function createChain(fn, defaults, meta) {
 	root.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, type: 'afterEach'}), true);
 	root.before = createHookChain(startChain('test.before', fn, {...defaults, type: 'before'}), false);
 	root.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, type: 'beforeEach'}), false);
+	root.cleanup = createCleanupChain(startChain('test.cleanup', (metadata, args) => {
+		fn({
+			...metadata,
+			cleanup: true,
+			type: 'before',
+		}, [...args]);
+		fn({
+			...metadata,
+			always: true,
+			cleanup: true,
+			type: 'after',
+		}, [...args]);
+	}, defaults));
 
 	root.serial.after = createHookChain(startChain('test.after', fn, {...defaults, serial: true, type: 'after'}), true);
 	root.serial.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, serial: true, type: 'afterEach'}), true);
 	root.serial.before = createHookChain(startChain('test.before', fn, {...defaults, serial: true, type: 'before'}), false);
 	root.serial.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, serial: true, type: 'beforeEach'}), false);
+	root.serial.cleanup = createCleanupChain(startChain('test.serial.cleanup', (metadata, args) => {
+		fn({
+			...metadata,
+			always: false,
+			cleanup: true,
+			serial: true,
+			type: 'before',
+		}, [...args]);
+		fn({
+			...metadata,
+			always: true,
+			cleanup: true,
+			serial: true,
+			type: 'after',
+		}, [...args]);
+	}, defaults));
 
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -139,6 +139,8 @@ export default class Runner extends Emittery {
 				if (title.isEmpty) {
 					if (metadata.type === 'test') {
 						throw new TypeError('Tests must have a title');
+					} else if (metadata.cleanup) {
+						fallbackTitle = 'cleanup hook';
 					} else if (metadata.always) {
 						fallbackTitle = `${metadata.type}.always hook`;
 					} else {

--- a/test-tap/hooks.js
+++ b/test-tap/hooks.js
@@ -117,6 +117,42 @@ test('after.always run even if before failed', t => {
 	});
 });
 
+test('cleanup runs before tests and after failures', t => {
+	t.plan(1);
+
+	const array = [];
+	return promiseEnd(new Runner({file: import.meta.url}), runner => {
+		runner.chain.cleanup(() => {
+			array.push('cleanup');
+		});
+
+		runner.chain('test', () => {
+			array.push('test');
+			throw new Error('something went wrong');
+		});
+	}).then(() => {
+		t.strictSame(array, ['cleanup', 'test', 'cleanup']);
+	});
+});
+
+test('cleanup can be skipped', t => {
+	t.plan(1);
+
+	const array = [];
+	return promiseEnd(new Runner({file: import.meta.url}), runner => {
+		runner.chain.cleanup.skip(() => {
+			array.push('cleanup');
+		});
+
+		runner.chain('test', a => {
+			a.pass();
+			array.push('test');
+		});
+	}).then(() => {
+		t.strictSame(array, ['test']);
+	});
+});
+
 test('stop if before hooks failed', t => {
 	t.plan(1);
 

--- a/test-types/module/conditional-chains.ts
+++ b/test-types/module/conditional-chains.ts
@@ -3,8 +3,12 @@ import anyTest from '../../entrypoints/main.js';
 
 anyTest.skipIf(true).beforeEach(() => {});
 anyTest.runIf(false).afterEach(() => {});
+anyTest.cleanup(() => {});
+anyTest.cleanup.skip(() => {});
 anyTest.skipIf(true).serial.before(() => {});
 anyTest.serial.runIf(true).after(() => {});
+anyTest.serial.cleanup(() => {});
+anyTest.serial.cleanup.skip(() => {});
 
 anyTest.skipIf(true).todo('skipIf todo should be allowed');
 anyTest.runIf(false).todo('runIf todo should be allowed');

--- a/types/test-fn.d.ts
+++ b/types/test-fn.d.ts
@@ -87,6 +87,7 @@ export type TestFn<Context = unknown> = {
 	afterEach: AfterFn<Context>;
 	before: BeforeFn<Context>;
 	beforeEach: BeforeFn<Context>;
+	cleanup: CleanupFn<Context>;
 	failing: FailingFn<Context>;
 	macro: MacroFn<Context>;
 	meta: Meta;
@@ -209,6 +210,7 @@ export type SerialFn<Context = unknown> = {
 	afterEach: AfterFn<Context>;
 	before: BeforeFn<Context>;
 	beforeEach: BeforeFn<Context>;
+	cleanup: CleanupFn<Context>;
 	failing: FailingFn<Context>;
 	only: OnlyFn<Context>;
 	/** Declare a test that only runs when `condition` is true; otherwise the test is skipped. */
@@ -226,6 +228,22 @@ export type SkipFn<Context = unknown> = {
 
 	/** Skip this test. */
 	<Args extends unknown[]>(macro: Macro<Args, Context>, ...args: Args): void;
+};
+
+export type CleanupFn<Context = unknown> = {
+	/**
+	 * Declare a hook that is run once before all tests and once again after all tests are done.
+	 * Additional arguments are passed to the implementation or macro.
+	 */
+	<Args extends unknown[]>(title: string, implementation: Implementation<Args, Context>, ...args: Args): void;
+
+	/**
+	 * Declare a hook that is run once before all tests and once again after all tests are done.
+	 * Additional arguments are passed to the implementation or macro.
+	 */
+	<Args extends unknown[]>(implementation: Implementation<Args, Context>, ...args: Args): void;
+
+	skip: HookSkipFn<Context>;
 };
 
 /** Declare a test that is skipped when `condition` is true. */


### PR DESCRIPTION
Fixes #928.

This adds `test.cleanup()` as a small lifecycle convenience for idempotent cleanup code. The declaration registers the same implementation as:

- a `before` hook, so state left behind by an interrupted or crashed previous run can be removed before tests start
- an `after.always` hook, so state created by the current run is removed after tests finish, including failed runs that still reach AVA's normal hook execution

It also adds `test.serial.cleanup()`, `.cleanup.skip()`, TypeScript declarations, docs, and regression coverage for failure and skipped cleanup behavior.

Checked:
- `npx tap test-tap/hooks.js --disable-coverage`
- `npx tap test-tap/runner.js --disable-coverage`
- `npx xo lib/create-chain.js lib/runner.js test-tap/hooks.js`
- `npm exec -- tsd --files test-types/module/conditional-chains.ts`
- `git diff --check`