### PR TITLE
Correct link to `CODE_OF_CONDUCT.md` in `CONTRIBUTING.md`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ✨ Thanks for contributing to AVA! ✨
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](/.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 Translations: [Español](https://github.com/avajs/ava-docs/blob/main/es_ES/contributing.md), [Français](https://github.com/avajs/ava-docs/blob/main/fr_FR/contributing.md), [Italiano](https://github.com/avajs/ava-docs/blob/main/it_IT/contributing.md), [日本語](https://github.com/avajs/ava-docs/blob/main/ja_JP/contributing.md), [Português](https://github.com/avajs/ava-docs/blob/main/pt_BR/contributing.md), [Русский](https://github.com/avajs/ava-docs/blob/main/ru_RU/contributing.md), [简体中文](https://github.com/avajs/ava-docs/blob/main/zh_CN/contributing.md)
 


### PR DESCRIPTION
Currently, the link to the code of conduct in the [contributing guidelines on the repo's landing page](https://github.com/avajs/ava?tab=contributing-ov-file#contributing-to-ava) is broken, pointing to <https://github.com/avajs/ava/blob/main/CODE_OF_CONDUCT.md>.[^1]

This fixes that by using an absolute file path, which GitHub seems to like better. It works both on the [repo's landing page](https://github.com/ericcornelissen/ava/tree/patch-1?tab=contributing-ov-file#contributing-to-ava) and the [file](https://github.com/ericcornelissen/ava/blob/patch-1/.github/CONTRIBUTING.md).

[^1]: it works fine from the [contributing guidelines file](https://github.com/avajs/ava/blob/bbfd946322fdeca2b547a691d947fb4e18c0c67f/.github/CONTRIBUTING.md).