### PR TITLE
Add cleanup hook helpers

### DIFF
--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -178,6 +178,10 @@ AVA lets you register hooks that are run before and after your tests. This allow
 
 `test.beforeEach()` registers a hook to be run before each test in your test file. Similarly `test.afterEach()` registers a hook to be run after each test. Use `test.afterEach.always()` to register an after hook that is called even if other test hooks, or the test itself, fail.
 
+Use `test.cleanup()` to register the same hook before all tests and after all tests have completed. This is shorthand for pairing `test.before()` with `test.after.always()`. Use `test.cleanupEach()` to run cleanup before each test and after each test has completed, equivalent to pairing `test.beforeEach()` with `test.afterEach.always()`.
+
+These helpers are also available as `test.serial.cleanup()` and `test.serial.cleanupEach()` when the paired hooks should run serially.
+
 If a test is skipped with the `.skip` modifier, the respective `.beforeEach()`, `.afterEach()` and `.afterEach.always()` hooks are not run. Likewise, if all tests in a test file are skipped `.before()`, `.after()` and `.after.always()` hooks for the file are not run.
 
 *You may not need to use `.afterEach.always()` hooks to clean up after a test.* You can use [`t.teardown()`](./02-execution-context.md#tteardownfn) to undo side-effects *within* a particular test. Or use [`registerCompletionHandler()`](./08-common-pitfalls.md#timeouts-because-a-file-failed-to-exit) to run cleanup code after AVA has completed its work.
@@ -211,6 +215,10 @@ test.after.always('guaranteed cleanup', t => {
 	// This will always run, regardless of earlier failures
 });
 
+test.cleanup('reset global state', t => {
+	// This runs before all tests and again after tests and other hooks complete
+});
+
 test.beforeEach(t => {
 	// This runs before each test
 });
@@ -221,6 +229,10 @@ test.afterEach(t => {
 
 test.afterEach.always(t => {
 	// This runs after each test and other test hooks, even if they failed
+});
+
+test.cleanupEach(t => {
+	// This runs before each test and again after that test and its hooks complete
 });
 
 test('title', t => {

--- a/docs/01-writing-tests.md
+++ b/docs/01-writing-tests.md
@@ -180,7 +180,7 @@ AVA lets you register hooks that are run before and after your tests. This allow
 
 Use `test.cleanup()` to register the same hook before all tests and after all tests have completed. This is shorthand for pairing `test.before()` with `test.after.always()`. Use `test.cleanupEach()` to run cleanup before each test and after each test has completed, equivalent to pairing `test.beforeEach()` with `test.afterEach.always()`.
 
-These helpers are also available as `test.serial.cleanup()` and `test.serial.cleanupEach()` when the paired hooks should run serially.
+These helpers are also available as `test.serial.cleanup()` and `test.serial.cleanupEach()` when the paired hooks should run serially. Use `test.cleanup.skip()` or `test.cleanupEach.skip()` to declare a skipped cleanup pair.
 
 If a test is skipped with the `.skip` modifier, the respective `.beforeEach()`, `.afterEach()` and `.afterEach.always()` hooks are not run. Likewise, if all tests in a test file are skipped `.before()`, `.after()` and `.after.always()` hooks for the file are not run.
 

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -118,14 +118,15 @@ function createHookChain(hook, isAfterHook) {
 	return hook;
 }
 
-function createCleanupChain(name, call, defaults, beforeType, afterType) {
-	const fn = (...args) => {
-		call({...defaults, type: beforeType}, args);
-		call({...defaults, type: afterType, always: true}, args);
-	};
-
-	Object.defineProperty(fn, 'name', {value: name});
-	return fn;
+function createCleanupChain(name, call, defaults, suffix = '') {
+	const beforeType = `before${suffix}`;
+	const afterType = `after${suffix}`;
+	const cleanup = startChain(name, (metadata, args) => {
+		call({...metadata, type: beforeType}, [...args]);
+		call({...metadata, type: afterType, always: true}, [...args]);
+	}, defaults);
+	extendChain(cleanup, 'skip', 'skipped');
+	return cleanup;
 }
 
 export default function createChain(fn, defaults, meta) {
@@ -156,15 +157,15 @@ export default function createChain(fn, defaults, meta) {
 	root.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, type: 'afterEach'}), true);
 	root.before = createHookChain(startChain('test.before', fn, {...defaults, type: 'before'}), false);
 	root.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, type: 'beforeEach'}), false);
-	root.cleanup = createCleanupChain('test.cleanup', fn, defaults, 'before', 'after');
-	root.cleanupEach = createCleanupChain('test.cleanupEach', fn, defaults, 'beforeEach', 'afterEach');
+	root.cleanup = createCleanupChain('test.cleanup', fn, defaults);
+	root.cleanupEach = createCleanupChain('test.cleanupEach', fn, defaults, 'Each');
 
 	root.serial.after = createHookChain(startChain('test.after', fn, {...defaults, serial: true, type: 'after'}), true);
 	root.serial.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, serial: true, type: 'afterEach'}), true);
 	root.serial.before = createHookChain(startChain('test.before', fn, {...defaults, serial: true, type: 'before'}), false);
 	root.serial.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, serial: true, type: 'beforeEach'}), false);
-	root.serial.cleanup = createCleanupChain('test.serial.cleanup', fn, {...defaults, serial: true}, 'before', 'after');
-	root.serial.cleanupEach = createCleanupChain('test.serial.cleanupEach', fn, {...defaults, serial: true}, 'beforeEach', 'afterEach');
+	root.serial.cleanup = createCleanupChain('test.serial.cleanup', fn, {...defaults, serial: true});
+	root.serial.cleanupEach = createCleanupChain('test.serial.cleanupEach', fn, {...defaults, serial: true}, 'Each');
 
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.

--- a/lib/create-chain.js
+++ b/lib/create-chain.js
@@ -118,6 +118,16 @@ function createHookChain(hook, isAfterHook) {
 	return hook;
 }
 
+function createCleanupChain(name, call, defaults, beforeType, afterType) {
+	const fn = (...args) => {
+		call({...defaults, type: beforeType}, args);
+		call({...defaults, type: afterType, always: true}, args);
+	};
+
+	Object.defineProperty(fn, 'name', {value: name});
+	return fn;
+}
+
 export default function createChain(fn, defaults, meta) {
 	// Test chaining rules:
 	// * `serial` must come at the start
@@ -146,11 +156,15 @@ export default function createChain(fn, defaults, meta) {
 	root.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, type: 'afterEach'}), true);
 	root.before = createHookChain(startChain('test.before', fn, {...defaults, type: 'before'}), false);
 	root.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, type: 'beforeEach'}), false);
+	root.cleanup = createCleanupChain('test.cleanup', fn, defaults, 'before', 'after');
+	root.cleanupEach = createCleanupChain('test.cleanupEach', fn, defaults, 'beforeEach', 'afterEach');
 
 	root.serial.after = createHookChain(startChain('test.after', fn, {...defaults, serial: true, type: 'after'}), true);
 	root.serial.afterEach = createHookChain(startChain('test.afterEach', fn, {...defaults, serial: true, type: 'afterEach'}), true);
 	root.serial.before = createHookChain(startChain('test.before', fn, {...defaults, serial: true, type: 'before'}), false);
 	root.serial.beforeEach = createHookChain(startChain('test.beforeEach', fn, {...defaults, serial: true, type: 'beforeEach'}), false);
+	root.serial.cleanup = createCleanupChain('test.serial.cleanup', fn, {...defaults, serial: true}, 'before', 'after');
+	root.serial.cleanupEach = createCleanupChain('test.serial.cleanupEach', fn, {...defaults, serial: true}, 'beforeEach', 'afterEach');
 
 	// "todo" tests cannot be chained. Allow todo tests to be flagged as needing
 	// to be serial.

--- a/test-tap/hooks.js
+++ b/test-tap/hooks.js
@@ -117,6 +117,42 @@ test('after.always run even if before failed', t => {
 	});
 });
 
+test('cleanup runs before and after even if the test fails', t => {
+	t.plan(1);
+
+	const array = [];
+	return promiseEnd(new Runner({file: import.meta.url}), runner => {
+		runner.chain.cleanup(() => {
+			array.push('cleanup');
+		});
+
+		runner.chain('test', () => {
+			array.push('test');
+			throw new Error('something went wrong');
+		});
+	}).then(() => {
+		t.strictSame(array, ['cleanup', 'test', 'cleanup']);
+	});
+});
+
+test('cleanup.skip skips both hooks', t => {
+	t.plan(1);
+
+	const array = [];
+	return promiseEnd(new Runner({file: import.meta.url}), runner => {
+		runner.chain.cleanup.skip(() => {
+			array.push('cleanup');
+		});
+
+		runner.chain('test', a => {
+			a.pass();
+			array.push('test');
+		});
+	}).then(() => {
+		t.strictSame(array, ['test']);
+	});
+});
+
 test('stop if before hooks failed', t => {
 	t.plan(1);
 
@@ -366,6 +402,36 @@ test('afterEach.always run even if beforeEach failed', t => {
 		});
 	}).then(() => {
 		t.strictSame(array, ['b']);
+	});
+});
+
+test('cleanupEach runs around passing and failing tests', t => {
+	t.plan(1);
+
+	const array = [];
+	return promiseEnd(new Runner({file: import.meta.url}), runner => {
+		runner.chain.cleanupEach(() => {
+			array.push('cleanup');
+		});
+
+		runner.chain.serial('pass', a => {
+			a.pass();
+			array.push('pass');
+		});
+
+		runner.chain.serial('fail', () => {
+			array.push('fail');
+			throw new Error('something went wrong');
+		});
+	}).then(() => {
+		t.strictSame(array, [
+			'cleanup',
+			'pass',
+			'cleanup',
+			'cleanup',
+			'fail',
+			'cleanup',
+		]);
 	});
 });
 

--- a/test-tap/reporters/tap.edgecases.v26.log
+++ b/test-tap/reporters/tap.edgecases.v26.log
@@ -4,7 +4,7 @@ not ok 1 - SyntaxError: Unexpected token 'do'
   ---
     name: SyntaxError
     message: Unexpected token 'do'
-    at: 'compileSourceTextModule (node:internal/modules/esm/utils:354:16)'
+    at: 'compileSourceTextModule (node:internal/modules/esm/utils:355:16)'
   ...
 ---tty-stream-chunk-separator
 not ok 2 - ast-syntax-error.js exited with a non-zero exit code: 1

--- a/test-types/module/conditional-chains.ts
+++ b/test-types/module/conditional-chains.ts
@@ -5,6 +5,15 @@ anyTest.skipIf(true).beforeEach(() => {});
 anyTest.runIf(false).afterEach(() => {});
 anyTest.skipIf(true).serial.before(() => {});
 anyTest.serial.runIf(true).after(() => {});
+anyTest.skipIf(true).cleanup(() => {});
+anyTest.runIf(false).cleanupEach(() => {});
+anyTest.serial.skipIf(true).cleanup(() => {});
+anyTest.serial.runIf(false).cleanupEach(() => {});
+
+anyTest.cleanup.skip(() => {});
+anyTest.cleanupEach.skip(() => {});
+anyTest.serial.cleanup.skip(() => {});
+anyTest.serial.cleanupEach.skip(() => {});
 
 anyTest.skipIf(true).todo('skipIf todo should be allowed');
 anyTest.runIf(false).todo('runIf todo should be allowed');

--- a/test/create-chain/test.js
+++ b/test/create-chain/test.js
@@ -245,3 +245,50 @@ test('skipIf(false).runIf(true) does not skip', t => {
 	t.is(calls.length, 1);
 	t.is(calls[0].metadata.skipped, undefined);
 });
+
+test('cleanup() registers before and after.always hooks', t => {
+	const {calls, chain} = createTestChain();
+	const implementation = () => {};
+
+	chain.cleanup('reset state', implementation, 'argument');
+
+	t.is(calls.length, 2);
+	t.is(calls[0].metadata.type, 'before');
+	t.is(calls[0].metadata.always, undefined);
+	t.deepEqual(calls[0].arguments_, ['reset state', implementation, 'argument']);
+	t.is(calls[1].metadata.type, 'after');
+	t.true(calls[1].metadata.always);
+	t.deepEqual(calls[1].arguments_, ['reset state', implementation, 'argument']);
+});
+
+test('cleanupEach() registers beforeEach and afterEach.always hooks', t => {
+	const {calls, chain} = createTestChain();
+	const implementation = () => {};
+
+	chain.cleanupEach(implementation, 'argument');
+
+	t.is(calls.length, 2);
+	t.is(calls[0].metadata.type, 'beforeEach');
+	t.is(calls[0].metadata.always, undefined);
+	t.deepEqual(calls[0].arguments_, [implementation, 'argument']);
+	t.is(calls[1].metadata.type, 'afterEach');
+	t.true(calls[1].metadata.always);
+	t.deepEqual(calls[1].arguments_, [implementation, 'argument']);
+});
+
+test('serial cleanup helpers preserve serial metadata', t => {
+	const {calls, chain} = createTestChain();
+	const implementation = () => {};
+
+	chain.serial.cleanup('reset state', implementation);
+	chain.serial.cleanupEach('reset state per test', implementation);
+
+	t.is(calls.length, 4);
+	t.true(calls.every(({metadata}) => metadata.serial));
+	t.deepEqual(calls.map(({metadata}) => [metadata.type, metadata.always]), [
+		['before', undefined],
+		['after', true],
+		['beforeEach', undefined],
+		['afterEach', true],
+	]);
+});

--- a/test/create-chain/test.js
+++ b/test/create-chain/test.js
@@ -276,6 +276,20 @@ test('cleanupEach() registers beforeEach and afterEach.always hooks', t => {
 	t.deepEqual(calls[1].arguments_, [implementation, 'argument']);
 });
 
+test('cleanup.skip() skips both hooks', t => {
+	const {calls, chain} = createTestChain();
+	const implementation = () => {};
+
+	chain.cleanup.skip('reset state', implementation);
+
+	t.is(calls.length, 2);
+	t.true(calls.every(({metadata}) => metadata.skipped));
+	t.deepEqual(calls.map(({metadata}) => [metadata.type, metadata.always]), [
+		['before', undefined],
+		['after', true],
+	]);
+});
+
 test('serial cleanup helpers preserve serial metadata', t => {
 	const {calls, chain} = createTestChain();
 	const implementation = () => {};
@@ -289,6 +303,22 @@ test('serial cleanup helpers preserve serial metadata', t => {
 		['before', undefined],
 		['after', true],
 		['beforeEach', undefined],
+		['afterEach', true],
+	]);
+});
+
+test('conditional chains preserve cleanup helper access', t => {
+	const {calls, chain} = createTestChain();
+	const implementation = () => {};
+
+	chain.skipIf(true).cleanup(implementation);
+	chain.serial.runIf(false).cleanupEach(implementation);
+
+	t.is(calls.length, 4);
+	t.deepEqual(calls.map(({metadata}) => [metadata.type, metadata.serial]), [
+		['before', undefined],
+		['after', undefined],
+		['beforeEach', true],
 		['afterEach', true],
 	]);
 });

--- a/types/test-fn.d.ts
+++ b/types/test-fn.d.ts
@@ -87,6 +87,10 @@ export type TestFn<Context = unknown> = {
 	afterEach: AfterFn<Context>;
 	before: BeforeFn<Context>;
 	beforeEach: BeforeFn<Context>;
+	/** Declare a cleanup hook that runs before and after all tests. */
+	cleanup: CleanupFn<Context>;
+	/** Declare a cleanup hook that runs before and after each test. */
+	cleanupEach: CleanupFn<Context>;
 	failing: FailingFn<Context>;
 	macro: MacroFn<Context>;
 	meta: Meta;
@@ -150,6 +154,18 @@ export type BeforeFn<Context = unknown> = {
 	skip: HookSkipFn<Context>;
 };
 
+export type CleanupFn<Context = unknown> = {
+	/**
+	 * Declare a cleanup hook pair. Additional arguments are passed to the implementation or macro.
+	 */
+	<Args extends unknown[]>(title: string, implementation: Implementation<Args, Context>, ...args: Args): void;
+
+	/**
+	 * Declare a cleanup hook pair. Additional arguments are passed to the implementation or macro.
+	 */
+	<Args extends unknown[]>(implementation: Implementation<Args, Context>, ...args: Args): void;
+};
+
 export type FailingFn<Context = unknown> = {
 	/**
 	 * Declare a concurrent test that is expected to fail.
@@ -209,6 +225,10 @@ export type SerialFn<Context = unknown> = {
 	afterEach: AfterFn<Context>;
 	before: BeforeFn<Context>;
 	beforeEach: BeforeFn<Context>;
+	/** Declare a cleanup hook that runs before and after all tests. */
+	cleanup: CleanupFn<Context>;
+	/** Declare a cleanup hook that runs before and after each test. */
+	cleanupEach: CleanupFn<Context>;
 	failing: FailingFn<Context>;
 	only: OnlyFn<Context>;
 	/** Declare a test that only runs when `condition` is true; otherwise the test is skipped. */

--- a/types/test-fn.d.ts
+++ b/types/test-fn.d.ts
@@ -164,6 +164,8 @@ export type CleanupFn<Context = unknown> = {
 	 * Declare a cleanup hook pair. Additional arguments are passed to the implementation or macro.
 	 */
 	<Args extends unknown[]>(implementation: Implementation<Args, Context>, ...args: Args): void;
+
+	skip: HookSkipFn<Context>;
 };
 
 export type FailingFn<Context = unknown> = {


### PR DESCRIPTION
Fixes #928

## Summary

- Add `test.cleanup()` and `test.cleanupEach()` as paired setup and guaranteed-cleanup hooks.
- Add serial and `.skip()` variants while preserving conditional-chain access.
- Register the helpers through the existing AVA hook machinery, so no runner-specific task type is needed.
- Clone declaration arguments for each paired registration because argument parsing consumes its input array.
- Document the public API and cover metadata, runtime order, failure paths, skipped pairs, and TypeScript declarations.
- Refresh the Node 26 TAP edge-case snapshot for Node 26.5.0 internal line-number output.

## Validation

Run locally:

- Node.js 24.12: `npx test-ava test/create-chain/test.js` - 25 passed
- Node.js 24.12: `npx tap test-tap/hooks.js` - 32 passed
- Node.js 26.5.0: `npx tap test-tap/reporters/tap.js` - 5 passed
- `npx tsc --noEmit` - passed
- `npx xo` - passed (10 existing TODO/FIXME warnings)

A complete `npm test` run passed lint, TypeScript, and all 217 core tests (2 skipped). The broader TAP run passed 1,625/1,628 assertions; the only three failures were existing Node 24 default-reporter snapshot mismatches, reproduced unchanged on `upstream/main`.

## Bounty

IssueHunt funded amount: $82. Payout GitHub user: @jamilahmadzai.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#928: Make it easier to write reliable cleanup tasks](https://oss.issuehunt.io/repos/26820798/issues/928)
---
</details>
<!-- /Issuehunt content-->