### PR TITLE
fix: improve throws no-throw message

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -438,7 +438,7 @@ export class Assertions {
 			if (!threw) {
 				throw fail(new AssertionError(message, {
 					assertion: 't.throws()',
-					formattedDetails: [formatWithLabel('Function returned:', retval)],
+					formattedDetails: [formatWithLabel('Function did not throw, instead returned:', retval)],
 				}));
 			}
 

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -839,13 +839,13 @@ test('.throws()', gather(t => {
 	failsWith(t, () => assertions.throws(() => {}), {
 		assertion: 't.throws()',
 		message: '',
-		formattedDetails: [{label: 'Function returned:', formatted: /undefined/}],
+		formattedDetails: [{label: 'Function did not throw, instead returned:', formatted: /undefined/}],
 	});
 
 	failsWith(t, () => assertions.throws(() => {}), {
 		assertion: 't.throws()',
 		message: '',
-		formattedDetails: [{label: 'Function returned:', formatted: /undefined/}],
+		formattedDetails: [{label: 'Function did not throw, instead returned:', formatted: /undefined/}],
 	});
 
 	// Fails because function doesn't throw. Asserts that 'my message' is used
@@ -853,7 +853,7 @@ test('.throws()', gather(t => {
 	failsWith(t, () => assertions.throws(() => {}, undefined, 'my message'), {
 		assertion: 't.throws()',
 		message: 'my message',
-		formattedDetails: [{label: 'Function returned:', formatted: /undefined/}],
+		formattedDetails: [{label: 'Function did not throw, instead returned:', formatted: /undefined/}],
 	});
 
 	// Fails because the function returned a promise.

--- a/test/assertions/fixtures/throws-no-error.js
+++ b/test/assertions/fixtures/throws-no-error.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('throws without throwing', t => {
+	t.throws(() => {});
+});

--- a/test/assertions/test.js
+++ b/test/assertions/test.js
@@ -13,6 +13,13 @@ test('throws requires native errors', async t => {
 	t.snapshot(result.stats.failed.map(({title}) => title), 'failed tests');
 });
 
+test('throws explains when the function did not throw', async t => {
+	const result = await t.throwsAsync(fixture(['throws-no-error.js']));
+	const [failed] = result.stats.failed;
+	const error = result.stats.getError(failed);
+	t.is(error.formattedDetails[0].label, 'Function did not throw, instead returned:');
+});
+
 test('throwsAsync requires native errors', async t => {
 	const result = await t.throwsAsync(fixture(['throws-async.js']));
 	t.snapshot(result.stats.passed.map(({title}) => title), 'passed tests');


### PR DESCRIPTION
## Summary
- Tweaks the `t.throws()` failure detail when the function returns instead of throwing.
- Adds a fixture and assertion test for the updated label.

Fixes #3361

## Verification
- `node node_modules/@ava/test/cli.js test/assertions/test.js` using Node 24.14.0
- `node node_modules/xo/dist/cli.js lib/assert.js test/assertions/test.js test/assertions/fixtures/throws-no-error.js` using Node 24.14.0

Note: On this Windows checkout I created a local ignored junction under the assertions fixture so `import 'ava'` resolves like the repository symlink setup expects.