### PR TITLE
Upgrade @ava/test to 8.0.1, still skip Node.js 26 for external assertions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
 		},
 		"node_modules/@ava/v8": {
 			"name": "ava",
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-8.0.0.tgz",
-			"integrity": "sha512-KMUyT3LcnZ/5ipDAqnTGn6PQUvr1Jk4dex3v7ieQrGaMlAblfIpMLwK56HfPcObvJEzyhCWXfZjbM98FeAy0oQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-8.0.1.tgz",
+			"integrity": "sha512-YlwwL5HX2EJRE75e2LR8nio8lKAJ702sFbv0QYnhzngAjyo9wB+Xg4JZh5f432khlWfVD5OQ93rrRopEXJptpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -150,7 +150,7 @@
 				"arrgv": "^1.0.2",
 				"arrify": "^3.0.0",
 				"callsites": "^4.2.0",
-				"cbor": "^10.0.12",
+				"cbor2": "^2.3.0",
 				"chalk": "^5.6.2",
 				"chunkd": "^2.0.1",
 				"ci-info": "^4.4.0",
@@ -188,7 +188,7 @@
 				"ava": "entrypoints/cli.js"
 			},
 			"engines": {
-				"node": "^22.20 || ^24.12 || >=25"
+				"node": "^22.20 || ^24.12 || >=26"
 			},
 			"peerDependencies": {
 				"@ava/typescript": "*"
@@ -3982,19 +3982,6 @@
 				}
 			],
 			"license": "CC-BY-4.0"
-		},
-		"node_modules/cbor": {
-			"version": "10.0.12",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.12.tgz",
-			"integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"nofilter": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=20"
-			}
 		},
 		"node_modules/cbor2": {
 			"version": "2.3.0",
@@ -8762,16 +8749,6 @@
 			"integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/nofilter": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
-			"integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.19"
-			}
 		},
 		"node_modules/nopt": {
 			"version": "8.1.0",

--- a/test/external-assertions/test.js
+++ b/test/external-assertions/test.js
@@ -16,7 +16,8 @@ const snapshotStdout = (t, stdout) => {
 for (const [label, selector] of Object.entries({
 	'^22.20': /^22\.(2\d\.|[3-9]\d\.)/,
 	'^24.12': /^24\.(1[2-9]\.|[2-9]\d\.)/,
-	// '^26': /^26\./, // FIXME
+	// FIXME: Unskip when https://github.com/nodejs/node/issues/63169 is resolved.
+	// '^26': /^26\./,
 })) {
 	// Tests need to be declared for all versions, so that snapshots can be
 	// updated by running `npx test-ava -u test/external-assertions/test.js` for


### PR DESCRIPTION
Due to Node.js bug, the snapshot holds an error, which is not the intention.
