### PR TITLE
fix: report TAP timeouts without crashing

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -6,6 +6,8 @@ import indentString from 'indent-string';
 import plur from 'plur';
 import * as supertap from 'supertap';
 
+import serializeError from '../serialize-error.js';
+
 import prefixTitle from './prefix-title.js';
 
 function dumpError({
@@ -148,7 +150,7 @@ export default class TapReporter {
 
 		for (const [testFile, tests] of evt.pendingTests) {
 			for (const title of tests) {
-				this.writeTest({testFile, title, err: error}, {passed: false, todo: false, skip: false});
+				this.writeTest({testFile, title, err: serializeError(error)}, {passed: false, todo: false, skip: false});
 			}
 		}
 	}

--- a/test-tap/reporters/tap.js
+++ b/test-tap/reporters/tap.js
@@ -50,4 +50,5 @@ test(async t => {
 	t.test('tap reporter - second failFast run', run('failFast2'));
 	t.test('tap reporter - only run', run('only'));
 	t.test('tap reporter - edge cases', run('edgeCases'));
+	t.test('tap reporter - timeout', run('timeoutInSingleFile'));
 });

--- a/test-tap/reporters/tap.timeoutinsinglefile.v22.log
+++ b/test-tap/reporters/tap.timeoutinsinglefile.v22.log
@@ -1,0 +1,27 @@
+TAP version 13
+---tty-stream-chunk-separator
+ok 1 - passes
+---tty-stream-chunk-separator
+ok 2 - passes two
+---tty-stream-chunk-separator
+not ok 3 - slow
+  ---
+    name: Error
+    message: Exited because no new tests completed within the last 2500ms of inactivity
+    at: 'TapReporter.writeTimeout (/lib/reporters/tap.js)'
+  ...
+---tty-stream-chunk-separator
+not ok 4 - slow two
+  ---
+    name: Error
+    message: Exited because no new tests completed within the last 2500ms of inactivity
+    at: 'TapReporter.writeTimeout (/lib/reporters/tap.js)'
+  ...
+---tty-stream-chunk-separator
+
+1..4
+# tests 4
+# pass 2
+# fail 2
+
+---tty-stream-chunk-separator

--- a/test-tap/reporters/tap.timeoutinsinglefile.v24.log
+++ b/test-tap/reporters/tap.timeoutinsinglefile.v24.log
@@ -1,0 +1,27 @@
+TAP version 13
+---tty-stream-chunk-separator
+ok 1 - passes
+---tty-stream-chunk-separator
+ok 2 - passes two
+---tty-stream-chunk-separator
+not ok 3 - slow
+  ---
+    name: Error
+    message: Exited because no new tests completed within the last 2500ms of inactivity
+    at: 'TapReporter.writeTimeout (/lib/reporters/tap.js)'
+  ...
+---tty-stream-chunk-separator
+not ok 4 - slow two
+  ---
+    name: Error
+    message: Exited because no new tests completed within the last 2500ms of inactivity
+    at: 'TapReporter.writeTimeout (/lib/reporters/tap.js)'
+  ...
+---tty-stream-chunk-separator
+
+1..4
+# tests 4
+# pass 2
+# fail 2
+
+---tty-stream-chunk-separator

--- a/test-tap/reporters/tap.timeoutinsinglefile.v26.log
+++ b/test-tap/reporters/tap.timeoutinsinglefile.v26.log
@@ -1,0 +1,27 @@
+TAP version 13
+---tty-stream-chunk-separator
+ok 1 - passes
+---tty-stream-chunk-separator
+ok 2 - passes two
+---tty-stream-chunk-separator
+not ok 3 - slow
+  ---
+    name: Error
+    message: Exited because no new tests completed within the last 2500ms of inactivity
+    at: 'TapReporter.writeTimeout (/lib/reporters/tap.js)'
+  ...
+---tty-stream-chunk-separator
+not ok 4 - slow two
+  ---
+    name: Error
+    message: Exited because no new tests completed within the last 2500ms of inactivity
+    at: 'TapReporter.writeTimeout (/lib/reporters/tap.js)'
+  ...
+---tty-stream-chunk-separator
+
+1..4
+# tests 4
+# pass 2
+# fail 2
+
+---tty-stream-chunk-separator


### PR DESCRIPTION
## Summary
- serialize the synthetic global-timeout error before the TAP reporter formats it
- add regression coverage for a timed-out test file and TAP snapshots for supported Node 22, 24, and 26

## Root cause
`writeTimeout()` created a native `Error` and passed it directly to `dumpError()`, which expects AVA's serialized error record. The raw error has no `originalError`, so the formatter throws while assigning its stack and the reporter surfaces an `AggregateError`.

Fixes #3461

## Validation
- `npx tap test-tap/reporters/tap.js` (Node 24; 6 subtests passed)
- the same reporter test run with temporary Node 22.23.1 and Node 26.5.0 while generating the required versioned snapshots
- `npx xo lib/reporters/tap.js test-tap/reporters/tap.js`
- `git diff --check`

`npm test` invokes a Bash script that cannot run under this Windows PowerShell checkout; the available WSL distribution has no Node runtime. A direct full lint/typecheck also exposes existing fixture/symlink resolution failures outside this change, while the affected reporter test and target lint pass.