### PR TITLE
[codex] Add assertion diff legend

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -7,13 +7,19 @@ import concordanceOptions from './concordance-options.js';
 import {CIRCULAR_SELECTOR, isLikeSelector, selectComparable} from './like-selector.js';
 import {SnapshotError, VersionMismatchError} from './snapshot-manager.js';
 
-function formatDescriptorDiff(actualDescriptor, expectedDescriptor, options) {
+function formatDescriptorDiff(actualDescriptor, expectedDescriptor, {expectedLabel = 'Expected', ...options} = {}) {
 	options = {...options, ...concordanceOptions};
 	const {diffGutters} = options.theme;
 	const {insertLine, deleteLine} = options.theme.string.diff;
+	const formatted = concordance.diffDescriptors(actualDescriptor, expectedDescriptor, options);
 	return {
-		label: `Difference (${diffGutters.actual}${deleteLine.open}actual${deleteLine.close}, ${diffGutters.expected}${insertLine.open}expected${insertLine.close}):`,
-		formatted: concordance.diffDescriptors(actualDescriptor, expectedDescriptor, options),
+		label: 'Difference:',
+		formatted: [
+			`${diffGutters.actual}${deleteLine.open}Received${deleteLine.close}`,
+			`${diffGutters.expected}${insertLine.open}${expectedLabel}${insertLine.close}`,
+			'',
+			formatted,
+		].join('\n'),
 	};
 }
 
@@ -674,7 +680,7 @@ export class Assertions {
 			if (result.actual) {
 				throw fail(new AssertionError(message ?? 'Did not match snapshot', {
 					assertion: 't.snapshot()',
-					formattedDetails: [formatDescriptorDiff(result.actual, result.expected, {invert: true})],
+					formattedDetails: [formatDescriptorDiff(result.actual, result.expected, {expectedLabel: 'Snapshot', invert: true})],
 				}));
 			} else {
 				// This can only occur in CI environments.

--- a/test-tap/assert.js
+++ b/test-tap/assert.js
@@ -320,7 +320,7 @@ test('.is()', t => {
 		assertion: 't.is()',
 		message: '',
 		formattedDetails: [
-			{label: 'Difference (- actual, + expected):', formatted: /- 'foo'\n\+ 'bar'/},
+			{label: 'Difference:', formatted: /- 'foo'\n\+ 'bar'/},
 		],
 	});
 
@@ -330,7 +330,7 @@ test('.is()', t => {
 		expected: 42,
 		message: '',
 		formattedDetails: [
-			{label: 'Difference (- actual, + expected):', formatted: /- 'foo'\n\+ 42/},
+			{label: 'Difference:', formatted: /- 'foo'\n\+ 42/},
 		],
 	});
 
@@ -338,7 +338,7 @@ test('.is()', t => {
 		assertion: 't.is()',
 		message: 'my message',
 		formattedDetails: [
-			{label: 'Difference (- actual, + expected):', formatted: /- 'foo'\n\+ 42/},
+			{label: 'Difference:', formatted: /- 'foo'\n\+ 42/},
 		],
 	});
 
@@ -346,7 +346,7 @@ test('.is()', t => {
 		assertion: 't.is()',
 		message: 'my message',
 		formattedDetails: [
-			{label: 'Difference (- actual, + expected):', formatted: /- 0\n\+ -0/},
+			{label: 'Difference:', formatted: /- 0\n\+ -0/},
 		],
 	});
 
@@ -354,7 +354,7 @@ test('.is()', t => {
 		assertion: 't.is()',
 		message: 'my message',
 		formattedDetails: [
-			{label: 'Difference (- actual, + expected):', formatted: /- -0\n\+ 0/},
+			{label: 'Difference:', formatted: /- -0\n\+ 0/},
 		],
 	});
 
@@ -580,19 +580,19 @@ test('.deepEqual()', t => {
 	failsWith(t, () => assertions.deepEqual('foo', 'bar'), {
 		assertion: 't.deepEqual()',
 		message: '',
-		formattedDetails: [{label: 'Difference (- actual, + expected):', formatted: /- 'foo'\n\+ 'bar'/}],
+		formattedDetails: [{label: 'Difference:', formatted: /- 'foo'\n\+ 'bar'/}],
 	});
 
 	failsWith(t, () => assertions.deepEqual('foo', 42), {
 		assertion: 't.deepEqual()',
 		message: '',
-		formattedDetails: [{label: 'Difference (- actual, + expected):', formatted: /- 'foo'\n\+ 42/}],
+		formattedDetails: [{label: 'Difference:', formatted: /- 'foo'\n\+ 42/}],
 	});
 
 	failsWith(t, () => assertions.deepEqual('foo', 42, 'my message'), {
 		assertion: 't.deepEqual()',
 		message: 'my message',
-		formattedDetails: [{label: 'Difference (- actual, + expected):', formatted: /- 'foo'\n\+ 42/}],
+		formattedDetails: [{label: 'Difference:', formatted: /- 'foo'\n\+ 42/}],
 	});
 
 	failsWith(t, () => assertions.deepEqual({}, {}, null), {
@@ -814,7 +814,7 @@ test('.like()', t => {
 	failsWith(t, () => assertions.like({a: 'foo', b: 'irrelevant'}, {a: 'bar'}), {
 		assertion: 't.like()',
 		message: '',
-		formattedDetails: [{label: 'Difference (- actual, + expected):', formatted: /{\n-\s*a: 'foo',\n\+\s*a: 'bar',\n\s*}/}],
+		formattedDetails: [{label: 'Difference:', formatted: /{\n-\s*a: 'foo',\n\+\s*a: 'bar',\n\s*}/}],
 	});
 
 	passes(t, () => assertions.like({a: [{a: 1, b: 2}]}, {a: [{a: 1}]}));
@@ -1520,7 +1520,7 @@ test('.snapshot()', async t => {
 		failsWith(t, () => assertions.snapshot({foo: 'not bar'}), {
 			assertion: 't.snapshot()',
 			message: 'Did not match snapshot',
-			formattedDetails: [{label: 'Difference (- actual, + expected):', formatted: '  {\n-   foo: \'not bar\',\n+   foo: \'bar\',\n  }'}],
+			formattedDetails: [{label: 'Difference:', formatted: '- Received\n+ Snapshot\n\n  {\n-   foo: \'not bar\',\n+   foo: \'bar\',\n  }'}],
 		});
 	}
 
@@ -1533,7 +1533,7 @@ test('.snapshot()', async t => {
 		failsWith(t, () => assertions.snapshot({foo: 'not bar'}, 'my message'), {
 			assertion: 't.snapshot()',
 			message: 'my message',
-			formattedDetails: [{label: 'Difference (- actual, + expected):', formatted: '  {\n-   foo: \'not bar\',\n+   foo: \'bar\',\n  }'}],
+			formattedDetails: [{label: 'Difference:', formatted: '- Received\n+ Snapshot\n\n  {\n-   foo: \'not bar\',\n+   foo: \'bar\',\n  }'}],
 		});
 	}
 

--- a/test-tap/reporters/default.regular.v22.log
+++ b/test-tap/reporters/default.regular.v22.log
@@ -127,7 +127,10 @@
   [41m[1m 29:   t.deepEqual(exp, act);[22m[49m
    [90m30:[39m });                     
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
     [90m{[39m
       a: [90m{[39m
@@ -156,7 +159,10 @@
   [41m[1m 55:   t.like(actual, pattern);[22m[49m
    [90m56:[39m });                       
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
     [90m{[39m
       a: [90m{[39m
@@ -226,7 +232,10 @@
   [41m[1m 22:   t.deepEqual('foo', 'bar');[22m[49m
    [90m23:[39m });                         
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
   [31m-[39m [34m'[39m[31mfoo[39m[34m'[39m
   [32m+[39m [34m'[39m[32mbar[39m[34m'[39m

--- a/test-tap/reporters/default.regular.v24.log
+++ b/test-tap/reporters/default.regular.v24.log
@@ -127,7 +127,10 @@
   [41m[1m 29:   t.deepEqual(exp, act);[22m[49m
    [90m30:[39m });                     
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
     [90m{[39m
       a: [90m{[39m
@@ -156,7 +159,10 @@
   [41m[1m 55:   t.like(actual, pattern);[22m[49m
    [90m56:[39m });                       
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
     [90m{[39m
       a: [90m{[39m
@@ -226,7 +232,10 @@
   [41m[1m 22:   t.deepEqual('foo', 'bar');[22m[49m
    [90m23:[39m });                         
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
   [31m-[39m [34m'[39m[31mfoo[39m[34m'[39m
   [32m+[39m [34m'[39m[32mbar[39m[34m'[39m

--- a/test-tap/reporters/default.regular.v26.log
+++ b/test-tap/reporters/default.regular.v26.log
@@ -127,7 +127,10 @@
   [41m[1m 29:   t.deepEqual(exp, act);[22m[49m
    [90m30:[39m });                     
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
     [90m{[39m
       a: [90m{[39m
@@ -156,7 +159,10 @@
   [41m[1m 55:   t.like(actual, pattern);[22m[49m
    [90m56:[39m });                       
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
     [90m{[39m
       a: [90m{[39m
@@ -226,7 +232,10 @@
   [41m[1m 22:   t.deepEqual('foo', 'bar');[22m[49m
    [90m23:[39m });                         
 
-  Difference ([31m-[39m [31mactual[39m, [32m+[39m [32mexpected[39m):
+  Difference:
+
+  [31m-[39m [31mReceived[39m
+  [32m+[39m [32mExpected[39m
 
   [31m-[39m [34m'[39m[31mfoo[39m[34m'[39m
   [32m+[39m [34m'[39m[32mbar[39m[34m'[39m

--- a/test-tap/reporters/tap.regular.v22.log
+++ b/test-tap/reporters/tap.regular.v22.log
@@ -14,9 +14,10 @@ not ok 3 - nested-objects › format with max depth 4
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference:': |2-
+      'Difference:': |-
           - Received
           + Expected
+
           {
             a: {
               b: {
@@ -40,9 +41,10 @@ not ok 4 - nested-objects › format like with max depth 4
     name: AssertionError
     assertion: t.like()
     details:
-      'Difference:': |2-
+      'Difference:': |-
           - Received
           + Expected
+
           {
             a: {
               b: {
@@ -138,6 +140,7 @@ not ok 14 - test › formatted
       'Difference:': |-
         - Received
         + Expected
+
         - 'foo'
         + 'bar'
     message: ''

--- a/test-tap/reporters/tap.regular.v22.log
+++ b/test-tap/reporters/tap.regular.v22.log
@@ -14,7 +14,9 @@ not ok 3 - nested-objects › format with max depth 4
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference (- actual, + expected):': |2-
+      'Difference:': |2-
+          - Received
+          + Expected
           {
             a: {
               b: {
@@ -38,7 +40,9 @@ not ok 4 - nested-objects › format like with max depth 4
     name: AssertionError
     assertion: t.like()
     details:
-      'Difference (- actual, + expected):': |2-
+      'Difference:': |2-
+          - Received
+          + Expected
           {
             a: {
               b: {
@@ -131,7 +135,9 @@ not ok 14 - test › formatted
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference (- actual, + expected):': |-
+      'Difference:': |-
+        - Received
+        + Expected
         - 'foo'
         + 'bar'
     message: ''

--- a/test-tap/reporters/tap.regular.v22.log
+++ b/test-tap/reporters/tap.regular.v22.log
@@ -15,8 +15,8 @@ not ok 3 - nested-objects › format with max depth 4
     assertion: t.deepEqual()
     details:
       'Difference:': |-
-          - Received
-          + Expected
+        - Received
+        + Expected
 
           {
             a: {
@@ -42,8 +42,8 @@ not ok 4 - nested-objects › format like with max depth 4
     assertion: t.like()
     details:
       'Difference:': |-
-          - Received
-          + Expected
+        - Received
+        + Expected
 
           {
             a: {

--- a/test-tap/reporters/tap.regular.v24.log
+++ b/test-tap/reporters/tap.regular.v24.log
@@ -14,9 +14,10 @@ not ok 3 - nested-objects › format with max depth 4
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference:': |2-
+      'Difference:': |-
           - Received
           + Expected
+
           {
             a: {
               b: {
@@ -40,9 +41,10 @@ not ok 4 - nested-objects › format like with max depth 4
     name: AssertionError
     assertion: t.like()
     details:
-      'Difference:': |2-
+      'Difference:': |-
           - Received
           + Expected
+
           {
             a: {
               b: {
@@ -138,6 +140,7 @@ not ok 14 - test › formatted
       'Difference:': |-
         - Received
         + Expected
+
         - 'foo'
         + 'bar'
     message: ''

--- a/test-tap/reporters/tap.regular.v24.log
+++ b/test-tap/reporters/tap.regular.v24.log
@@ -14,7 +14,9 @@ not ok 3 - nested-objects › format with max depth 4
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference (- actual, + expected):': |2-
+      'Difference:': |2-
+          - Received
+          + Expected
           {
             a: {
               b: {
@@ -38,7 +40,9 @@ not ok 4 - nested-objects › format like with max depth 4
     name: AssertionError
     assertion: t.like()
     details:
-      'Difference (- actual, + expected):': |2-
+      'Difference:': |2-
+          - Received
+          + Expected
           {
             a: {
               b: {
@@ -131,7 +135,9 @@ not ok 14 - test › formatted
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference (- actual, + expected):': |-
+      'Difference:': |-
+        - Received
+        + Expected
         - 'foo'
         + 'bar'
     message: ''

--- a/test-tap/reporters/tap.regular.v24.log
+++ b/test-tap/reporters/tap.regular.v24.log
@@ -15,8 +15,8 @@ not ok 3 - nested-objects › format with max depth 4
     assertion: t.deepEqual()
     details:
       'Difference:': |-
-          - Received
-          + Expected
+        - Received
+        + Expected
 
           {
             a: {
@@ -42,8 +42,8 @@ not ok 4 - nested-objects › format like with max depth 4
     assertion: t.like()
     details:
       'Difference:': |-
-          - Received
-          + Expected
+        - Received
+        + Expected
 
           {
             a: {

--- a/test-tap/reporters/tap.regular.v26.log
+++ b/test-tap/reporters/tap.regular.v26.log
@@ -14,9 +14,10 @@ not ok 3 - nested-objects › format with max depth 4
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference:': |2-
+      'Difference:': |-
           - Received
           + Expected
+
           {
             a: {
               b: {
@@ -40,9 +41,10 @@ not ok 4 - nested-objects › format like with max depth 4
     name: AssertionError
     assertion: t.like()
     details:
-      'Difference:': |2-
+      'Difference:': |-
           - Received
           + Expected
+
           {
             a: {
               b: {
@@ -138,6 +140,7 @@ not ok 14 - test › formatted
       'Difference:': |-
         - Received
         + Expected
+
         - 'foo'
         + 'bar'
     message: ''

--- a/test-tap/reporters/tap.regular.v26.log
+++ b/test-tap/reporters/tap.regular.v26.log
@@ -14,7 +14,9 @@ not ok 3 - nested-objects › format with max depth 4
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference (- actual, + expected):': |2-
+      'Difference:': |2-
+          - Received
+          + Expected
           {
             a: {
               b: {
@@ -38,7 +40,9 @@ not ok 4 - nested-objects › format like with max depth 4
     name: AssertionError
     assertion: t.like()
     details:
-      'Difference (- actual, + expected):': |2-
+      'Difference:': |2-
+          - Received
+          + Expected
           {
             a: {
               b: {
@@ -131,7 +135,9 @@ not ok 14 - test › formatted
     name: AssertionError
     assertion: t.deepEqual()
     details:
-      'Difference (- actual, + expected):': |-
+      'Difference:': |-
+        - Received
+        + Expected
         - 'foo'
         + 'bar'
     message: ''

--- a/test-tap/reporters/tap.regular.v26.log
+++ b/test-tap/reporters/tap.regular.v26.log
@@ -15,8 +15,8 @@ not ok 3 - nested-objects › format with max depth 4
     assertion: t.deepEqual()
     details:
       'Difference:': |-
-          - Received
-          + Expected
+        - Received
+        + Expected
 
           {
             a: {
@@ -42,8 +42,8 @@ not ok 4 - nested-objects › format like with max depth 4
     assertion: t.like()
     details:
       'Difference:': |-
-          - Received
-          + Expected
+        - Received
+        + Expected
 
           {
             a: {

--- a/test-tap/test.js
+++ b/test-tap/test.js
@@ -213,7 +213,7 @@ test('fails with the first assertError', t => ava(a => {
 	t.equal(result.passed, false);
 	t.equal(result.error.name, 'AssertionError');
 	t.equal(result.error.formattedDetails.length, 1);
-	t.equal(result.error.formattedDetails[0].label, 'Difference (- actual, + expected):');
+	t.equal(result.error.formattedDetails[0].label, 'Difference:');
 	t.match(result.error.formattedDetails[0].formatted, /- 1\n\+ 2/);
 }));
 


### PR DESCRIPTION
/claim #2501

## Summary

- Add an explicit diff legend before assertion diffs.
- Use `- Received` / `+ Expected` for regular assertion diffs.
- Use `- Received` / `+ Snapshot` for snapshot mismatch diffs.
- Update TAP reporter fixture output for the changed formatting.

## Scope

This is a narrow slice for the rolled-in #1558 reporter issue only. It does not attempt to resolve the broader #2501 reporter backlog.

## Why

The previous output only explained diff gutters inline in the `Difference (- actual, + expected):` label. That made the `-` and `+` lines less explicit, and snapshot mismatches could not distinguish the expected value from the stored snapshot in the legend.

## Validation

- GitHub Actions run 28708888104 passed all matrix jobs, lint, TypeScript compatibility checks, package-lock check, and Codecov checks.
- Local checks were not run in this pass.
