### PR TITLE
Add related test selection

### DIFF
--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -35,6 +35,8 @@ Options:
   -m, --match              Only run tests with matching title (can be repeated)
                                                                         [string]
       --no-worker-threads  Don't use worker threads                    [boolean]
+      --find-related-tests Treat provided paths as changed source files and run
+                           related tests                               [boolean]
       --node-arguments     Additional Node.js arguments for launching worker
                            processes (specify as a single string)       [string]
   -s, --serial             Run tests serially                          [boolean]
@@ -79,6 +81,16 @@ Files inside `node_modules` are *always* ignored. So are files starting with `_`
 * `**/tests/**/fixtures/**/*`
 
 When using `npm test`, you can pass positional arguments directly `npm test test2.js`, but flags needs to be passed like `npm test -- --verbose`.
+
+## Running tests related to changed files
+
+Use the `--find-related-tests` flag to treat positional arguments as changed source files instead of test file filters. AVA traces the configured test files and runs those that depend on the provided files:
+
+```console
+npx ava --find-related-tests src/index.js src/api.js
+```
+
+Changed test files are run directly. If AVA cannot determine which tests depend on a changed file, it runs all configured tests. This matches watch mode's conservative behavior.
 
 ## Running tests with matching titles
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -150,7 +150,7 @@ export default class Api extends Emittery {
 		try {
 			testFiles = await globs.findTests({cwd: this.options.projectDir, ...apiOptions.globs});
 			if (typeof testFileSelector === 'function') {
-				selectedFiles = testFileSelector(testFiles, selectedFiles);
+				selectedFiles = await testFileSelector(testFiles, selectedFiles);
 			} else if (selectedFiles.length === 0) {
 				selectedFiles = filter.length === 0
 					? testFiles

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -49,6 +49,11 @@ const FLAGS = {
 		description: 'Don\'t use worker threads',
 		type: 'boolean',
 	},
+	'find-related-tests': {
+		coerce: coerceLastValue,
+		description: 'Treat provided paths as changed source files and run related tests',
+		type: 'boolean',
+	},
 	'node-arguments': {
 		coerce: coerceLastValue,
 		description: 'Additional Node.js arguments for launching worker processes (specify as a single string)',
@@ -290,6 +295,10 @@ export default async function loadCli() { // eslint-disable-line complexity
 			exit('The TAP reporter is not available when using watch mode.');
 		}
 
+		if (combined['find-related-tests']) {
+			exit('The --find-related-tests flag is not available when using watch mode.');
+		}
+
 		if (isCi) {
 			exit('Watch mode is not available in CI, as it prevents AVA from terminating.');
 		}
@@ -302,6 +311,10 @@ export default async function loadCli() { // eslint-disable-line complexity
 	if (debug !== null) {
 		if (argv.tap && !conf.tap) {
 			exit('The TAP reporter is not available when debugging.');
+		}
+
+		if (combined['find-related-tests']) {
+			exit('The --find-related-tests flag is not available when debugging.');
 		}
 
 		if (isCi) {
@@ -403,6 +416,26 @@ export default async function loadCli() { // eslint-disable-line complexity
 			pattern: normalizePattern(path.relative(projectDir, path.resolve(process.cwd(), pattern))),
 			...rest,
 		}));
+
+	let testFileSelector;
+	if (combined['find-related-tests']) {
+		if (input.length === 0) {
+			exit('The --find-related-tests flag requires at least one changed source file path.');
+		}
+
+		if (filter.some(({lineNumbers}) => lineNumbers !== null)) {
+			exit('Line numbers cannot be used with the --find-related-tests flag.');
+		}
+
+		const {selectTestsRelatedToChangedFiles} = await import('./watcher.js');
+		const changedFiles = filter.map(({pattern}) => pattern);
+		testFileSelector = testFiles => selectTestsRelatedToChangedFiles({
+			changedFiles,
+			globs,
+			projectDir,
+			testFiles,
+		});
+	}
 
 	const api = new Api({
 		cacheEnabled: combined.cache !== false,
@@ -523,7 +556,7 @@ export default async function loadCli() { // eslint-disable-line complexity
 			}
 		});
 
-		const runStatus = await api.run({filter});
+		const runStatus = await api.run({filter, testFileSelector});
 
 		if (debugWithoutSpecificFile && !debug.active) {
 			exit('Provide the path to the test file you wish to debug');

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -703,6 +703,49 @@ class Tree extends Map {
 	}
 }
 
+export async function selectTestsRelatedToChangedFiles({changedFiles, globs, projectDir, testFiles}) {
+	const relativeTestFiles = new Map(testFiles.map(file => [nodePath.relative(projectDir, file), file]));
+	const fileTracer = new FileTracer({base: projectDir});
+	fileTracer.update(testFiles.map(file => ({
+		path: nodePath.relative(projectDir, file),
+		isTest: true,
+		exists: true,
+	})));
+
+	await fileTracer.busy;
+
+	const cwdAndGlobs = {cwd: projectDir, ...globs};
+	const selected = new Set();
+	for (const file of changedFiles) {
+		const path = nodePath.relative(projectDir, nodePath.resolve(projectDir, file));
+		const {isTest} = classify(path, cwdAndGlobs);
+
+		if (isTest) {
+			if (!relativeTestFiles.has(path)) {
+				return testFiles;
+			}
+
+			selected.add(path);
+			continue;
+		}
+
+		if (!fileTracer.has(path)) {
+			return testFiles;
+		}
+
+		const dependingTestFiles = fileTracer.traceToTestFile(path);
+		if (dependingTestFiles.length === 0) {
+			return testFiles;
+		}
+
+		for (const testFile of dependingTestFiles) {
+			selected.add(testFile);
+		}
+	}
+
+	return testFiles.filter(file => selected.has(nodePath.relative(projectDir, file)));
+}
+
 // Track file dependencies to determine which test files to run.
 class FileTracer {
 	#base;

--- a/test/related-tests/fixtures/basic/other.js
+++ b/test/related-tests/fixtures/basic/other.js
@@ -1,0 +1,1 @@
+export default 'other';

--- a/test/related-tests/fixtures/basic/other.test.js
+++ b/test/related-tests/fixtures/basic/other.test.js
@@ -1,0 +1,7 @@
+import other from './other.js';
+
+const {default: test} = await import(process.env.TEST_AVA_IMPORT_FROM);
+
+test('other', t => {
+	t.is(other, 'other');
+});

--- a/test/related-tests/fixtures/basic/package.json
+++ b/test/related-tests/fixtures/basic/package.json
@@ -1,0 +1,8 @@
+{
+	"type": "module",
+	"ava": {
+		"files": [
+			"*.test.js"
+		]
+	}
+}

--- a/test/related-tests/fixtures/basic/source.js
+++ b/test/related-tests/fixtures/basic/source.js
@@ -1,0 +1,1 @@
+export default 'source';

--- a/test/related-tests/fixtures/basic/source.test.js
+++ b/test/related-tests/fixtures/basic/source.test.js
@@ -1,0 +1,7 @@
+import source from './source.js';
+
+const {default: test} = await import(process.env.TEST_AVA_IMPORT_FROM);
+
+test('source', t => {
+	t.is(source, 'source');
+});

--- a/test/related-tests/fixtures/basic/unrelated.js
+++ b/test/related-tests/fixtures/basic/unrelated.js
@@ -1,0 +1,1 @@
+export default 'unrelated';

--- a/test/related-tests/test.js
+++ b/test/related-tests/test.js
@@ -1,0 +1,62 @@
+import {fileURLToPath} from 'node:url';
+
+import test from '@ava/test';
+
+import {cleanOutput, fixture} from '../helpers/exec.js';
+
+const fixtureDir = fileURLToPath(new URL('fixtures/basic', import.meta.url));
+
+test('runs tests related to a changed source file', async t => {
+	const result = await fixture(['--find-related-tests', 'source.js'], {cwd: fixtureDir});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('runs tests related to an absolute changed source file path', async t => {
+	const sourceFile = fileURLToPath(new URL('fixtures/basic/source.js', import.meta.url));
+	const result = await fixture(['--find-related-tests', sourceFile], {cwd: fixtureDir});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('runs tests related to multiple changed source files', async t => {
+	const result = await fixture(['--find-related-tests', 'source.js', 'other.js'], {cwd: fixtureDir});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'other.test.js', title: 'other'},
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('runs changed test files directly', async t => {
+	const result = await fixture(['--find-related-tests', 'source.test.js'], {cwd: fixtureDir});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('runs all tests when a changed file is not in the dependency graph', async t => {
+	const result = await fixture(['--find-related-tests', 'unrelated.js'], {cwd: fixtureDir});
+
+	t.deepEqual(result.stats.passed, [
+		{file: 'other.test.js', title: 'other'},
+		{file: 'source.test.js', title: 'source'},
+	]);
+});
+
+test('requires at least one changed source file path', async t => {
+	const result = await t.throwsAsync(fixture(['--find-related-tests'], {cwd: fixtureDir}));
+
+	t.regex(cleanOutput(result.stderr), /requires at least one changed source file path/);
+});
+
+test('rejects line numbers', async t => {
+	const result = await t.throwsAsync(fixture(['--find-related-tests', 'source.js:1'], {cwd: fixtureDir}));
+
+	t.regex(cleanOutput(result.stderr), /Line numbers cannot be used with the --find-related-tests flag/);
+});


### PR DESCRIPTION
Fixes #1986.

IssueHunt bounty: https://issuehunt.io/repos/26820798/issues/1986

## Summary
- add `--find-related-tests` so positional paths can be treated as changed source files for lint-staged / Jest-like workflows
- reuse AVA's existing watch-mode dependency tracer to select test files that depend on changed source files
- run changed test files directly and conservatively run all configured tests when AVA cannot determine the dependency relationship
- document the new command-line mode and cover source, test, absolute-path, multi-file, and error cases with fixtures

## Verification
- `npx test-ava test/related-tests/test.js`
- `npx test-ava test/watch-mode/scenarios.js`
- `npx tap test-tap/integration/assorted.js test-tap/integration/debug.js`
- `npx tap test-tap/globs.js`
- `npx xo` (exits 0; existing TODO/FIXME warnings only)
- `npx tsc --noEmit`
- `git diff --check`
- `npm test`

## Bounty criteria
This PR implements the requested ability to pass changed source files and have AVA determine the related test files to run. It is submitted for the IssueHunt-funded issue above.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1986: Analyze source & test dependencies to figure out which tests to run (first)](https://oss.issuehunt.io/repos/26820798/issues/1986)
---
</details>
<!-- /Issuehunt content-->