### PR TITLE
Improve invalid worker argument reporting

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -11,7 +11,7 @@ import ms from 'ms';
 import pMap from 'p-map';
 import tempDir from 'temp-dir';
 
-import fork from './fork.js';
+import fork, {preflightWorkerThread} from './fork.js';
 import * as globs from './globs.js';
 import isCi from './is-ci.js';
 import {getApplicableLineNumbers} from './line-numbers.js';
@@ -236,6 +236,10 @@ export default class Api extends Emittery {
 					}
 				}
 			});
+
+			if (apiOptions.workerThreads) {
+				await preflightWorkerThread(apiOptions.nodeArguments);
+			}
 
 			const providerStates = [];
 			await Promise.all(providers.map(async ({type, main}) => {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -15,6 +15,29 @@ export function _testOnlyReplaceWorkerPath(replacement) {
 
 const additionalExecArgv = ['--enable-source-maps'];
 
+export async function preflightWorkerThread(execArgv = process.execArgv) {
+	let worker;
+	try {
+		worker = new Worker('', {
+			eval: true,
+			execArgv: [...execArgv, ...additionalExecArgv],
+		});
+	} catch (error) {
+		if (error?.code !== 'ERR_WORKER_INVALID_EXEC_ARGV') {
+			throw error;
+		}
+
+		const message = [
+			error.message,
+			'',
+			'Remove the incompatible Node.js arguments or disable worker threads with --no-worker-threads or by setting workerThreads to false in AVA’s configuration.',
+		].join('\n');
+		throw Object.assign(new Error(message, {cause: error}), {code: error.code});
+	}
+
+	await worker.terminate();
+}
+
 const createWorker = (options, execArgv) => {
 	let worker;
 	let postMessage;

--- a/test/node-arguments/fixtures/invalid-worker-arguments/first.js
+++ b/test/node-arguments/fixtures/invalid-worker-arguments/first.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('first', t => {
+	t.pass();
+});

--- a/test/node-arguments/fixtures/invalid-worker-arguments/package.json
+++ b/test/node-arguments/fixtures/invalid-worker-arguments/package.json
@@ -1,0 +1,8 @@
+{
+	"type": "module",
+	"ava": {
+		"files": [
+			"*.js"
+		]
+	}
+}

--- a/test/node-arguments/fixtures/invalid-worker-arguments/second.js
+++ b/test/node-arguments/fixtures/invalid-worker-arguments/second.js
@@ -1,0 +1,5 @@
+import test from 'ava';
+
+test('second', t => {
+	t.pass();
+});

--- a/test/node-arguments/test.js
+++ b/test/node-arguments/test.js
@@ -13,6 +13,30 @@ test('passed node arguments to workers', async t => {
 	t.snapshot(result.stats.passed, 'tests pass');
 });
 
+test('invalid worker arguments fail once with an actionable message', async t => {
+	const options = {
+		cwd: cwd('invalid-worker-arguments'),
+	};
+
+	const result = await t.throwsAsync(fixture(['--node-arguments="--title=ava-repro"'], options));
+
+	t.is(result.stats.internalErrors.length, 1);
+	const error = result.stats.getError(result.stats.internalErrors[0]);
+	t.is(error.type, 'native');
+	t.regex(error.message, /--title=ava-repro/);
+	t.regex(error.message, /Remove the incompatible Node\.js arguments or disable worker threads/);
+});
+
+test('invalid worker arguments can be used when worker threads are disabled', async t => {
+	const options = {
+		cwd: cwd('invalid-worker-arguments'),
+	};
+
+	const result = await fixture(['--no-worker-threads', '--node-arguments="--title=ava-repro"'], options);
+
+	t.is(result.stats.passed.length, 2);
+});
+
 test('`filterNodeArgumentsForWorkerThreads` configuration filters arguments for worker thread', async t => {
 	const options = {
 		cwd: cwd('thread-arguments-filter'),


### PR DESCRIPTION
Closes #3025.

## What changed

- preflight worker-thread startup once before test files are scheduled
- turn `ERR_WORKER_INVALID_EXEC_ARGV` into a single actionable diagnostic
- preserve `--no-worker-threads` and `workerThreads: false` as working escape hatches
- add a two-file regression fixture to prove the error is not aggregated per test file

## Verification

- `npx xo`
- `npx tsc --noEmit`
- `npx test-ava test/node-arguments/test.js test/worker-threads/test.js`
- `npx tap test-tap/node-arguments.js`
- manual two-file reproduction under Node.js 24.20.0

The full local suite reaches the watch-mode tests, which fail with macOS `EMFILE: too many open files`; the same isolated watch test fails identically on the unmodified `bbfd9463` baseline.

## AI assistance disclosure

I used OpenAI Codex to help investigate the issue, implement the focused change, and run verification. I reviewed the diff and verified the behavior locally. The commit includes an `Assisted-by` trailer.