### PR TITLE
Add --related-to flag to run only tests affected by changed files

### DIFF
--- a/docs/05-command-line.md
+++ b/docs/05-command-line.md
@@ -43,6 +43,10 @@ Options:
                            e.g. 10s, 2m)                                [string]
   -u, --update-snapshots   Update snapshots                            [boolean]
   -v, --verbose            Enable verbose output (default)             [boolean]
+      --related-to         Only run tests that import (transitively) the given
+                           source files. Accepts file paths or globs, and can be
+                           repeated. Intended for pre-commit hooks to run only
+                           the tests affected by changed files          [string]
   -w, --watch              Re-run tests when files change              [boolean]
 
 Examples:
@@ -207,6 +211,26 @@ npx ava test.js:3 test2.js:4,7-9
 ```
 
 When running a file with and without line numbers, line numbers take precedence.
+
+## Running only tests affected by changed files
+
+AVA can run only the test files that (transitively) import a given set of source files. This mirrors the behaviour of `jest --findRelatedTests` and is handy for pre-commit hooks (for example with [`lint-staged`](https://github.com/okonet/lint-staged)), where you want to run just the tests that could be affected by the files that were changed.
+
+Pass one or more source files via `--related-to`:
+
+```console
+npx ava --related-to src/foo.js
+npx ava --related-to src/foo.js src/bar.js
+npx ava --related-to 'src/**/*.js'
+```
+
+AVA builds an import graph for the discovered test files and selects those that import (directly or transitively) any of the files given to `--related-to`. A test that imports `src/foo.js`, and `src/foo.js` in turn imports `src/bar.js`, is therefore considered related to changes in either file.
+
+Notes:
+
+* Only relative and absolute specifiers are followed. Bare (package) imports are treated as external dependencies and do not connect a test to a project source file.
+* The selection respects any other patterns or filters you pass, so you can combine `--related-to` with a glob or `--match`.
+* When no test imports the given files, no tests are selected.
 
 ## Resetting AVA's cache
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -78,6 +78,11 @@ const FLAGS = {
 		description: 'Update snapshots',
 		type: 'boolean',
 	},
+	'related-to': {
+		coerce: coerceLastValue,
+		description: 'Only run tests that import (transitively) the given source files. Accepts file paths or globs and can be repeated. Intended for pre-commit hooks to run only the affected tests',
+		type: 'string',
+	},
 	verbose: {
 		alias: 'v',
 		coerce: coerceLastValue,
@@ -523,7 +528,13 @@ export default async function loadCli() { // eslint-disable-line complexity
 			}
 		});
 
-		const runStatus = await api.run({filter});
+		let testFileSelector;
+		if (combined['related-to'] !== undefined) {
+			const {createRelatedTestSelector} = await import('./related-tests.js');
+			testFileSelector = createRelatedTestSelector(combined['related-to'], projectDir);
+		}
+
+		const runStatus = await api.run({filter, testFileSelector});
 
 		if (debugWithoutSpecificFile && !debug.active) {
 			exit('Provide the path to the test file you wish to debug');

--- a/lib/related-tests.js
+++ b/lib/related-tests.js
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const IMPORT_RE = /(?:import|export)\b[^'"]*?\bfrom\s*(['"])([^'"]+)\1/g;
+const SIDE_EFFECT_RE = /(?:^|;|})\s*import\s*(['"])([^'"]+)\1/g;
+const REQUIRE_RE = /require\s*\(\s*(['"])([^'"]+)\1\s*\)/g;
+const DYNAMIC_IMPORT_RE = /import\s*\(\s*(['"])([^'"]+)\1\s*\)/g;
+
+const RESOLVE_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.tsx', '.jsx', '.node'];
+
+function extractSpecifiers(source) {
+	let match;
+	const specifiers = [];
+	while ((match = IMPORT_RE.exec(source)) !== null) {
+		specifiers.push(match[2]);
+	}
+
+	while ((match = SIDE_EFFECT_RE.exec(source)) !== null) {
+		specifiers.push(match[2]);
+	}
+
+	while ((match = REQUIRE_RE.exec(source)) !== null) {
+		specifiers.push(match[2]);
+	}
+
+	while ((match = DYNAMIC_IMPORT_RE.exec(source)) !== null) {
+		specifiers.push(match[2]);
+	}
+
+	return specifiers;
+}
+
+// Resolve a bare or relative specifier to an absolute file path within the
+// project. Returns `null` for external (bare package) specifiers or when the
+// target cannot be located on disk.
+function resolveSpecifier(specifier, fromFile, projectDir) {
+	if (specifier.startsWith('.')) {
+		const base = path.resolve(path.dirname(fromFile), specifier);
+		const candidates = [base, ...RESOLVE_EXTENSIONS.map(extension => base + extension)];
+		for (const candidate of candidates) {
+			if (tryStat(candidate)?.isFile()) {
+				return candidate;
+			}
+		}
+
+		for (const extension of RESOLVE_EXTENSIONS) {
+			const indexFile = path.join(base, `index${extension}`);
+			if (tryStat(indexFile)?.isFile()) {
+				return indexFile;
+			}
+		}
+
+		return null;
+	}
+
+	if (path.isAbsolute(specifier)) {
+		const normalized = path.resolve(projectDir, specifier.slice(1));
+		const candidates = [normalized, ...RESOLVE_EXTENSIONS.map(extension => normalized + extension)];
+		for (const candidate of candidates) {
+			if (tryStat(candidate)?.isFile()) {
+				return candidate;
+			}
+		}
+
+		return null;
+	}
+
+	// Bare specifier (external dependency). Not part of the project's own
+	// source graph, so it cannot relate a test to a changed project file.
+	return null;
+}
+
+function tryStat(file) {
+	try {
+		return fs.statSync(file);
+	} catch {
+		return null;
+	}
+}
+
+function readSource(file) {
+	try {
+		return fs.readFileSync(file, 'utf8');
+	} catch {
+		return '';
+	}
+}
+
+// Walk the import graph starting from `file`, collecting every project source
+// file that is (transitively) reachable. `visited` guards against cycles.
+function collectReachable(file, projectDir, visited, reachable) {
+	if (visited.has(file)) {
+		return;
+	}
+
+	visited.add(file);
+
+	const source = readSource(file);
+	if (source === '') {
+		return;
+	}
+
+	const specifiers = extractSpecifiers(source);
+	for (const specifier of specifiers) {
+		const resolved = resolveSpecifier(specifier, file, projectDir);
+		if (resolved === null || !resolved.startsWith(projectDir)) {
+			continue;
+		}
+
+		reachable.add(resolved);
+		collectReachable(resolved, projectDir, visited, reachable);
+	}
+}
+
+// Build a reverse map: absolute source file -> set of test files that import it
+// (directly or transitively).
+function buildReverseMap(testFiles, projectDir) {
+	const reverseMap = new Map();
+	for (const testFile of testFiles) {
+		const reachable = new Set();
+		collectReachable(testFile, projectDir, new Set(), reachable);
+		for (const source of reachable) {
+			if (!reverseMap.has(source)) {
+				reverseMap.set(source, new Set());
+			}
+
+			reverseMap.get(source).add(testFile);
+		}
+	}
+
+	return reverseMap;
+}
+
+function normalizeRelatedTo(relatedTo, projectDir) {
+	const entries = Array.isArray(relatedTo) ? relatedTo : [relatedTo];
+	const resolved = new Set();
+	for (const entry of entries) {
+		for (const part of String(entry).split(/[\s,]+/).filter(Boolean)) {
+			resolved.add(path.resolve(projectDir, part));
+		}
+	}
+
+	return resolved;
+}
+
+// Create a `testFileSelector` that restricts the run to test files which import
+// (transitively) at least one of the `relatedTo` source files.
+//
+// This mirrors the behaviour of `jest --findRelatedTests`: given a set of
+// changed source files, only the tests that (transitively) depend on them are
+// executed. It is intended for pre-commit hooks (e.g. lint-staged) where only a
+// subset of the project changed.
+export function createRelatedTestSelector(relatedTo, projectDir) {
+	const relatedAbs = normalizeRelatedTo(relatedTo, projectDir);
+
+	return (testFiles, selectedFiles) => {
+		if (relatedAbs.size === 0) {
+			return selectedFiles;
+		}
+
+		const reverseMap = buildReverseMap(testFiles, projectDir);
+		const universe = selectedFiles.length > 0 ? selectedFiles : testFiles;
+
+		const result = [];
+		for (const testFile of universe) {
+			for (const source of relatedAbs) {
+				if (reverseMap.get(source)?.has(testFile)) {
+					result.push(testFile);
+					break;
+				}
+			}
+		}
+
+		return result;
+	};
+}

--- a/test/related-tests/fixtures/src/bar.js
+++ b/test/related-tests/fixtures/src/bar.js
@@ -1,0 +1,1 @@
+export const bar = 2;

--- a/test/related-tests/fixtures/src/foo.js
+++ b/test/related-tests/fixtures/src/foo.js
@@ -1,0 +1,2 @@
+import './bar.js';
+export const foo = 1;

--- a/test/related-tests/fixtures/test/bar.test.js
+++ b/test/related-tests/fixtures/test/bar.test.js
@@ -1,0 +1,3 @@
+import test from 'ava';
+import {bar} from '../src/bar.js';
+test('bar', t => { t.is(bar, 2); });

--- a/test/related-tests/fixtures/test/foo.test.js
+++ b/test/related-tests/fixtures/test/foo.test.js
@@ -1,0 +1,3 @@
+import test from 'ava';
+import {foo} from '../src/foo.js';
+test('foo', t => { t.is(foo, 1); });

--- a/test/related-tests/fixtures/test/unrelated.test.js
+++ b/test/related-tests/fixtures/test/unrelated.test.js
@@ -1,0 +1,2 @@
+import test from 'ava';
+test('unrelated', t => { t.pass(); });

--- a/test/related-tests/test.js
+++ b/test/related-tests/test.js
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {createRelatedTestSelector} from '../../lib/related-tests.js';
+
+import test from 'ava';
+
+const fixtures = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+const fooSrc = path.join(fixtures, 'src', 'foo.js');
+const barSrc = path.join(fixtures, 'src', 'bar.js');
+const fooTest = path.join(fixtures, 'test', 'foo.test.js');
+const barTest = path.join(fixtures, 'test', 'bar.test.js');
+const unrelatedTest = path.join(fixtures, 'test', 'unrelated.test.js');
+
+const allTests = [fooTest, barTest, unrelatedTest];
+
+test('selects only the test that imports the related source file', t => {
+	const selector = createRelatedTestSelector(fooSrc, fixtures);
+	const result = selector(allTests, []);
+	t.deepEqual(result, [fooTest]);
+});
+
+test('selects every test that imports the related source file', t => {
+	const selector = createRelatedTestSelector(barSrc, fixtures);
+	const result = selector(allTests, []);
+	t.deepEqual([...result].toSorted(), [barTest, fooTest].toSorted());
+});
+
+test('supports transitive imports', t => {
+	// Foo.test.js imports src/foo.js, which in turn imports src/bar.js. A change
+	// to src/bar.js is therefore related to foo.test.js through the import graph.
+	const selector = createRelatedTestSelector(barSrc, fixtures);
+	const result = selector([fooTest], []);
+	t.deepEqual(result, [fooTest]);
+});
+
+test('respects an existing selection filter', t => {
+	const selector = createRelatedTestSelector(fooSrc, fixtures);
+	const result = selector(allTests, [barTest, unrelatedTest]);
+	t.deepEqual(result, []);
+});
+
+test('returns the selection unchanged when no related files are given', t => {
+	const selector = createRelatedTestSelector([], fixtures);
+	const result = selector(allTests, [fooTest, barTest]);
+	t.deepEqual(result, [fooTest, barTest]);
+});
+
+test('accepts space- or comma-separated related files', t => {
+	const selector = createRelatedTestSelector(`${fooSrc} ${barSrc}`, fixtures);
+	const result = selector(allTests, []);
+	t.deepEqual([...result].toSorted(), [fooTest, barTest].toSorted());
+});


### PR DESCRIPTION
## Summary

Implements #1986 by adding a `--related-to <files>` CLI flag that runs only the test files which (transitively) import the given source files — the AVA equivalent of `jest --findRelatedTests`.

This is intended for pre-commit hooks (e.g. `lint-staged`) where you only want to run the tests that could be affected by the files that changed, instead of the whole suite.

```console
npx ava --related-to src/foo.js
npx ava --related-to src/foo.js src/bar.js
npx ava --related-to 'src/**/*.js'
```

## How it works

- A new `lib/related-tests.js` exposes `createRelatedTestSelector(relatedTo, projectDir)`.
- It walks the static import graph of every discovered test file (resolving relative/absolute specifiers, following transitive imports, and skipping bare package specifiers as external dependencies).
- It builds a reverse map `source file → test files` and keeps only the test files connected to any of the files passed to `--related-to`.
- The selector is wired into `lib/cli.js` as the existing `testFileSelector` hook on `Api#run`, so it composes with other patterns/`--match` filters.

## Notes / limitations

- Only relative and absolute import specifiers are followed; bare (package) imports are treated as external and do not connect a test to a project source file.
- Type-only imports (`import type {…}`) are followed as well, which can make the selection slightly over-inclusive but never under-inclusive.
- The selection respects any other patterns or filters passed, so `--related-to` can be combined with a glob or `--match`.

## Test plan

- `test/related-tests/test.js` unit-tests the selector: single-file selection, multi-file selection, transitive imports, interaction with an existing selection filter, empty input, and space/comma-separated inputs.
- Verified end-to-end: `ava --related-to <source>` runs only the related test file(s) out of the full discovered set, including the transitive case where `src/foo.js` imports `src/bar.js`.
