### PR TITLE
Report updated snapshot files

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -730,6 +730,10 @@ export default class Reporter {
 			this.lineWriter.writeLine(colors.todo(`${this.stats.todoTests} ${plur('test', this.stats.todoTests)} todo`));
 		}
 
+		if (this.stats.snapshotFilesUpdated > 0) {
+			this.lineWriter.writeLine(colors.pass(`${this.stats.snapshotFilesUpdated} ${plur('snapshot file', 'snapshot files', this.stats.snapshotFilesUpdated)} updated`));
+		}
+
 		if (this.stats.unhandledRejections > 0) {
 			this.lineWriter.writeLine(colors.error(`${this.stats.unhandledRejections} unhandled ${plur('rejection', this.stats.unhandledRejections)}`));
 		}

--- a/lib/run-status.js
+++ b/lib/run-status.js
@@ -33,6 +33,7 @@ export default class RunStatus extends Emittery {
 			passedTests: 0,
 			selectedTests: 0,
 			sharedWorkerErrors: 0,
+			snapshotFilesUpdated: 0,
 			skippedTests: 0,
 			timedOutTests: 0,
 			timeouts: 0,
@@ -144,6 +145,17 @@ export default class RunStatus extends Emittery {
 
 			case 'test-register-log-reference': {
 				this.addPendingTestLogs(event);
+				break;
+			}
+
+			case 'touched-files': {
+				const snapshotFilesUpdated = event.files.changedFiles.filter(file => file.endsWith('.snap')).length;
+				if (snapshotFilesUpdated === 0) {
+					changedStats = false;
+				} else {
+					stats.snapshotFilesUpdated += snapshotFilesUpdated;
+				}
+
 				break;
 			}
 

--- a/test-tap/reporters/default.js
+++ b/test-tap/reporters/default.js
@@ -1,7 +1,11 @@
+import path from 'node:path';
+import {setImmediate as delayImmediate} from 'node:timers/promises';
 import {fileURLToPath} from 'node:url';
+import {stripVTControlCharacters} from 'node:util';
 
 import {test} from 'tap';
 
+import RunStatus from '../../lib/run-status.js';
 import fixReporterEnv from '../helper/fix-reporter-env.js';
 import report from '../helper/report.js';
 import TTYStream from '../helper/tty-stream.js';
@@ -62,5 +66,69 @@ test(async t => {
 		t.test('single file with only certain tests matched run', run('timeoutWithMatch'));
 		t.test('logs provided during a pending test logged at the end', run('timeoutContextLogs'));
 		t.end();
+	});
+
+	t.test('default reporter - snapshot update count', async t => {
+		t.plan(4);
+
+		const projectDir = '/project';
+		const testFile = path.join(projectDir, 'test.js');
+		const tty = new TTYStream({columns: 200});
+		const reporter = new Reporter({
+			extensions: ['js'],
+			projectDir,
+			durationThreshold: 60_000,
+			reportStream: tty,
+			stdStream: tty,
+			watching: false,
+		});
+		const status = new RunStatus(1, null, {
+			filter: [],
+			ignoredFilterPatternFiles: [],
+			selectionCount: 1,
+			testFileCount: 1,
+		});
+
+		status.observeWorker({onStateChange() {}}, testFile, {});
+		reporter.startRun({
+			bailWithoutReporting: false,
+			failFastEnabled: false,
+			filePathPrefix: projectDir,
+			files: [testFile],
+			firstRun: true,
+			matching: false,
+			previousFailures: 0,
+			status,
+		});
+
+		status.emitStateChange({type: 'selected-test', testFile, title: 'updates snapshots'});
+		status.emitStateChange({
+			duration: 1,
+			knownFailing: false,
+			logs: [],
+			testFile,
+			title: 'updates snapshots',
+			type: 'test-passed',
+		});
+		status.emitStateChange({
+			files: {
+				changedFiles: [
+					path.join(projectDir, 'test.js.snap'),
+					path.join(projectDir, 'test.js.md'),
+					path.join(projectDir, 'other.js.snap'),
+				],
+				temporaryFiles: [],
+			},
+			type: 'touched-files',
+		});
+		await delayImmediate();
+		reporter.endRun();
+		tty.end();
+
+		const output = stripVTControlCharacters(tty.asBuffer().toString('utf8'));
+		t.match(output, '1 test passed');
+		t.match(output, '2 snapshot files updated');
+		t.notMatch(output, '3 snapshot files updated');
+		t.equal(status.stats.snapshotFilesUpdated, 2);
 	});
 });


### PR DESCRIPTION
## Summary
- Track updated snapshot files from existing touched-files events in run status
- Show the updated snapshot file count in the default reporter summary
- Add a focused reporter test that verifies .snap files are counted and .md reports are ignored

Contributes to #2501 by addressing the snapshot update reporting item from #1583.

## Tests
- npm test
- npx tap test-tap/reporters/default.js
- npx tap test-tap/api.js
- npx tap test-tap/reporters/tap.js
- npx test-ava 'test/snapshot-workflow/*.js'
- npx xo lib/run-status.js lib/reporters/default.js test-tap/reporters/default.js


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2501: Known reporter issues](https://oss.issuehunt.io/repos/26820798/issues/2501)
---
</details>
<!-- /Issuehunt content-->