### PR TITLE
Add --randomize flag to randomize test order

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -20,6 +20,7 @@ import {observeWorkerProcess} from './plugin-support/shared-workers.js';
 import RunStatus from './run-status.js';
 import scheduler from './scheduler.js';
 import serializeError from './serialize-error.js';
+import {fileOrderSeed, generateSeed, shuffle} from './test-order.js';
 
 function normalizeRequireOption(require) {
 	return arrify(require).map(name => {
@@ -92,6 +93,10 @@ export default class Api extends Emittery {
 		let setupOrGlobError;
 
 		const apiOptions = this.options;
+
+		// When randomization is enabled, derive (or accept) a seed. The seed is
+		// reported back to the user so a failing order can be reproduced.
+		const randomSeed = apiOptions.randomize ? (apiOptions.randomSeed ?? generateSeed()) : undefined;
 
 		// Each run will have its own status. It can only be created when test files
 		// have been found.
@@ -197,6 +202,10 @@ export default class Api extends Emittery {
 
 			selectedFiles = scheduler.failingTestsFirst(selectedFiles, this._getLocalCacheDir(), this.options.cacheEnabled);
 
+			if (randomSeed) {
+				selectedFiles = shuffle(selectedFiles, fileOrderSeed(randomSeed));
+			}
+
 			const debugWithoutSpecificFile = Boolean(this.options.debug) && !this.options.debug.active && selectedFiles.length !== 1;
 
 			await this.emit('run', {
@@ -205,6 +214,7 @@ export default class Api extends Emittery {
 				failFastEnabled: failFast,
 				filePathPrefix: getFilePathPrefix(selectedFiles),
 				files: selectedFiles,
+				randomSeed,
 				matching: apiOptions.match.length > 0 || runtimeOptions.interactiveMatchPattern !== undefined,
 				previousFailures: runtimeOptions.countPreviousFailures?.() ?? 0,
 				firstRun: runtimeOptions.firstRun ?? true,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -54,6 +54,16 @@ const FLAGS = {
 		description: 'Additional Node.js arguments for launching worker processes (specify as a single string)',
 		type: 'string',
 	},
+	randomize: {
+		coerce: coerceLastValue,
+		description: 'Randomize test file and concurrent test order',
+		type: 'boolean',
+	},
+	seed: {
+		coerce: coerceLastValue,
+		description: 'Seed for randomized test order',
+		type: 'string',
+	},
 	serial: {
 		alias: 's',
 		coerce: coerceLastValue,
@@ -234,6 +244,16 @@ export default async function loadCli() { // eslint-disable-line complexity
 			} else if (flag !== 'node-arguments') {
 				combined[flag] = argv[flag];
 			}
+		}
+	}
+
+	const hasSeed = Object.hasOwn(combined, 'seed');
+	const randomize = combined.randomize === true || (combined.randomize !== false && hasSeed);
+	let randomSeed;
+	if (randomize && hasSeed) {
+		randomSeed = String(combined.seed);
+		if (randomSeed.length === 0) {
+			exit('The --seed flag must be provided with a non-empty value.');
 		}
 	}
 
@@ -424,6 +444,8 @@ export default async function loadCli() { // eslint-disable-line complexity
 		providers,
 		ranFromCli: true,
 		require: arrify(combined.require),
+		randomize,
+		randomSeed,
 		serial: combined.serial,
 		snapshotDir: combined.snapshotDir ? path.resolve(projectDir, combined.snapshotDir) : null,
 		timeout: combined.timeout ?? '10s',

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -157,6 +157,10 @@ export default class Reporter {
 		}
 
 		this.lineWriter.writeLine();
+
+		if (plan.randomSeed) {
+			this.lineWriter.writeLine(chalk.gray.dim(`Randomized test order with seed ${plan.randomSeed}. Re-run with --seed ${plan.randomSeed} to reproduce the same order.`));
+		}
 	}
 
 	consumeStateChange(event) { // eslint-disable-line complexity

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -9,6 +9,7 @@ import createChain from './create-chain.js';
 import parseTestArgs from './parse-test-args.js';
 import serializeError from './serialize-error.js';
 import {load as loadSnapshots, determineSnapshotDir} from './snapshot-manager.js';
+import {shuffle, testOrderSeed} from './test-order.js';
 import Runnable from './test.js';
 import {waitForReady} from './worker/state.js';
 
@@ -34,6 +35,7 @@ export default class Runner extends Emittery {
 		this.matchPatterns = options.match ?? [];
 		this.projectDir = options.projectDir;
 		this.recordNewSnapshots = options.recordNewSnapshots === true;
+		this.randomSeed = options.randomSeed;
 		this.serial = options.serial === true;
 		this.snapshotDir = options.snapshotDir;
 		this.updateSnapshots = options.updateSnapshots;
@@ -512,7 +514,10 @@ export default class Runner extends Emittery {
 
 			// If a concurrent test fails, even if `failFast` is enabled it won't
 			// stop other concurrent tests from running.
-			const allOkays = await Promise.all(concurrentTests.map(task => this.runTest(task, contextRef.copy())));
+			const orderedConcurrentTests = this.randomSeed
+				? shuffle(concurrentTests, testOrderSeed(this.randomSeed, this.file))
+				: concurrentTests;
+			const allOkays = await Promise.all(orderedConcurrentTests.map(task => this.runTest(task, contextRef.copy())));
 			return allOkays.every(Boolean);
 		});
 

--- a/lib/test-order.js
+++ b/lib/test-order.js
@@ -1,0 +1,65 @@
+import crypto from 'node:crypto';
+
+// Derive a well-distributed 32-bit unsigned integer from an arbitrary seed
+// string. FNV-1a over the UTF-8 bytes, followed by an avalanche mix so that
+// seeds differing by even a single character yield unrelated starting states.
+function deriveState(seed) {
+	let hash = 0x811c9dc5;
+	const bytes = new TextEncoder().encode(String(seed));
+	for (const byte of bytes) {
+		hash ^= byte;
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+
+	hash ^= hash >>> 15;
+	hash = Math.imul(hash, 0x2c1b3c6d) >>> 0;
+	hash ^= hash >>> 12;
+
+	return hash >>> 0;
+}
+
+// xorshift32 — a tiny, fast PRNG with a full 2**32 - 1 period and good
+// distribution. Seeded from a 32-bit state it produces a deterministic stream
+// of floats in [0, 1), which is what makes `--seed` reproducible.
+function createRng(seedState) {
+	let state = seedState >>> 0;
+	if (state === 0) {
+		state = 0x9e3779b9;
+	}
+
+	return () => {
+		state ^= state << 13;
+		state >>>= 0;
+		state ^= state >> 17;
+		state ^= state << 5;
+		state >>>= 0;
+		return (state >>> 0) / 0x100000000;
+	};
+}
+
+export function generateSeed() {
+	return crypto.randomBytes(8).toString('hex');
+}
+
+export function fileOrderSeed(seed) {
+	return `files:${seed}`;
+}
+
+export function testOrderSeed(seed, file) {
+	return `tests:${seed}:${file}`;
+}
+
+// Deterministic Fisher-Yates shuffle driven by a seed-derived PRNG. The same
+// (seed, salt) pair always yields the same permutation, which is what makes
+// `--seed` reproducible across machines and runs.
+export function shuffle(items, seed) {
+	const shuffled = [...items];
+	const next = createRng(deriveState(seed));
+
+	for (let index = shuffled.length - 1; index > 0; index--) {
+		const swapIndex = Math.floor(next() * (index + 1));
+		[shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+	}
+
+	return shuffled;
+}

--- a/lib/worker/base.js
+++ b/lib/worker/base.js
@@ -79,6 +79,7 @@ const run = async options => {
 		file: options.file,
 		match: options.match,
 		projectDir: options.projectDir,
+		randomSeed: options.randomSeed,
 		recordNewSnapshots: options.recordNewSnapshots,
 		serial: options.serial,
 		snapshotDir: options.snapshotDir,

--- a/test/scheduler/fixtures/random-1.js
+++ b/test/scheduler/fixtures/random-1.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('passes in random-1', t => {
+	t.pass();
+});

--- a/test/scheduler/fixtures/random-2.js
+++ b/test/scheduler/fixtures/random-2.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('passes in random-2', t => {
+	t.pass();
+});

--- a/test/scheduler/fixtures/random-3.js
+++ b/test/scheduler/fixtures/random-3.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('passes in random-3', t => {
+	t.pass();
+});

--- a/test/scheduler/test.js
+++ b/test/scheduler/test.js
@@ -60,3 +60,24 @@ test.serial('scheduler disabled in CI', async t => {
 		t.true(timestamps.passed < timestamps.failed);
 	}
 });
+
+test('reports the seed when --randomize is combined with --seed', async t => {
+	const results = await fixture(['--randomize', '--seed=abc123', 'random-1.js', 'random-2.js', 'random-3.js']);
+	t.true(results.stdout.includes('Randomized test order with seed abc123'));
+});
+
+test('reports a generated seed when --randomize is used without --seed', async t => {
+	const results = await fixture(['--randomize', 'random-1.js', 'random-2.js', 'random-3.js']);
+	t.regex(results.stdout, /Randomized test order with seed [0-9a-f]{16}/);
+});
+
+test('does not report a seed when --randomize is omitted', async t => {
+	const results = await fixture(['random-1.js', 'random-2.js', 'random-3.js']);
+	t.false(results.stdout.includes('Randomized test order'));
+});
+
+test('errors when --seed is provided with an empty value', async t => {
+	const error = await t.throwsAsync(fixture(['--randomize', '--seed=', 'random-1.js']));
+	const output = `${error.stdout}${error.stderr}`;
+	t.true(output.includes('The --seed flag must be provided with a non-empty value'));
+});


### PR DESCRIPTION
## Summary

Implements seeded randomization of the test run order, resolving #595.

- New `--randomize` flag randomizes both the **order of test files** and the **order of concurrent tests within a file**.
- New `--seed <seed>` flag reproduces a specific order. When `--randomize` is used without `--seed`, a random 16-character hex seed is generated.
- The active seed is reported in the run output so a failing order can be reproduced:

  ```
  Randomized test order with seed <seed>. Re-run with --seed <seed> to reproduce the same order.
  ```

- `.serial` tests are unaffected: within-file randomization only reorders concurrent tests, preserving the source order that serial execution relies on.
- Passing an empty `--seed` value exits with a clear error.

## Implementation

- **`lib/test-order.js`** (new): deterministic Fisher-Yates shuffle backed by an xorshift32 PRNG seeded from an FNV-1a hash of the seed string. `fileOrderSeed()` and `testOrderSeed()` give file-level and within-file salts so the two shuffle passes are independent.
- **`lib/api.js`**: derives (or accepts) `randomSeed` when `randomize` is enabled, shuffles the selected files, and includes `randomSeed` in the `run` event.
- **`lib/runner.js`**: shuffles concurrent tests within a file using a file-specific salt.
- **`lib/worker/base.js`**: forwards `randomSeed` into the worker so the runner can use it.
- **`lib/cli.js`**: adds the `--randomize` and `--seed` flags and resolves `randomize`/`randomSeed`.
- **`lib/reporters/default.js`**: prints the seed line when a run is randomized.
- **`test/scheduler/test.js`**: tests for seed reporting, generated seed, absence without `--randomize`, and the empty `--seed` error.

## Notes

- Default behavior is unchanged: without `--randomize`, no shuffling occurs and nothing is reported.
- The same seed always yields the same order across machines and runs.
