### PR TITLE
Add seeded test order randomization

### DIFF
--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -37,6 +37,8 @@ Options:
       --no-worker-threads  Don't use worker threads                    [boolean]
       --node-arguments     Additional Node.js arguments for launching worker
                            processes (specify as a single string)       [string]
+      --randomize          Run tests in a random order                 [boolean]
+      --seed               Seed for randomizing test order              [number]
   -s, --serial             Run tests serially                          [boolean]
   -t, --tap                Generate TAP output                         [boolean]
   -T, --timeout            Set global timeout (milliseconds or human-readable,
@@ -144,6 +146,22 @@ test('moo will also run', t => {
 test.only('boo will run but not exclusively', t => {
 	t.pass();
 });
+```
+
+## Running tests in a random order
+
+Use the `--randomize` flag to shuffle the order in which AVA starts test files and the order in which non-serial tests are started within each file. Tests declared with `test.serial()` keep their declaration order.
+
+AVA reports the seed used for the run:
+
+```console
+npx ava --randomize
+```
+
+Use `--seed` to reproduce the same randomized order. Providing a seed also enables randomization:
+
+```console
+npx ava --seed=314159
 ```
 
 ## Running tests at specific line numbers

--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -59,6 +59,8 @@ Arguments passed to the CLI will always take precedence over the CLI options con
 - `require`: [extra modules to load before test files](#requiring-extra-modules)
 - `timeout`: Timeouts in AVA behave differently than in other test frameworks. AVA resets a timer after each test, forcing tests to quit if no new test results were received within the specified timeout. This can be used to handle stalled tests. See our [timeout documentation](./07-test-timeouts.md) for more options.
 - `nodeArguments`: Configure Node.js arguments used to launch worker processes.
+- `randomize`: if `true`, starts test files and non-serial tests within each file in a random order. AVA reports the seed so the order can be reproduced.
+- `seed`: sets the seed for randomized test order. Providing this also enables randomization.
 - `sortTestFiles`: A comparator function to sort test files with. Available only when using a `ava.config.*` file. See an example use case [here](recipes/splitting-tests-ci.md).
 - `utilizeParallelBuilds`: If `false`, disable [parallel builds](/docs/recipes/splitting-tests-ci.md) (default: true)
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -17,6 +17,7 @@ import isCi from './is-ci.js';
 import {getApplicableLineNumbers} from './line-numbers.js';
 import {setCappedTimeout} from './now-and-timers.js';
 import {observeWorkerProcess} from './plugin-support/shared-workers.js';
+import {shuffle} from './randomize.js';
 import RunStatus from './run-status.js';
 import scheduler from './scheduler.js';
 import serializeError from './serialize-error.js';
@@ -77,7 +78,7 @@ export default class Api extends Emittery {
 	constructor(options) {
 		super();
 
-		this.options = {match: [], ...options};
+		this.options = {match: [], randomSeed: null, ...options};
 		this.options.require = normalizeRequireOption(this.options.require);
 
 		this._cacheDir = null;
@@ -181,6 +182,10 @@ export default class Api extends Emittery {
 				// The files must be in the same order across all runs, so sort them.
 				const defaultComparator = (a, b) => a.localeCompare(b, [], {numeric: true});
 				selectedFiles = selectedFiles.toSorted(this.options.sortTestFiles ?? defaultComparator);
+				if (this.options.randomSeed !== null) {
+					selectedFiles = shuffle(selectedFiles, this.options.randomSeed);
+				}
+
 				selectedFiles = chunkd(selectedFiles, currentIndex, totalRuns);
 
 				const currentFileCount = selectedFiles.length;
@@ -196,6 +201,9 @@ export default class Api extends Emittery {
 			}
 
 			selectedFiles = scheduler.failingTestsFirst(selectedFiles, this._getLocalCacheDir(), this.options.cacheEnabled);
+			if (!this.options.parallelRuns && this.options.randomSeed !== null) {
+				selectedFiles = shuffle(selectedFiles, this.options.randomSeed);
+			}
 
 			const debugWithoutSpecificFile = Boolean(this.options.debug) && !this.options.debug.active && selectedFiles.length !== 1;
 
@@ -207,6 +215,7 @@ export default class Api extends Emittery {
 				files: selectedFiles,
 				matching: apiOptions.match.length > 0 || runtimeOptions.interactiveMatchPattern !== undefined,
 				previousFailures: runtimeOptions.countPreviousFailures?.() ?? 0,
+				randomSeed: apiOptions.randomSeed,
 				firstRun: runtimeOptions.firstRun ?? true,
 				status: runStatus,
 			});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,6 +19,7 @@ import {splitPatternAndLineNumbers} from './line-numbers.js';
 import {loadConfig} from './load-config.js';
 import normalizeNodeArguments from './node-arguments.js';
 import pkg from './pkg.js';
+import {createRandomSeed, isRandomSeed} from './randomize.js';
 
 function exit(message) {
 	console.error(`\n  ${chalk.red(figures.cross)} ${message}`);
@@ -53,6 +54,16 @@ const FLAGS = {
 		coerce: coerceLastValue,
 		description: 'Additional Node.js arguments for launching worker processes (specify as a single string)',
 		type: 'string',
+	},
+	randomize: {
+		coerce: coerceLastValue,
+		description: 'Run tests in a random order',
+		type: 'boolean',
+	},
+	seed: {
+		coerce: coerceLastValue,
+		description: 'Seed for randomizing test order',
+		type: 'number',
 	},
 	serial: {
 		alias: 's',
@@ -317,6 +328,14 @@ export default async function loadCli() { // eslint-disable-line complexity
 		exit('The --concurrency or -c flag must be provided with a non-negative integer.');
 	}
 
+	if (Object.hasOwn(combined, 'randomize') && typeof combined.randomize !== 'boolean') {
+		exit('`randomize` must be a boolean.');
+	}
+
+	if (Object.hasOwn(combined, 'seed') && !isRandomSeed(combined.seed)) {
+		exit('The --seed flag must be provided with an integer from 0 to 4294967295.');
+	}
+
 	if (Object.hasOwn(conf, 'sortTestFiles') && typeof conf.sortTestFiles !== 'function') {
 		exit('’sortTestFiles’ must be a comparator function.');
 	}
@@ -373,6 +392,9 @@ export default async function loadCli() { // eslint-disable-line complexity
 	}
 
 	const workerThreads = combined.workerThreads !== false;
+	const randomSeed = combined.randomize === true || Object.hasOwn(combined, 'seed')
+		? combined.seed ?? createRandomSeed()
+		: null;
 
 	let nodeArguments;
 	try {
@@ -419,6 +441,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 		match,
 		nodeArguments,
 		parallelRuns,
+		randomSeed,
 		sortTestFiles: conf.sortTestFiles,
 		projectDir,
 		providers,

--- a/lib/randomize.js
+++ b/lib/randomize.js
@@ -1,0 +1,30 @@
+import {randomInt} from 'node:crypto';
+
+const seedUpperBound = 2 ** 32;
+const generatorModulus = 2_147_483_647;
+const generatorMultiplier = 48_271;
+
+export function createRandomSeed() {
+	return randomInt(seedUpperBound);
+}
+
+export function isRandomSeed(value) {
+	return Number.isSafeInteger(value) && value >= 0 && value < seedUpperBound;
+}
+
+export function shuffle(items, seed) {
+	const result = [...items];
+	let state = (seed % (generatorModulus - 1)) + 1;
+
+	const random = () => {
+		state = (state * generatorMultiplier) % generatorModulus;
+		return state / generatorModulus;
+	};
+
+	for (let index = result.length - 1; index > 0; index--) {
+		const swapIndex = Math.floor(random() * (index + 1));
+		[result[index], result[swapIndex]] = [result[swapIndex], result[index]];
+	}
+
+	return result;
+}

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -123,6 +123,7 @@ export default class Reporter {
 		this.unhandledRejections = [];
 
 		this.previousFailures = 0;
+		this.randomSeed = null;
 
 		this.failFastEnabled = false;
 		this.matching = false;
@@ -141,6 +142,7 @@ export default class Reporter {
 		this.failFastEnabled = plan.failFastEnabled;
 		this.matching = plan.matching;
 		this.previousFailures = plan.previousFailures;
+		this.randomSeed = plan.randomSeed ?? null;
 		this.emptyParallelRun = plan.status.emptyParallelRun;
 		this.selectionInsights = plan.status.selectionInsights;
 
@@ -696,6 +698,11 @@ export default class Reporter {
 				totalRuns,
 			} = this.stats.parallelRuns;
 			this.lineWriter.writeLine(colors.information(`Ran ${currentFileCount} test ${plur('file', currentFileCount)} out of ${this.stats.files} for job ${currentIndex + 1} of ${totalRuns}`));
+			this.lineWriter.writeLine();
+		}
+
+		if (this.randomSeed !== null) {
+			this.lineWriter.writeLine(colors.information(`Randomized test order with seed ${this.randomSeed}`));
 			this.lineWriter.writeLine();
 		}
 

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -62,6 +62,7 @@ export default class TapReporter {
 		this.prefixTitle = (testFile, title) => title;
 		this.relativeFile = file => path.relative(options.projectDir, file);
 		this.stats = null;
+		this.randomSeed = null;
 	}
 
 	startRun(plan) {
@@ -70,6 +71,7 @@ export default class TapReporter {
 		}
 
 		plan.status.on('stateChange', ({data: evt}) => this.consumeStateChange(evt));
+		this.randomSeed = plan.randomSeed ?? null;
 
 		this.reportStream.write(supertap.start() + os.EOL);
 	}
@@ -87,6 +89,10 @@ export default class TapReporter {
 			if (this.stats.parallelRuns) {
 				const {currentFileCount, currentIndex, totalRuns} = this.stats.parallelRuns;
 				this.reportStream.write(`# Ran ${currentFileCount} test ${plur('file', currentFileCount)} out of ${this.stats.files} for job ${currentIndex + 1} of ${totalRuns}` + os.EOL + os.EOL);
+			}
+
+			if (this.randomSeed !== null) {
+				this.reportStream.write(`# Randomized test order with seed ${this.randomSeed}` + os.EOL + os.EOL);
 			}
 		} else {
 			this.reportStream.write(supertap.finish({

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -7,6 +7,7 @@ import * as matcher from 'matcher';
 import ContextRef from './context-ref.js';
 import createChain from './create-chain.js';
 import parseTestArgs from './parse-test-args.js';
+import {shuffle} from './randomize.js';
 import serializeError from './serialize-error.js';
 import {load as loadSnapshots, determineSnapshotDir} from './snapshot-manager.js';
 import Runnable from './test.js';
@@ -33,6 +34,7 @@ export default class Runner extends Emittery {
 		this.checkSelectedByLineNumbers = options.checkSelectedByLineNumbers;
 		this.matchPatterns = options.match ?? [];
 		this.projectDir = options.projectDir;
+		this.randomSeed = options.randomSeed ?? null;
 		this.recordNewSnapshots = options.recordNewSnapshots === true;
 		this.serial = options.serial === true;
 		this.snapshotDir = options.snapshotDir;
@@ -403,7 +405,17 @@ export default class Runner extends Emittery {
 		return alwaysOk && hooksOk && testOk;
 	}
 
+	scheduleConcurrentTests(concurrentTests, serialTests, concurrentCandidates) {
+		const selected = this.randomSeed === null ? concurrentCandidates : shuffle(concurrentCandidates, this.randomSeed);
+		if (this.serial) {
+			serialTests.push(...selected);
+		} else {
+			concurrentTests.push(...selected);
+		}
+	}
+
 	async start() {
+		const concurrentCandidates = [];
 		const concurrentTests = [];
 		const serialTests = [];
 		for (const task of this.tasks.serial) {
@@ -443,12 +455,12 @@ export default class Runner extends Emittery {
 
 			if (task.metadata.skipped) {
 				this.snapshots.skipBlock(task.title, task.metadata.taskIndex);
-			} else if (this.serial) {
-				serialTests.push(task);
 			} else {
-				concurrentTests.push(task);
+				concurrentCandidates.push(task);
 			}
 		}
+
+		this.scheduleConcurrentTests(concurrentTests, serialTests, concurrentCandidates);
 
 		for (const task of this.tasks.todo) {
 			if (!task.metadata.selected || (this.runOnlyExclusive && !task.metadata.exclusive)) {

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -79,6 +79,7 @@ const run = async options => {
 		file: options.file,
 		match: options.match,
 		projectDir: options.projectDir,
+		randomSeed: options.randomSeed,
 		recordNewSnapshots: options.recordNewSnapshots,
 		serial: options.serial,
 		snapshotDir: options.snapshotDir,

--- a/test-tap/integration/assorted.js
+++ b/test-tap/integration/assorted.js
@@ -160,3 +160,21 @@ test('uses sortTestFiles to sort test files', t => {
 		t.end();
 	});
 });
+
+test('randomizes tests with a reproducible seed', async t => {
+	const run = seed => new Promise(resolve => {
+		execCli([`--seed=${seed}`, '--no-color'], {dirname: 'fixture/sort-tests'}, (error, stdout) => {
+			resolve({error, stdout});
+		});
+	});
+
+	const [first, second, different] = await Promise.all([run(1), run(1), run(100)]);
+
+	t.error(first.error);
+	t.error(second.error);
+	t.error(different.error);
+	t.match(first.stdout, /Randomized test order with seed 1/);
+	t.match(first.stdout, /should run second[\s\S]+?should run third[\s\S]+?should run first/);
+	t.equal(first.stdout, second.stdout);
+	t.not(first.stdout, different.stdout);
+});

--- a/test-tap/runner.js
+++ b/test-tap/runner.js
@@ -99,6 +99,66 @@ test('run serial tests before concurrent ones', t => {
 	});
 });
 
+test('randomSeed shuffles non-serial tests', async t => {
+	const run = async seed => {
+		const array = [];
+		await promiseEnd(new Runner({file: import.meta.url, randomSeed: seed, serial: true}), runner => {
+			runner.chain('one', a => {
+				array.push('one');
+				a.pass();
+			});
+
+			runner.chain('two', a => {
+				array.push('two');
+				a.pass();
+			});
+
+			runner.chain('three', a => {
+				array.push('three');
+				a.pass();
+			});
+
+			runner.chain('four', a => {
+				array.push('four');
+				a.pass();
+			});
+		});
+
+		return array;
+	};
+
+	t.strictSame(await run(1), await run(1));
+	t.notSame(await run(1), await run(100));
+});
+
+test('randomSeed preserves test.serial declaration order', t => {
+	const array = [];
+	return promiseEnd(new Runner({file: import.meta.url, randomSeed: 42, serial: true}), runner => {
+		runner.chain('one', a => {
+			array.push('one');
+			a.pass();
+		});
+
+		runner.chain.serial('serial one', a => {
+			array.push('serial one');
+			a.pass();
+		});
+
+		runner.chain('two', a => {
+			array.push('two');
+			a.pass();
+		});
+
+		runner.chain.serial('serial two', a => {
+			array.push('serial two');
+			a.pass();
+		});
+	}).then(() => {
+		t.strictSame(array.slice(0, 2), ['serial one', 'serial two']);
+		t.strictSame(new Set(array), new Set(['serial one', 'serial two', 'one', 'two']));
+	});
+});
+
 test('anything can be skipped', t => {
 	const array = [];
 	function pusher(title) {


### PR DESCRIPTION
Fixes #595.

IssueHunt bounty: https://oss.issuehunt.io/r/avajs/ava/issues/595

## Summary
- Add `--randomize` and `--seed` so AVA can shuffle selected test files and non-serial tests within each file.
- Keep `test.serial()` declarations in source order while randomizing ordinary tests.
- Report the seed in the default and TAP reporters so a randomized order can be reproduced.

## Test plan
- `npx tap test-tap/runner.js`
- `npx tap test-tap/integration/assorted.js`
- `npx xo` (passes with existing TODO warnings)
- `npx tsc --noEmit`
- `git diff --check`