### PR TITLE
Fix typos in source code and comments

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -662,7 +662,7 @@ export class Assertions {
 				}
 
 				throw fail(new AssertionError(message ?? 'Could not compare snapshot', {
-					asssertion: 't.snapshot()',
+					assertion: 't.snapshot()',
 					improperUsage,
 				}));
 			}

--- a/test-tap/helper/report.js
+++ b/test-tap/helper/report.js
@@ -111,7 +111,7 @@ const run = async (type, reporter, {match = [], filter} = {}) => {
 		});
 	}
 
-	// Mimick watch mode
+	// Mimic watch mode
 	return api.run({files, filter, runtimeOptions: {countPreviousFailures: () => 0, firstRun: true}}).then(() => {
 		reporter.endRun();
 		return api.run({files, filter, runtimeOptions: {countPreviousFailures: () => 2, firstRun: false}});

--- a/test/watch-mode/helpers/watch.js
+++ b/test/watch-mode/helpers/watch.js
@@ -127,7 +127,7 @@ export const withFixture = fixture => async (t, task) => {
 						// Sending the `abort-watcher` message should suffice, but on Linux
 						// the recursive watch handle does not close properly. See
 						// <https://github.com/nodejs/node/issues/48437> but there seem to be
-						// other isues.
+						// other issues.
 						setTimeout(() => {
 							process?.kill('SIGKILL');
 						}, 1000).unref();


### PR DESCRIPTION
Fix three typos found via codespell:

- **`lib/assert.js` line 665**: `asssertion` → `assertion` (triple 's'). This is a real bug: the `AssertionError` constructor destructures `assertion` from its options object, but the wrong key was passed here, meaning the `.assertion` property would be `undefined` on snapshot comparison errors.
- **`test/watch-mode/helpers/watch.js` line 130**: `isues` → `issues` in a comment.
- **`test-tap/helper/report.js` line 114**: `Mimick` → `Mimic` in a comment.